### PR TITLE
added Lathes to both boyardee's

### DIFF
--- a/_maps/shuttles/shiptest/boyardee.dmm
+++ b/_maps/shuttles/shiptest/boyardee.dmm
@@ -1572,13 +1572,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/machinery/icecream_vat,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/autolathe,
 /turf/open/floor/plating,
 /area/ship/maintenance)
 "Fp" = (
@@ -1933,13 +1933,11 @@
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew/canteen)
 "Nc" = (
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = null
-	},
 /obj/effect/turf_decal/box,
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
+/obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/dark,
 /area/ship/storage)
 "Ng" = (

--- a/_maps/shuttles/shiptest/boyardee_b.dmm
+++ b/_maps/shuttles/shiptest/boyardee_b.dmm
@@ -1450,6 +1450,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/autolathe,
 /turf/open/floor/plating,
 /area/ship/maintenance)
 "FA" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds Autolathes to both Boyardee's which are missing them making progression not possible

## Why It's Good For The Game
Makes the two Boyardee's usable again
![image](https://user-images.githubusercontent.com/82520990/151876856-522f2f84-c6ea-4c8f-81a3-1c13f44eddf1.png)
![image](https://user-images.githubusercontent.com/82520990/151876900-ea771d4f-305f-42ce-bfce-5b5d5eb83414.png)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Autolathes to boyardees
moved: icecream machine to freezer on boyardee
removed: one empty freezer fridge from boyardee
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
