### PR TITLE
Turns autopunctuation into a preference.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -39,6 +39,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/see_chat_non_mob = TRUE
 	///Whether emotes will be displayed on runechat. Requires chat_on_map to have effect. Boolean.
 	var/see_rc_emotes = TRUE
+	///Whether or not the mobs messages (sent with say) should be auto punctuated
+	var/auto_punctuate = FALSE
 
 	// Custom Keybindings
 	var/list/key_bindings = list()
@@ -801,6 +803,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Runechat message char limit:</b> <a href='?_src_=prefs;preference=max_chat_length;task=input'>[max_chat_length]</a><br>"
 			dat += "<b>See Runechat for non-mobs:</b> <a href='?_src_=prefs;preference=see_chat_non_mob'>[see_chat_non_mob ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<b>See Runechat emotes:</b> <a href='?_src_=prefs;preference=see_rc_emotes'>[see_rc_emotes ? "Enabled" : "Disabled"]</a><br>"
+			dat += "<b>Autopunctuate your messages:</b> <a href='?_src_=prefs;preference=auto_punctuate'>[auto_punctuate ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<br>"
 			dat += "<b>Outline:</b> <a href='?_src_=prefs;preference=outline_enabled'>[outline_enabled ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<b>Outline Color:</b> <span style='border:1px solid #161616; background-color: [outline_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=outline_color'>Change</a><BR>"
@@ -2050,6 +2053,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					see_chat_non_mob = !see_chat_non_mob
 				if("see_rc_emotes")
 					see_rc_emotes = !see_rc_emotes
+				if("auto_punctuate")
+					auto_punctuate = !auto_punctuate
 
 				if("action_buttons")
 					buttons_locked = !buttons_locked

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -349,10 +349,10 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		message = CLOCK_CULT_SLUR(message)
 
 
-	// check for and apply punctuation. thanks, bee
-	var/end = copytext(message, length(message))
-	if(!(end in list("!", ".", "?", ":", "\"", "-")))
-		message += "."
+	if(client?.prefs.auto_punctuate)
+		var/end = copytext(message, length(message))
+		if(!(end in list("!", ".", "?", ":", "\"", "-")))
+			message += "."
 
 	message = capitalize(message)
 


### PR DESCRIPTION
reopening cus of a weird conflict
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Forcefully adding a period onto the end of a message is a LITTLE weird, i've never personally liked it, so this turns the auto adding of a period into a preference (which auto defaults to OFF)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is listed in the projects section (https://github.com/users/Jackriip/projects/1), and also as stated above, it feels weird to have periods forced into your sentences... it doesn't really flow in a virtual context especially when other punctuation is universally ignored (aside from ! and ?)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Auto punctuation of your messages, is now a preference.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
