### PR TITLE
Restores electrode’s original functionality.

### DIFF
--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -4,19 +4,48 @@
 	color = "#FFFF00"
 	nodamage = FALSE
 	hitsound = 'sound/weapons/taserhit.ogg'
-	damage = 40
-	damage_type = STAMINA
-	stutter = 5
-	jitter = 20
-	range = 6
+	range = 7
 	tracer_type = /obj/effect/projectile/tracer/stun
 	muzzle_type = /obj/effect/projectile/muzzle/stun
 	impact_type = /obj/effect/projectile/impact/stun
+
+	var/confusion_amt = 10		// Void crew edit, restores electrodes original function.
+	var/stamina_loss_amt = 60
+	var/apply_stun_delay = 2 SECONDS
+	var/stun_time = 7 SECONDS
+
+	var/attack_cooldown_check = 0 SECONDS
+	var/attack_cooldown = 2.5 SECONDS		
 
 /obj/projectile/energy/electrode/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
 		do_sparks(1, TRUE, src)
+	else if(iscarbon(target))
+		var/mob/living/carbon/C = target
+		if(C.dna && C.dna.check_mutation(HULK))
+			C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
+		else if((C.status_flags & CANKNOCKDOWN) && !HAS_TRAIT(C, TRAIT_STUNIMMUNE))
+			C.Jitter(20)				//WS Edit Begin - Nerfs tasers
+			C.confused = max(confusion_amt, C.confused)
+			C.stuttering = max(8, C.stuttering)
+			C.apply_damage(stamina_loss_amt, STAMINA, BODY_ZONE_CHEST)
+			SEND_SIGNAL(C, COMSIG_LIVING_MINOR_SHOCK)
+			addtimer(CALLBACK(src, .proc/apply_stun_effect_end, C), apply_stun_delay)
+
+			attack_cooldown_check = world.time + attack_cooldown
+
+
+
+/obj/projectile/energy/electrode/proc/apply_stun_effect_end(mob/living/target)
+	var/trait_check = HAS_TRAIT(target, TRAIT_STUNRESISTANCE) //var since we check it in out to_chat as well as determine stun duration
+	if(trait_check)
+		target.Knockdown(stun_time * 0.1)
+	else
+		target.Knockdown(stun_time)
+	if(!target.IsKnockdown())
+		to_chat(target, "<span class='warning'>Your muscles seize, making you collapse[trait_check ? ", but your body quickly recovers..." : "!"]</span>")		
+
 
 /obj/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
 	do_sparks(1, TRUE, src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tasers had there original hard stun abilities stripped from them in https://github.com/shiptest-ss13/Shiptest/pull/45 making them only do stamina damage. This reverts the changes done to tasers actually making them useful again. This will also effect everything that uses the electrodes IE AI turrets and pulserifles. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Tasers being a worse version of a disabler is not a good thing.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Bluespace magic put the strength back into electrodes making them stun again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
