### PR TITLE
Mineral/Robotic beings cannot get nanites anymore

### DIFF
--- a/voidcrew/code/datums/components/nanites.dm
+++ b/voidcrew/code/datums/components/nanites.dm
@@ -49,9 +49,7 @@
 	if(isliving(parent))
 		host_mob = parent
 
-		if(!(host_mob.mob_biotypes & (MOB_ORGANIC|MOB_UNDEAD))) //Shouldn't happen, but this avoids HUD runtimes in case a silicon gets them somehow.
-			return COMPONENT_INCOMPATIBLE
-		if(host_mob.mob_biotypes & MOB_ROBOTIC)
+		if(host_mob.mob_biotypes & (MOB_MINERAL|MOB_ROBOTIC))
 			return COMPONENT_INCOMPATIBLE
 
 		start_time = world.time

--- a/voidcrew/code/datums/components/nanites.dm
+++ b/voidcrew/code/datums/components/nanites.dm
@@ -51,6 +51,8 @@
 
 		if(!(host_mob.mob_biotypes & (MOB_ORGANIC|MOB_UNDEAD))) //Shouldn't happen, but this avoids HUD runtimes in case a silicon gets them somehow.
 			return COMPONENT_INCOMPATIBLE
+		if(host_mob.mob_biotypes & MOB_ROBOTIC)
+			return COMPONENT_INCOMPATIBLE
 
 		start_time = world.time
 

--- a/voidcrew/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/voidcrew/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -3,8 +3,30 @@
 	id = SPECIES_IPC
 	sexes = FALSE
 	say_mod = "states"
-	species_traits = list(AGENDER,NOTRANSSTING,NOEYESPRITES,NO_DNA_COPY,NOBLOOD,TRAIT_EASYDISMEMBER,NOZOMBIE,MUTCOLORS,REVIVESBYHEALING,NOHUSK,NOMOUTH,NO_BONES, MUTCOLORS, NO_UNDERWEAR) //all of these + whatever we inherit from the real species
-	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_VIRUSIMMUNE,TRAIT_NOBREATH,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_LIMBATTACHMENT)
+	species_traits = list(
+		AGENDER,
+		NOTRANSSTING,
+		NOEYESPRITES,
+		NO_DNA_COPY,
+		NOBLOOD,
+		TRAIT_EASYDISMEMBER,
+		NOZOMBIE,
+		MUTCOLORS,
+		REVIVESBYHEALING,
+		NOHUSK,
+		NOMOUTH,
+		NO_BONES,
+		MUTCOLORS,
+		NO_UNDERWEAR,
+	)
+	inherent_traits = list(
+		TRAIT_RESISTCOLD,
+		TRAIT_VIRUSIMMUNE,
+		TRAIT_NOBREATH,
+		TRAIT_RADIMMUNE,
+		TRAIT_GENELESS,
+		TRAIT_LIMBATTACHMENT,
+	)
 	inherent_biotypes = list(MOB_ROBOTIC, MOB_HUMANOID)
 	mutantbrain = /obj/item/organ/brain/mmi_holder/posibrain
 	mutanteyes = /obj/item/organ/eyes/robotic
@@ -15,8 +37,17 @@
 	mutantlungs = null
 	mutantappendix = null
 	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)
-	mutant_bodyparts = list("ipc_screen", "ipc_antenna", "ipc_chassis")
-	default_features = list("mcolor" = "#7D7D7D", "ipc_screen" = "Static", "ipc_antenna" = "None", "ipc_chassis" = "Morpheus Cyberkinetics(Greyscale)")
+	mutant_bodyparts = list(
+		"ipc_screen",
+		"ipc_antenna",
+		"ipc_chassis",
+	)
+	default_features = list(
+		"mcolor" = "#7D7D7D",
+		"ipc_screen" = "Static",
+		"ipc_antenna" = "None",
+		"ipc_chassis" = "Morpheus Cyberkinetics(Greyscale)",
+	)
 	meat = /obj/item/stack/sheet/plasteel{amount = 5}
 	skinned_type = /obj/item/stack/sheet/metal{amount = 10}
 	exotic_blood = /datum/reagent/fuel/oil


### PR DESCRIPTION
## About The Pull Request

Since nanites are now "ours", we should balance them around what would fit best

## Why It's Good For The Game

I hope it is agreed that Robots (Cyborgs, AIs, IPCs, Drones) and Minerals (Plasmamen (already the case), Golems) shouldn't be able to get Nanites, in the same way they cannot get diseases or mutations.

## Changelog
:cl:
balance: IPCs and Golems cannot get Nanites anymore.
/:cl: