### PR TITLE
Adds voidcrew to build.js

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -43,6 +43,7 @@ const taskDm = new Task('dm')
   .depends('code/**')
   .depends('goon/**')
   .depends('html/**')
+  .depends('voidcrew/code/**') // voidcrew edit - Adds modularized folders to CBT checking
   .depends('whitesands/code/**') // WS Edit - Adds modularized folders to CBT checking
   .depends('interface/**')
   .depends('whitesands/**')

--- a/voidcrew/tg_edits.md
+++ b/voidcrew/tg_edits.md
@@ -1,0 +1,3 @@
+## List of all edits voidcrew code touches, within TG files:
+
+- build.js - Adds our files to be checked when building


### PR DESCRIPTION
## About The Pull Request

This is likely why I hadn't caught the nanite double-define.
Also adds a placeholder file to store all voidcrew TG edits.

Nothing player facing so nothing else written.