### PR TITLE
Adds an Abandoned Art Gallery Ruin in Space.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/ArtGallery.dmm
+++ b/_maps/RandomRuins/SpaceRuins/ArtGallery.dmm
@@ -1,0 +1,80 @@
+"bn" = (/obj/structure/window/reinforced/spawner,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"by" = (/obj/structure/rack,/obj/item/canvas/twentythreeXtwentythree,/obj/item/canvas/twentythreeXnineteen,/obj/item/canvas/twentythreeXnineteen,/obj/item/canvas/nineteenXnineteen,/obj/item/storage/crayons,/obj/item/stack/cable_coil/red,/obj/item/stack/cable_coil/red,/obj/item/stack/cable_coil/red,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"bQ" = (/mob/living/simple_animal/hostile/faithless,/turf/open/floor/plating/rust,/area/ruin/space)
+"dX" = (/obj/structure/window/reinforced/spawner/east,/obj/effect/decal/cleanable/glass,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"fn" = (/obj/effect/decal/cleanable/blood/tracks,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"gS" = (/obj/structure/window/reinforced/spawner/west,/obj/structure/window/reinforced/spawner/north,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"hg" = (/obj/structure/bookcase/random,/obj/structure/bookcase/random,/turf/open/floor/plating,/area/ruin/space)
+"lc" = (/obj/effect/decal/cleanable/blood/gibs/limb,/obj/item/shard,/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/blood/drip,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"lH" = (/obj/item/shard,/turf/open/floor/plating/rust,/area/ruin/space)
+"mL" = (/obj/effect/decal/cleanable/blood/drip,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"nc" = (/obj/effect/decal/cleanable/blood,/obj/effect/decal/cleanable/glass,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"nz" = (/turf/open/floor/plating,/area/ruin/space)
+"oz" = (/obj/effect/decal/cleanable/blood/gibs/core,/obj/effect/decal/cleanable/blood/drip,/obj/effect/decal/cleanable/blood/drip,/turf/open/floor/plating/rust,/area/ruin/space)
+"ql" = (/obj/effect/mob_spawn/human/corpse/assistant,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"qU" = (/obj/structure/lattice,/turf/open/space/basic,/area/ruin/space)
+"rx" = (/obj/structure/bookcase/random,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"sU" = (/obj/item/bikehorn/golden,/obj/effect/decal/cleanable/blood/footprints{dir = 1},/turf/open/floor/plating,/area/ruin/space)
+"tu" = (/turf/closed/wall/mineral/iron{color = null},/area/ruin/space)
+"wb" = (/obj/item/wallframe/painting,/turf/closed/wall/mineral/iron{color = null},/area/ruin/space)
+"xn" = (/obj/effect/decal/cleanable/blood/gibs/core,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"xU" = (/obj/effect/decal/cleanable/glass,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"zn" = (/turf/open/floor/plating/rust,/area/ruin/space)
+"zF" = (/obj/effect/decal/cleanable/glass,/turf/open/floor/plating/rust,/area/ruin/space)
+"zS" = (/obj/structure/window/reinforced/spawner,/obj/effect/decal/cleanable/glass,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"Bl" = (/obj/effect/decal/cleanable/blood,/obj/effect/decal/cleanable/blood/tracks{dir = 9},/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"Cn" = (/obj/effect/decal/cleanable/blood/gibs/old,/turf/open/floor/plating/rust,/area/ruin/space)
+"CR" = (/obj/effect/mob_spawn/human/corpse/wizard,/turf/open/floor/plating,/area/ruin/space)
+"DK" = (/obj/item/shard,/turf/open/floor/plating,/area/ruin/space)
+"Ev" = (/obj/effect/decal/cleanable/blood/tracks,/obj/effect/decal/cleanable/blood/gibs/up,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"EP" = (/obj/effect/decal/cleanable/blood/splatter,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"FR" = (/obj/effect/decal/cleanable/blood,/obj/effect/decal/cleanable/blood/drip,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"Gk" = (/obj/effect/decal/cleanable/blood/gibs/limb,/obj/effect/decal/cleanable/blood/gibs/core,/turf/open/floor/plating/rust,/area/ruin/space)
+"Gu" = (/obj/effect/decal/cleanable/blood/tracks,/obj/effect/decal/cleanable/blood/innards,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"HK" = (/obj/structure/lattice,/obj/structure/lattice,/turf/open/space/basic,/area/ruin/space)
+"HV" = (/obj/item/book/granter/spell/random,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"Ip" = (/obj/effect/decal/cleanable/blood,/turf/open/floor/plating/rust,/area/ruin/space)
+"IA" = (/obj/effect/mob_spawn/human/clown/corpse,/obj/item/toy/crayon/spraycan/lubecan,/turf/open/floor/plating/rust,/area/ruin/space)
+"JD" = (/obj/structure/window/reinforced/spawner,/obj/structure/window/reinforced/spawner/west,/obj/effect/decal/cleanable/glass,/turf/open/floor/plating/rust,/area/ruin/space)
+"LN" = (/obj/item/shard,/obj/effect/decal/cleanable/blood/drip,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"Mc" = (/obj/effect/decal/cleanable/blood/drip,/turf/open/floor/plating,/area/ruin/space)
+"Mi" = (/obj/effect/decal/cleanable/blood/footprints{dir = 1},/obj/effect/decal/cleanable/blood/drip,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"Mt" = (/obj/machinery/door/airlock/glass_large,/obj/effect/decal/cleanable/blood/footprints{dir = 1},/turf/open/floor/plating/rust,/area/ruin/space)
+"Nl" = (/turf/template_noop,/area/template_noop)
+"NH" = (/obj/structure/bookcase/random,/turf/open/floor/plating,/area/ruin/space)
+"Os" = (/mob/living/simple_animal/hostile/faithless,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"PG" = (/obj/structure/statue/sandstone/venus,/obj/effect/mob_spawn/human/corpse/assistant,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"Qj" = (/obj/effect/decal/cleanable/blood/gibs/old,/obj/effect/decal/cleanable/glass,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"QC" = (/obj/effect/decal/cleanable/blood/tracks{dir = 6},/obj/effect/decal/cleanable/blood/gibs/torso,/obj/effect/decal/cleanable/blood/innards,/turf/open/floor/plating/rust,/area/ruin/space)
+"Rl" = (/obj/structure/bookcase/random,/obj/item/book/granter/spell/random,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"RE" = (/obj/effect/decal/cleanable/blood/gibs/core,/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/blood/drip,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"TK" = (/obj/item/shard,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"TP" = (/obj/effect/decal/cleanable/blood/drip,/turf/open/floor/plating/rust,/area/ruin/space)
+"Vj" = (/mob/living/simple_animal/hostile/statue,/turf/open/floor/plating/rust,/area/ruin/space)
+"WG" = (/obj/effect/mob_spawn/human/corpse/assistant,/turf/open/floor/plating/rust,/area/ruin/space)
+"Xb" = (/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"Xd" = (/obj/structure/rack,/obj/item/canvas/twentythreeXtwentythree,/obj/item/canvas/twentythreeXtwentythree,/obj/item/canvas/nineteenXnineteen,/obj/item/canvas/nineteenXnineteen,/obj/item/storage/crayons,/obj/item/storage/crayons,/obj/item/stack/cable_coil/red,/turf/open/floor/carpet/red_gold,/area/ruin/space)
+"Za" = (/obj/structure/lattice,/turf/open/space,/area/ruin/space)
+
+(1,1,1) = {"
+NlNlqUNlNlNlNlqUNlNlNlNlNlNlqUNlNlNlNlNl
+qUNlqUNlqUNlNlNlqUqUNlqUqUqUNlNlNlNlNlNl
+NlqUtuwbtutuhgznnzqUnzznznzntutuwbtuHKNl
+NlNltuXbXbtuznHVVjCRqUVjznzntuXbXbtuqUHK
+NlNltuXbXbturxNHNHsUIArxNHRltuznXbtuqUqU
+NlqUnzXbXbtuwbtutuMtXbtutuwbtuznXbtuqUNl
+NlNlznzFXbqlXbtubyMimLXdtuXbXbznzntuqUNl
+qUqUlHqUlHTPxUtuwbMtXbtutuznXbxUTKtuqUNl
+NlqUNlZaznncmLEvOsozXbOsXbzngSlHqUnzqUNl
+NlHKZaZadXDKBlQCTPXbznznznxUIpnzqUqUqUNl
+NlZaNlNlZanzGuEPEPTPTPTPXbLNxUPGxUtuNlqU
+NlNltuznXbGkfntutuwbwbtutuxUJDzSbntuqUNl
+qUqUtuXbXbXbQjlHznXbXbXbREXbznxnXbtuNlqU
+NlNltuXbOsTPznWGXbznEPCnCnznznXblctuNlNl
+NlNltuznXbnzznIpTPXbXbbQznznXbznznNlqUNl
+NlNlNlznNlXbnzXbXbznTPmLXbXbFRnzNlqUqUNl
+NlNlqUNlnzNlznXbznznTPMcXbXbnzXbqUqUqUNl
+NlNlqUqUznqUnztutuzntutututuqUqUqUNlNlNl
+NlNlNlqUqUqUNlNlqUqUNlqUNlNlqUNlqUqUNlNl
+NlNlqUNlqUqUNlqUqUNlqUqUNlNlNlNlNlNlNlNl
+"}

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -326,3 +326,9 @@
 	suffix = "wizardmaze.dmm"
 	name = "Wizard Maze"
 	description = "A hellish maze made by the Wizard Federation to test their acolytes."
+
+/datum/map_template/ruin/space/ArtGallery
+	id = "ArtGallery"
+	suffix = "ArtGallery.dmm"
+	name = "Abandoned Art Gallery"
+	description = "This was once apart of a far larger exhibition of artwork though most of it is gone now, Though there seems to be a few things left arround by the visiters that were here most don't seem freindly. ."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a New Space Ruin that is a Derelict chunk of an Abandonded Art Gallery that was destroyed, Main "loot" is 2 random spawn spell books and the golden clown horn. Contains some extra bits of Art Supplies and books if you like it and some forskaen and living statue enemies.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
![artgallery](https://user-images.githubusercontent.com/57418512/152093300-2a7d7905-5e67-4a91-9a31-da97f179963c.png)

## Why It's Good For The Game
I Just want more Variety for ruins mostly so I did it myself also others can enjoy it as well.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add:  New Art Gallery space ruin

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
