### PR TITLE
possibly fixes join game button not working

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -265,7 +265,8 @@
 	return JOB_AVAILABLE
 
 /mob/dead/new_player/proc/AttemptLateSpawn(datum/job/job, obj/structure/overmap/ship/simulated/ship)
-	if (isnull(ship))
+	if (isnull(ship) || isnull(ship.shuttle))
+		stack_trace("Tried to spawn ([ckey]) into a null ship! Please report this on Github.")
 		return FALSE
 	var/error = IsJobUnavailable(job, ship)
 	if(error != JOB_AVAILABLE)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -265,6 +265,8 @@
 	return JOB_AVAILABLE
 
 /mob/dead/new_player/proc/AttemptLateSpawn(datum/job/job, obj/structure/overmap/ship/simulated/ship)
+	if (isnull(ship))
+		return FALSE
 	var/error = IsJobUnavailable(job, ship)
 	if(error != JOB_AVAILABLE)
 		alert(src, get_job_unavailable_error_message(error, job))


### PR DESCRIPTION
Whenever the join button stops working it runtimes in this proc due to a null ship (or ship shuttle). This will result in an endless loop of new player panel (maybe), but it will give me more insight into what exactly is breaking. I can't QUITE see why this proc is even being calle before the new player panel pops up. Hopefully this will help