### PR TITLE
Changes meta coin round end rewards

### DIFF
--- a/code/__DEFINES/~whitesands_defines/metacoin.dm
+++ b/code/__DEFINES/~whitesands_defines/metacoin.dm
@@ -5,10 +5,10 @@
 /// Rewarded when you complete a crew objective
 #define METACOIN_CO_REWARD(is_speed_round, round_duration) is_speed_round ? 50 : max(min(round(100 * (round_duration / 72000)), 50), 150)
 /// Rewarded when you escape on the shuttle
-#define METACOIN_ESCAPE_REWARD(is_speed_round, round_duration) is_speed_round ? 100 : max(min(round(200 * (round_duration / 72000)), 100), 350)
+#define METACOIN_ESCAPE_REWARD(is_speed_round, round_duration) is_speed_round ? 100 : max(min(round(100 * (round_duration / 72000)), 100), 100) // VOID CREW EDIT
 /// Rewarded when you survive the round
-#define METACOIN_SURVIVE_REWARD(is_speed_round, round_duration) is_speed_round ? 50 : max(min(round(100 * (round_duration / 72000)), 50), 250)
+#define METACOIN_SURVIVE_REWARD(is_speed_round, round_duration) is_speed_round ? 50 : max(min(round(50 * (round_duration / 72000)), 50), 50) // VOID CREW EDIT
 /// Rewarded when you don't survive the round, but stick around till the end
-#define METACOIN_NOTSURVIVE_REWARD 100
+//#define METACOIN_NOTSURVIVE_REWARD 100 VOID CREW EDIT
 /// Rewarded when you are alive and active for 10 minutes
 #define METACOIN_TENMINUTELIVING_REWARD 15

--- a/code/__DEFINES/~whitesands_defines/metacoin.dm
+++ b/code/__DEFINES/~whitesands_defines/metacoin.dm
@@ -5,9 +5,9 @@
 /// Rewarded when you complete a crew objective
 #define METACOIN_CO_REWARD(is_speed_round, round_duration) is_speed_round ? 50 : max(min(round(100 * (round_duration / 72000)), 50), 150)
 /// Rewarded when you escape on the shuttle
-#define METACOIN_ESCAPE_REWARD(is_speed_round, round_duration) is_speed_round ? 350 : max(min(round(200 * (round_duration / 72000)), 100), 350)
+#define METACOIN_ESCAPE_REWARD(is_speed_round, round_duration) is_speed_round ? 100 : max(min(round(200 * (round_duration / 72000)), 100), 350)
 /// Rewarded when you survive the round
-#define METACOIN_SURVIVE_REWARD(is_speed_round, round_duration) is_speed_round ? 200 : max(min(round(100 * (round_duration / 72000)), 50), 250)
+#define METACOIN_SURVIVE_REWARD(is_speed_round, round_duration) is_speed_round ? 50 : max(min(round(100 * (round_duration / 72000)), 50), 250)
 /// Rewarded when you don't survive the round, but stick around till the end
 #define METACOIN_NOTSURVIVE_REWARD 100
 /// Rewarded when you are alive and active for 10 minutes

--- a/whitesands/code/modules/metacoin/metacoin.dm
+++ b/whitesands/code/modules/metacoin/metacoin.dm
@@ -46,8 +46,11 @@
 	if(M.mind && !isnewplayer(M))
 		if(M.stat != DEAD && !isbrain(M))
 			inc_metabalance(METACOIN_ESCAPE_REWARD(is_speed_round, round_duration), reason="Survived the shift.")
+/*
+VOID CREW EDIT
 		else
 			inc_metabalance(METACOIN_NOTSURVIVE_REWARD, reason="You tried.")
+*/
 
 /client/proc/process_greentext(is_speed_round, round_duration)
 	inc_metabalance(METACOIN_GREENTEXT_REWARD(is_speed_round, round_duration), reason="Greentext!")


### PR DESCRIPTION
Round end getting 350 fucking coins for getting on the shuttle, on top
of the (now functioning) 10 minute coin reward is a LOT, jackrip has
expressed that this is too much. 
You will now get 100 coins for escaping the round on the shuttle, and 50 coins if you managed to stay alive but not escape.