### PR TITLE
Buffs Mechs to be more relevant mid-late game

### DIFF
--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -4,9 +4,9 @@
 	icon_state = "durand"
 	step_in = 4
 	dir_in = 1 //Facing North.
-	max_integrity = 400
+	max_integrity = 450
 	deflect_chance = 20
-	armor = list("melee" = 40, "bullet" = 35, "laser" = 15, "energy" = 10, "bomb" = 20, "bio" = 0, "rad" = 50, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 50, "bullet" = 40, "laser" = 25, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 50, "fire" = 100, "acid" = 100)
 	max_temperature = 30000
 	infra_luminosity = 8
 	force = 40

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -6,7 +6,7 @@
 	dir_in = 1 //Facing North.
 	max_integrity = 450
 	deflect_chance = 20
-	armor = list("melee" = 50, "bullet" = 40, "laser" = 25, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 50, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 50, "bullet" = 40, "laser" = 25, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 50, "fire" = 100, "acid" = 100) //VoidTest Edit, gives combat mechs a moderate stats buff
 	max_temperature = 30000
 	infra_luminosity = 8
 	force = 40

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -6,7 +6,7 @@
 	dir_in = 1 //Facing North.
 	max_integrity = 300
 	deflect_chance = 5
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 40, "energy" = 15, "bomb" = 15, "bio" = 0, "rad" = 10, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 30, "bullet" = 30, "laser" = 40, "energy" = 15, "bomb" = 15, "bio" = 0, "rad" = 10, "fire" = 100, "acid" = 100) //VoidTest Edit, gives combat mechs a moderate stats buff
 	max_temperature = 25000
 	leg_overload_coeff = 80
 	infra_luminosity = 6

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -4,9 +4,9 @@
 	icon_state = "gygax"
 	step_in = 3
 	dir_in = 1 //Facing North.
-	max_integrity = 250
+	max_integrity = 300
 	deflect_chance = 5
-	armor = list("melee" = 25, "bullet" = 20, "laser" = 30, "energy" = 15, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 30, "bullet" = 30, "laser" = 40, "energy" = 15, "bomb" = 15, "bio" = 0, "rad" = 10, "fire" = 100, "acid" = 100)
 	max_temperature = 25000
 	leg_overload_coeff = 80
 	infra_luminosity = 6
@@ -27,7 +27,7 @@
 	icon_state = "darkgygax"
 	max_integrity = 300
 	deflect_chance = 20
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 50, "energy" = 35, "bomb" = 20, "bio" = 0, "rad" =20, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 40, "bullet" = 40, "laser" = 50, "energy" = 35, "bomb" = 20, "bio" = 0, "rad" = 20, "fire" = 100, "acid" = 100)
 	max_temperature = 35000
 	leg_overload_coeff = 70
 	force = 30

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -6,7 +6,7 @@
 	max_integrity = 150
 	deflect_chance = 60
 	internal_damage_threshold = 50
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100) //VoidTest Edit, gives combat mechs a moderate stats buff
 	max_temperature = 25000
 	infra_luminosity = 5
 	operation_req_access = list(ACCESS_THEATRE)

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -3,10 +3,10 @@
 	name = "\improper H.O.N.K"
 	icon_state = "honker"
 	step_in = 3
-	max_integrity = 140
+	max_integrity = 150
 	deflect_chance = 60
-	internal_damage_threshold = 60
-	armor = list("melee" = -20, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
+	internal_damage_threshold = 50
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
 	max_temperature = 25000
 	infra_luminosity = 5
 	operation_req_access = list(ACCESS_THEATRE)

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -7,7 +7,7 @@
 	step_energy_drain = 3
 	max_integrity = 250
 	deflect_chance = 30
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 30, "bomb" = 35, "bio" = 0, "rad" = 50, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 30, "bomb" = 35, "bio" = 0, "rad" = 50, "fire" = 100, "acid" = 100) //VoidTest Edit, gives combat mechs a moderate stats buff
 	max_temperature = 25000
 	infra_luminosity = 3
 	wreckage = /obj/structure/mecha_wreckage/phazon

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -5,9 +5,9 @@
 	step_in = 2
 	dir_in = 2 //Facing South.
 	step_energy_drain = 3
-	max_integrity = 200
+	max_integrity = 250
 	deflect_chance = 30
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 30, "bio" = 0, "rad" = 50, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 30, "bomb" = 35, "bio" = 0, "rad" = 50, "fire" = 100, "acid" = 100)
 	max_temperature = 25000
 	infra_luminosity = 3
 	wreckage = /obj/structure/mecha_wreckage/phazon

--- a/code/game/mecha/combat/reticence.dm
+++ b/code/game/mecha/combat/reticence.dm
@@ -6,7 +6,7 @@
 	dir_in = 1 //Facing North.
 	max_integrity = 100
 	deflect_chance = 3
-	armor = list("melee" = 25, "bullet" = 20, "laser" = 30, "energy" = 15, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 25, "bullet" = 20, "laser" = 30, "energy" = 15, "bomb" = 10, "bio" = 0, "rad" = 10, "fire" = 100, "acid" = 100)
 	max_temperature = 15000
 	wreckage = /obj/structure/mecha_wreckage/reticence
 	operation_req_access = list(ACCESS_THEATRE)

--- a/code/game/mecha/combat/reticence.dm
+++ b/code/game/mecha/combat/reticence.dm
@@ -6,7 +6,7 @@
 	dir_in = 1 //Facing North.
 	max_integrity = 100
 	deflect_chance = 3
-	armor = list("melee" = 25, "bullet" = 20, "laser" = 30, "energy" = 15, "bomb" = 10, "bio" = 0, "rad" = 10, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 25, "bullet" = 20, "laser" = 30, "energy" = 15, "bomb" = 10, "bio" = 0, "rad" = 10, "fire" = 100, "acid" = 100) //VoidTest Edit, gives combat mechs a moderate stats buff
 	max_temperature = 15000
 	wreckage = /obj/structure/mecha_wreckage/reticence
 	operation_req_access = list(ACCESS_THEATRE)

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -546,7 +546,7 @@
 	name = "RCS thruster package"
 	desc = "A set of thrusters that allow for exosuit movement in zero-gravity enviroments, by expelling gas from the internal life support tank."
 	effect_type = /obj/effect/particle_effect/smoke
-	var/move_cost = 20 //moles per step
+	var/move_cost = 7.5 //moles per step // VoidTest Edit, changes 20 to 7.5
 
 /obj/item/mecha_parts/mecha_equipment/thrusters/gas/try_attach_part(mob/user, obj/mecha/M)
 	if(!M.internal_tank)

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -558,59 +558,58 @@
 	desc = "A complicated kit containing all the parts necessary to upgrade a MK-II's armour with additional armour plates and improved insulation around the electronics. Must be applied to a MK-II's frame and cannot be removed once applied. "
 	icon_state = "ripleyupgrade"
 
-
-/obj/item/mecha_parts/mecha_equipment/ripleyupgrade/firefighter/can_attach(obj/mecha/working/ripley/M)
-	if(M.type != /obj/mecha/working/ripley/mkii)
+/obj/item/mecha_parts/mecha_equipment/ripleyupgrade/firefighter/can_attach(obj/mecha/working/ripley/target_mech)
+	if(target_mech.type != /obj/mecha/working/ripley/mkii)
 		to_chat(loc, "<span class='warning'>This conversion kit can only be applied to APLU MK-II models.</span>")
 		return FALSE
-	if(M.cargo.len)
-		to_chat(loc, "<span class='warning'>[M]'s cargo hold must be empty before this conversion kit can be applied.</span>")
+	if(target_mech.cargo.len)
+		to_chat(loc, "<span class='warning'>[target_mech]'s cargo hold must be empty before this conversion kit can be applied.</span>")
 		return FALSE
-	if(!M.maint_access) //non-removable upgrade, so lets make sure the pilot or owner has their say.
-		to_chat(loc, "<span class='warning'>[M] must have maintenance protocols active in order to allow this conversion kit.</span>")
+	if(!target_mech.maint_access) //non-removable upgrade, so lets make sure the pilot or owner has their say.
+		to_chat(loc, "<span class='warning'>[target_mech] must have maintenance protocols active in order to allow this conversion kit.</span>")
 		return FALSE
-	if(M.occupant) //We're actualy making a new mech and swapping things over, it might get weird if players are involved
-		to_chat(loc, "<span class='warning'>[M] must be unoccupied before this conversion kit can be applied.</span>")
+	if(target_mech.occupant) //We're actualy making a new mech and swapping things over, it might get weird if players are involved
+		to_chat(loc, "<span class='warning'>[target_mech] must be unoccupied before this conversion kit can be applied.</span>")
 		return FALSE
-	if(!M.cell) //Turns out things break if the cell is missing
+	if(!target_mech.cell) //Turns out things break if the cell is missing
 		to_chat(loc, "<span class='warning'>The conversion process requires a cell installed.</span>")
 		return FALSE
 	return TRUE
 
-/obj/item/mecha_parts/mecha_equipment/ripleyupgrade/firefighter/attach(obj/mecha/M)
-	var/obj/mecha/working/ripley/mkii/N = new /obj/mecha/working/ripley/firefighter(get_turf(M),1)
-	if(!N)
+/obj/item/mecha_parts/mecha_equipment/ripleyupgrade/firefighter/attach(obj/mecha/target_mech)
+	var/obj/mecha/working/ripley/mkii/new_mech = new /obj/mecha/working/ripley/firefighter(get_turf(target_mech),1)
+	if(!new_mech)
 		return
-	QDEL_NULL(N.cell)
-	if (M.cell)
-		N.cell = M.cell
-		M.cell.forceMove(N)
-		M.cell = null
-	QDEL_NULL(N.scanmod)
-	if (M.scanmod)
-		N.scanmod = M.scanmod
-		M.scanmod.forceMove(N)
-		M.scanmod = null
-	QDEL_NULL(N.capacitor)
-	if (M.capacitor)
-		N.capacitor = M.capacitor
-		M.capacitor.forceMove(N)
-		M.capacitor = null
-	N.update_part_values()
-	for(var/obj/item/mecha_parts/E in M.contents)
+	QDEL_NULL(new_mech.cell)
+	if (target_mech.cell)
+		new_mech.cell = target_mech.cell
+		target_mech.cell.forceMove(new_mech)
+		target_mech.cell = null
+	QDEL_NULL(new_mech.scanmod)
+	if (target_mech.scanmod)
+		new_mech.scanmod = target_mech.scanmod
+		target_mech.scanmod.forceMove(new_mech)
+		target_mech.scanmod = null
+	QDEL_NULL(new_mech.capacitor)
+	if (target_mech.capacitor)
+		new_mech.capacitor = target_mech.capacitor
+		target_mech.capacitor.forceMove(new_mech)
+		target_mech.capacitor = null
+	new_mech.update_part_values()
+	for(var/obj/item/mecha_parts/E in target_mech.contents)
 		if(istype(E, /obj/item/mecha_parts/concealed_weapon_bay)) //why is the bay not just a variable change who did this
-			E.forceMove(N)
-	for(var/obj/item/mecha_parts/mecha_equipment/E in M.equipment) //Move the equipment over...
+			E.forceMove(new_mech)
+	for(var/obj/item/mecha_parts/mecha_equipment/E in target_mech.equipment) //Move the equipment over...
 		E.detach()
-		E.attach(N)
-		M.equipment -= E
-	N.dna_lock = M.dna_lock
-	N.maint_access = M.maint_access
-	N.strafe = M.strafe
-	N.obj_integrity = M.obj_integrity //This is not a repair tool
-	if (M.name != "\improper APLU MK-II \"Ripley\"")
-		N.name = M.name
-	M.wreckage = 0
-	qdel(M)
-	playsound(get_turf(N),'sound/items/ratchet.ogg',50,TRUE)
+		E.attach(new_mech)
+		target_mech.equipment -= E
+	new_mech.dna_lock = target_mech.dna_lock
+	new_mech.maint_access = target_mech.maint_access
+	new_mech.strafe = target_mech.strafe
+	new_mech.obj_integrity = target_mech.obj_integrity //This is not a repair tool
+	if (target_mech.name != "\improper APLU MK-II \"Ripley\"")
+		new_mech.name = target_mech.name
+	target_mech.wreckage = 0
+	qdel(target_mech)
+	playsound(get_turf(new_mech),'sound/items/ratchet.ogg',50,TRUE)
 	return

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -558,7 +558,6 @@
 	desc = "A complicated kit containing all the parts necessary to upgrade a MK-II's armour with additional armour plates and improved insulation around the electronics. Must be applied to a MK-II's frame and cannot be removed once applied. "
 	icon_state = "ripleyupgrade"
 
-	var/obj/mecha/working/ripley/mkii/N = new /obj/mecha/working/ripley/firefighter(get_turf(M),1)
 
 /obj/item/mecha_parts/mecha_equipment/ripleyupgrade/firefighter/can_attach(obj/mecha/working/ripley/M)
 	if(M.type != /obj/mecha/working/ripley/mkii)
@@ -577,3 +576,41 @@
 		to_chat(loc, "<span class='warning'>The conversion process requires a cell installed.</span>")
 		return FALSE
 	return TRUE
+
+/obj/item/mecha_parts/mecha_equipment/ripleyupgrade/firefighter/attach(obj/mecha/M)
+	var/obj/mecha/working/ripley/mkii/N = new /obj/mecha/working/ripley/firefighter(get_turf(M),1)
+	if(!N)
+		return
+	QDEL_NULL(N.cell)
+	if (M.cell)
+		N.cell = M.cell
+		M.cell.forceMove(N)
+		M.cell = null
+	QDEL_NULL(N.scanmod)
+	if (M.scanmod)
+		N.scanmod = M.scanmod
+		M.scanmod.forceMove(N)
+		M.scanmod = null
+	QDEL_NULL(N.capacitor)
+	if (M.capacitor)
+		N.capacitor = M.capacitor
+		M.capacitor.forceMove(N)
+		M.capacitor = null
+	N.update_part_values()
+	for(var/obj/item/mecha_parts/E in M.contents)
+		if(istype(E, /obj/item/mecha_parts/concealed_weapon_bay)) //why is the bay not just a variable change who did this
+			E.forceMove(N)
+	for(var/obj/item/mecha_parts/mecha_equipment/E in M.equipment) //Move the equipment over...
+		E.detach()
+		E.attach(N)
+		M.equipment -= E
+	N.dna_lock = M.dna_lock
+	N.maint_access = M.maint_access
+	N.strafe = M.strafe
+	N.obj_integrity = M.obj_integrity //This is not a repair tool
+	if (M.name != "\improper APLU MK-II \"Ripley\"")
+		N.name = M.name
+	M.wreckage = 0
+	qdel(M)
+	playsound(get_turf(N),'sound/items/ratchet.ogg',50,TRUE)
+	return

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -552,3 +552,28 @@
 	qdel(M)
 	playsound(get_turf(N),'sound/items/ratchet.ogg',50,TRUE)
 	return
+
+/obj/item/mecha_parts/mecha_equipment/ripleyupgrade/firefighter
+	name = "Ripley Heavy-Duty Frontier kit"
+	desc = "A complicated kit containing all the parts necessary to upgrade a MK-II's armour with additional armour plates and improved insulation around the electronics. Must be applied to a MK-II's frame and cannot be removed once applied. "
+	icon_state = "ripleyupgrade"
+
+	var/obj/mecha/working/ripley/mkii/N = new /obj/mecha/working/ripley/firefighter(get_turf(M),1)
+
+/obj/item/mecha_parts/mecha_equipment/ripleyupgrade/firefighter/can_attach(obj/mecha/working/ripley/M)
+	if(M.type != /obj/mecha/working/ripley/mkii)
+		to_chat(loc, "<span class='warning'>This conversion kit can only be applied to APLU MK-II models.</span>")
+		return FALSE
+	if(M.cargo.len)
+		to_chat(loc, "<span class='warning'>[M]'s cargo hold must be empty before this conversion kit can be applied.</span>")
+		return FALSE
+	if(!M.maint_access) //non-removable upgrade, so lets make sure the pilot or owner has their say.
+		to_chat(loc, "<span class='warning'>[M] must have maintenance protocols active in order to allow this conversion kit.</span>")
+		return FALSE
+	if(M.occupant) //We're actualy making a new mech and swapping things over, it might get weird if players are involved
+		to_chat(loc, "<span class='warning'>[M] must be unoccupied before this conversion kit can be applied.</span>")
+		return FALSE
+	if(!M.cell) //Turns out things break if the cell is missing
+		to_chat(loc, "<span class='warning'>The conversion process requires a cell installed.</span>")
+		return FALSE
+	return TRUE

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -75,7 +75,7 @@
 	addtimer(CALLBACK(src, .proc/set_ready_state, 1), equip_cooldown)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
-	equip_cooldown = 8
+	equip_cooldown = 5
 	name = "\improper CH-PS \"Immolator\" laser"
 	desc = "A weapon for combat exosuits. Shoots basic lasers."
 	icon_state = "mecha_laser"
@@ -85,7 +85,7 @@
 	harmful = TRUE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/disabler
-	equip_cooldown = 8
+	equip_cooldown = 5
 	name = "\improper CH-DS \"Peacemaker\" disabler"
 	desc = "A weapon for combat exosuits. Shoots basic disablers."
 	icon_state = "mecha_disabler"
@@ -122,7 +122,7 @@
 	harmful = TRUE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse
-	equip_cooldown = 30
+	equip_cooldown = 15
 	name = "eZ-13 MK2 heavy pulse rifle"
 	desc = "A weapon for combat exosuits. Shoots powerful destructive blasts capable of demolishing obstacles."
 	icon_state = "mecha_pulse"
@@ -292,7 +292,7 @@
 	desc = "A weapon for combat exosuits. A mime invention, field tests have shown that targets cannot even scream before going down."
 	fire_sound = 'sound/weapons/gun/general/heavy_shot_suppressed.ogg'
 	icon_state = "mecha_mime"
-	equip_cooldown = 30
+	equip_cooldown = 20
 	projectile = /obj/projectile/bullet/mime
 	projectiles = 6
 	projectile_energy_cost = 50

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -75,7 +75,7 @@
 	addtimer(CALLBACK(src, .proc/set_ready_state, 1), equip_cooldown)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
-	equip_cooldown = 5
+	equip_cooldown = 5 //VoidTest Edit, gives mech weaponry a minor stat buff
 	name = "\improper CH-PS \"Immolator\" laser"
 	desc = "A weapon for combat exosuits. Shoots basic lasers."
 	icon_state = "mecha_laser"
@@ -85,7 +85,7 @@
 	harmful = TRUE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/disabler
-	equip_cooldown = 5
+	equip_cooldown = 5 //VoidTest Edit, gives mech weaponry a minor stat buff
 	name = "\improper CH-DS \"Peacemaker\" disabler"
 	desc = "A weapon for combat exosuits. Shoots basic disablers."
 	icon_state = "mecha_disabler"
@@ -122,7 +122,7 @@
 	harmful = TRUE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse
-	equip_cooldown = 15
+	equip_cooldown = 15 //VoidTest Edit, gives mech weaponry a minor stat buff
 	name = "eZ-13 MK2 heavy pulse rifle"
 	desc = "A weapon for combat exosuits. Shoots powerful destructive blasts capable of demolishing obstacles."
 	icon_state = "mecha_pulse"
@@ -292,7 +292,7 @@
 	desc = "A weapon for combat exosuits. A mime invention, field tests have shown that targets cannot even scream before going down."
 	fire_sound = 'sound/weapons/gun/general/heavy_shot_suppressed.ogg'
 	icon_state = "mecha_mime"
-	equip_cooldown = 20
+	equip_cooldown = 20 //VoidTest Edit, gives mech weaponry a minor stat buff
 	projectile = /obj/projectile/bullet/mime
 	projectiles = 6
 	projectile_energy_cost = 50

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -63,7 +63,7 @@
 
 
 /obj/mecha/working/ripley/mkii
-	desc = "Autonomous Power Loader Unit MK-II. This prototype Ripley is refitted with a pressurized cabin, trading its prior speed for atmospheric protection"
+	desc = "Autonomous Power Loader Unit MK-II. This prototype Ripley is refitted with a pressurized cabin, trading its prior speed for atmospheric protection. While the air-tight cabin provides additional integrity, this model was rarely seen on well-developed stations."
 	name = "\improper APLU MK-II \"Ripley\""
 	icon_state = "ripleymkii"
 	fast_pressure_step_in = 2 //step_in while in low pressure conditions
@@ -77,7 +77,7 @@
 	opacity = TRUE
 
 /obj/mecha/working/ripley/firefighter
-	desc = "Autonomous Power Loader Unit MK-III. This model is refitted with a pressurized cabin and additional thermal protection."
+	desc = "Autonomous Power Loader Unit MK-III. This model has an improved plasteel-alloy armour system; based on lessons learned during the Nanotrasen-Syndicate War, it offers near-total immunity from heat and grants excellent protection from conventional weaponry."
 	name = "\improper APLU MK-III \"Firefighter\""
 	icon_state = "firefighter"
 	max_temperature = 65000
@@ -88,7 +88,7 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	light_range = 7
 	light_power = 1
-	armor = list("melee" = 55, "bullet" = 35, "laser" = 35, "energy" = 30, "bomb" = 70, "bio" = 0, "rad" = 95, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 55, "bullet" = 35, "laser" = 35, "energy" = 30, "bomb" = 70, "bio" = 0, "rad" = 90, "fire" = 100, "acid" = 100)
 	max_equip = 5 // More armor, less tools
 	wreckage = /obj/structure/mecha_wreckage/ripley/firefighter
 	enclosed = TRUE

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -69,7 +69,7 @@
 	fast_pressure_step_in = 2 //step_in while in low pressure conditions
 	slow_pressure_step_in = 4 //step_in while in normal pressure conditions
 	step_in = 4
-	armor = list("melee" = 50, "bullet" = 20, "laser" = 10, "energy" = 20, "bomb" = 45, "bio" = 0, "rad" = 60, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 50, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 60, "bio" = 0, "rad" = 60, "fire" = 100, "acid" = 100)
 	wreckage = /obj/structure/mecha_wreckage/ripley/mkii
 	enclosed = TRUE
 	enter_delay = 40
@@ -88,7 +88,7 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	light_range = 7
 	light_power = 1
-	armor = list("melee" = 55, "bullet" = 35, "laser" = 35, "energy" = 30, "bomb" = 60, "bio" = 0, "rad" = 95, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 55, "bullet" = 35, "laser" = 35, "energy" = 30, "bomb" = 70, "bio" = 0, "rad" = 95, "fire" = 100, "acid" = 100)
 	max_equip = 5 // More armor, less tools
 	wreckage = /obj/structure/mecha_wreckage/ripley/firefighter
 	enclosed = TRUE
@@ -101,11 +101,14 @@
 	desc = "OH SHIT IT'S THE DEATHSQUAD WE'RE ALL GONNA DIE"
 	name = "\improper DEATH-RIPLEY"
 	icon_state = "deathripley"
-	fast_pressure_step_in = 2 //step_in while in low pressure conditions
+	max_integrity = 400
+	max_temperature = 100000 // Admin-only deathsquad mech, let's make it not die in a fire
+	fast_pressure_step_in = 1.5 //step_in while in low pressure conditions
 	slow_pressure_step_in = 3 //step_in while in normal pressure conditions
 	step_in = 4
 	light_range = 7
 	light_power = 1
+	armor = list("melee" = 60, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = 75, "bio" = 0, "rad" = 100, "fire" = 100, "acid" = 100)
 	wreckage = /obj/structure/mecha_wreckage/ripley/deathripley
 	step_energy_drain = 0
 	enclosed = TRUE

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -69,7 +69,7 @@
 	fast_pressure_step_in = 2 //step_in while in low pressure conditions
 	slow_pressure_step_in = 4 //step_in while in normal pressure conditions
 	step_in = 4
-	armor = list("melee" = 40, "bullet" = 20, "laser" = 10, "energy" = 20, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 50, "bullet" = 20, "laser" = 10, "energy" = 20, "bomb" = 45, "bio" = 0, "rad" = 60, "fire" = 100, "acid" = 100)
 	wreckage = /obj/structure/mecha_wreckage/ripley/mkii
 	enclosed = TRUE
 	enter_delay = 40
@@ -81,14 +81,14 @@
 	name = "\improper APLU MK-III \"Firefighter\""
 	icon_state = "firefighter"
 	max_temperature = 65000
-	max_integrity = 250
+	max_integrity = 300
 	fast_pressure_step_in = 2 //step_in while in low pressure conditions
 	slow_pressure_step_in = 4 //step_in while in normal pressure conditions
 	step_in = 4
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	light_range = 7
 	light_power = 1
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 60, "bio" = 0, "rad" = 70, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 55, "bullet" = 35, "laser" = 35, "energy" = 30, "bomb" = 60, "bio" = 0, "rad" = 95, "fire" = 100, "acid" = 100)
 	max_equip = 5 // More armor, less tools
 	wreckage = /obj/structure/mecha_wreckage/ripley/firefighter
 	enclosed = TRUE

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -14,6 +14,7 @@
 	icon_state = "gold"
 	base_icon_state = "gold_wall"
 	sheet_type = /obj/item/stack/sheet/mineral/gold
+	hardness = 60 // VoidTest Edit
 	explosion_block = 0 //gold is a soft metal you dingus.
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_GOLD_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_GOLD_WALLS)
@@ -25,6 +26,7 @@
 	icon_state = "silver_wall-0"
 	base_icon_state = "silver_wall"
 	sheet_type = /obj/item/stack/sheet/mineral/silver
+	hardness = 60 // VoidTest Edit
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_SILVER_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_SILVER_WALLS)
@@ -38,6 +40,7 @@
 	sheet_type = /obj/item/stack/sheet/mineral/diamond
 	slicing_duration = 200   //diamond wall takes twice as much time to slice
 	explosion_block = 3
+	hardness = 10 // VoidTest Edit, buffs walls
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_DIAMOND_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_DIAMOND_WALLS)
@@ -73,6 +76,7 @@
 	icon_state = "uranium_wall-0"
 	base_icon_state = "uranium_wall"
 	sheet_type = /obj/item/stack/sheet/mineral/uranium
+	hardness = 20 // VoidTest Edit, buffs walls
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_URANIUM_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_URANIUM_WALLS)
@@ -221,6 +225,7 @@
 	icon_state = "abductor_wall-0"
 	base_icon_state = "abductor_wall"
 	sheet_type = /obj/item/stack/sheet/mineral/abductor
+	hardness = 15 // VoidTest Edit, buffs walls
 	slicing_duration = 200   //alien wall takes twice as much time to slice
 	explosion_block = 3
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
@@ -239,6 +244,7 @@
 	flags_1 = CAN_BE_DIRTY_1
 	flags_ricochet = RICOCHET_SHINY | RICOCHET_HARD
 	sheet_type = /obj/item/stack/sheet/mineral/titanium
+	hardness = 25 // VoidTest Edit, buffs walls
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_TITANIUM_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_TITANIUM_WALLS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTLE_PARTS)
@@ -314,6 +320,7 @@
 	icon_state = "plastitanium_wall-0"
 	base_icon_state = "plastitanium_wall"
 	explosion_block = 4
+	hardness = 15 // VoidTest Edit, buffs walls
 	sheet_type = /obj/item/stack/sheet/mineral/plastitanium
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_PLASTITANIUM_WALLS)

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -244,7 +244,7 @@
 	flags_1 = CAN_BE_DIRTY_1
 	flags_ricochet = RICOCHET_SHINY | RICOCHET_HARD
 	sheet_type = /obj/item/stack/sheet/mineral/titanium
-	hardness = 20 // VoidTest Edit, buffs walls
+	hardness = 25 // VoidTest Edit, buffs walls
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_TITANIUM_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_TITANIUM_WALLS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTLE_PARTS)

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -14,7 +14,6 @@
 	icon_state = "gold"
 	base_icon_state = "gold_wall"
 	sheet_type = /obj/item/stack/sheet/mineral/gold
-	hardness = 60 // VoidTest Edit
 	explosion_block = 0 //gold is a soft metal you dingus.
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_GOLD_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_GOLD_WALLS)
@@ -26,7 +25,6 @@
 	icon_state = "silver_wall-0"
 	base_icon_state = "silver_wall"
 	sheet_type = /obj/item/stack/sheet/mineral/silver
-	hardness = 60 // VoidTest Edit
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_SILVER_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_SILVER_WALLS)
@@ -40,7 +38,6 @@
 	sheet_type = /obj/item/stack/sheet/mineral/diamond
 	slicing_duration = 200   //diamond wall takes twice as much time to slice
 	explosion_block = 3
-	hardness = 10 // VoidTest Edit, buffs walls
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_DIAMOND_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_DIAMOND_WALLS)
@@ -76,7 +73,6 @@
 	icon_state = "uranium_wall-0"
 	base_icon_state = "uranium_wall"
 	sheet_type = /obj/item/stack/sheet/mineral/uranium
-	hardness = 20 // VoidTest Edit, buffs walls
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_URANIUM_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_URANIUM_WALLS)
@@ -225,7 +221,6 @@
 	icon_state = "abductor_wall-0"
 	base_icon_state = "abductor_wall"
 	sheet_type = /obj/item/stack/sheet/mineral/abductor
-	hardness = 15 // VoidTest Edit, buffs walls
 	slicing_duration = 200   //alien wall takes twice as much time to slice
 	explosion_block = 3
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
@@ -244,7 +239,6 @@
 	flags_1 = CAN_BE_DIRTY_1
 	flags_ricochet = RICOCHET_SHINY | RICOCHET_HARD
 	sheet_type = /obj/item/stack/sheet/mineral/titanium
-	hardness = 25 // VoidTest Edit, buffs walls
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_TITANIUM_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_TITANIUM_WALLS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTLE_PARTS)
@@ -320,7 +314,6 @@
 	icon_state = "plastitanium_wall-0"
 	base_icon_state = "plastitanium_wall"
 	explosion_block = 4
-	hardness = 15 // VoidTest Edit, buffs walls
 	sheet_type = /obj/item/stack/sheet/mineral/plastitanium
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_PLASTITANIUM_WALLS)

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -14,6 +14,7 @@
 	icon_state = "gold"
 	base_icon_state = "gold_wall"
 	sheet_type = /obj/item/stack/sheet/mineral/gold
+	hardness = 60 // VoidTest Edit
 	explosion_block = 0 //gold is a soft metal you dingus.
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_GOLD_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_GOLD_WALLS)
@@ -25,6 +26,7 @@
 	icon_state = "silver_wall-0"
 	base_icon_state = "silver_wall"
 	sheet_type = /obj/item/stack/sheet/mineral/silver
+	hardness = 60 // VoidTest Edit
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_SILVER_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_SILVER_WALLS)
@@ -38,6 +40,7 @@
 	sheet_type = /obj/item/stack/sheet/mineral/diamond
 	slicing_duration = 200   //diamond wall takes twice as much time to slice
 	explosion_block = 3
+	hardness = 10 // VoidTest Edit, buffs walls
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_DIAMOND_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_DIAMOND_WALLS)
@@ -73,6 +76,7 @@
 	icon_state = "uranium_wall-0"
 	base_icon_state = "uranium_wall"
 	sheet_type = /obj/item/stack/sheet/mineral/uranium
+	hardness = 20 // VoidTest Edit, buffs walls
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_URANIUM_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_URANIUM_WALLS)
@@ -221,6 +225,7 @@
 	icon_state = "abductor_wall-0"
 	base_icon_state = "abductor_wall"
 	sheet_type = /obj/item/stack/sheet/mineral/abductor
+	hardness = 15 // VoidTest Edit, buffs walls
 	slicing_duration = 200   //alien wall takes twice as much time to slice
 	explosion_block = 3
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
@@ -239,6 +244,7 @@
 	flags_1 = CAN_BE_DIRTY_1
 	flags_ricochet = RICOCHET_SHINY | RICOCHET_HARD
 	sheet_type = /obj/item/stack/sheet/mineral/titanium
+	hardness = 20 // VoidTest Edit, buffs walls
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_TITANIUM_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_TITANIUM_WALLS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTLE_PARTS)
@@ -314,6 +320,7 @@
 	icon_state = "plastitanium_wall-0"
 	base_icon_state = "plastitanium_wall"
 	explosion_block = 4
+	hardness = 15 // VoidTest Edit, buffs walls
 	sheet_type = /obj/item/stack/sheet/mineral/plastitanium
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_PLASTITANIUM_WALLS)

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -246,7 +246,6 @@
 	icon_state = "plastitanium_wall-0"
 	base_icon_state = "plastitanium_wall"
 	explosion_block = 20
-	hardness = 0 // VoidTest Edit, buffs walls
 	sheet_type = /obj/item/stack/sheet/mineral/plastitanium
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_SYNDICATE_WALLS)

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -246,6 +246,7 @@
 	icon_state = "plastitanium_wall-0"
 	base_icon_state = "plastitanium_wall"
 	explosion_block = 20
+	hardness = 0 // VoidTest Edit, buffs walls
 	sheet_type = /obj/item/stack/sheet/mineral/plastitanium
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_SYNDICATE_WALLS)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -26,7 +26,8 @@
 /obj/projectile/beam/laser/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
-	damage = 40
+	damage = 50
+	armour_penetration = 10
 	tracer_type = /obj/effect/projectile/tracer/heavy_laser
 	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
 	impact_type = /obj/effect/projectile/impact/heavy_laser

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -26,7 +26,7 @@
 /obj/projectile/beam/laser/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
-	damage = 50
+	damage = 50 //VoidTest Edit, changes 40,0 to 50,10
 	armour_penetration = 10
 	tracer_type = /obj/effect/projectile/tracer/heavy_laser
 	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser

--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -32,7 +32,7 @@
 // Mech LMG
 
 /obj/projectile/bullet/lmg
-	damage = 25
+	damage = 25 //VoidTest Edit, changes 20 to 25
 
 // Mech FNX-99
 

--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -32,7 +32,7 @@
 // Mech LMG
 
 /obj/projectile/bullet/lmg
-	damage = 20
+	damage = 25
 
 // Mech FNX-99
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -102,4 +102,4 @@
 // Mech Scattershot
 
 /obj/projectile/bullet/scattershot
-	damage = 25
+	damage = 25 //VoidTest Edit, changes 24 to 25

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -102,4 +102,4 @@
 // Mech Scattershot
 
 /obj/projectile/bullet/scattershot
-	damage = 24
+	damage = 25

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -28,7 +28,7 @@
 	mine_range = 5
 
 /obj/projectile/plasma/adv/mech
-	damage = 10
+	damage = 20 // VoidTest Edit, changes 10 to 20
 	range = 9
 	mine_range = 3
 

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -72,8 +72,9 @@
 	construction_time = 100
 	category = list("Ripley")
 
-//firefighter subtype
-/datum/design/firefighter_chassis
+//firefighter subtype // Replaced by a printable firefighter upgrade module
+
+/*/datum/design/firefighter_chassis
 	name = "Exosuit Chassis (APLU \"Firefighter\")"
 	id = "firefighter_chassis"
 	build_type = MECHFAB
@@ -81,6 +82,7 @@
 	materials = list(/datum/material/iron=20000)
 	construction_time = 100
 	category = list("Firefighter")
+*/
 
 /datum/design/ripley_torso
 	name = "Exosuit Torso (APLU \"Ripley\")"
@@ -490,7 +492,7 @@
 	id = "ripleyupgrade_firefighter"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/ripleyupgrade/firefighter
-	materials = list(/datum/material/iron=15000,/datum/material/plasma=15000,/datum/material/titanium=10000,/datum/material/uranium/10000)
+	materials = list(/datum/material/iron=15000,/datum/material/plasma=15000,/datum/material/titanium=10000,/datum/material/uranium=15000)
 	construction_time = 100
 	category = list("Exosuit Equipment")
 

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -72,7 +72,7 @@
 	construction_time = 100
 	category = list("Ripley")
 
-//firefighter subtype // Replaced by a printable firefighter upgrade module
+//firefighter subtype // Replaced by the "MK-III Upgrade", found at your local exofab
 
 /*/datum/design/firefighter_chassis
 	name = "Exosuit Chassis (APLU \"Firefighter\")"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -485,6 +485,15 @@
 	construction_time = 100
 	category = list("Exosuit Equipment")
 
+/datum/design/ripleyupgrade/firefighter
+	name = "Ripley MK-II to MK-III conversion kit"
+	id = "ripleyupgrade_firefighter"
+	build_type = MECHFAB
+	build_path = /obj/item/mecha_parts/mecha_equipment/ripleyupgrade/firefighter
+	materials = list(/datum/material/iron=15000,/datum/material/plasma=15000,/datum/material/titanium=10000,/datum/material/uranium/10000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
+
 /datum/design/mech_hydraulic_clamp
 	name = "Exosuit Engineering Equipment (Hydraulic Clamp)"
 	id = "mech_hydraulic_clamp"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -736,6 +736,15 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
+/datum/techweb_node/firefighter
+	id = "mecha_firefighter"
+	display_name = "MK-III Upgrade Kit"
+	description = "MK-III Kit Design"
+	prereq_ids = list("adv_mecha")
+	design_ids = list("ripleyupgrade_firefighter")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	export_price = 1500
+
 /datum/techweb_node/odysseus
 	id = "mecha_odysseus"
 	display_name = "EXOSUIT: Odysseus"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -772,7 +772,7 @@
 	prereq_ids = list("adv_mecha", "adv_weaponry")
 	design_ids = list("durand_chassis", "durand_torso", "durand_head", "durand_left_arm", "durand_right_arm", "durand_left_leg", "durand_right_leg", "durand_main",
 	"durand_peri", "durand_targ", "durand_armor")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
 	export_price = 5000
 
 /datum/techweb_node/phazon
@@ -782,7 +782,7 @@
 	prereq_ids = list("adv_mecha", "weaponry" , "micro_bluespace")
 	design_ids = list("phazon_chassis", "phazon_torso", "phazon_head", "phazon_left_arm", "phazon_right_arm", "phazon_left_leg", "phazon_right_leg", "phazon_main",
 	"phazon_peri", "phazon_targ", "phazon_armor")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
 	export_price = 5000
 
 /datum/techweb_node/adv_mecha_tools

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -762,7 +762,7 @@
 	prereq_ids = list("adv_mecha", "weaponry")
 	design_ids = list("gygax_chassis", "gygax_torso", "gygax_head", "gygax_left_arm", "gygax_right_arm", "gygax_left_leg", "gygax_right_leg", "gygax_main",
 	"gygax_peri", "gygax_targ", "gygax_armor")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3500)
 	export_price = 5000
 
 /datum/techweb_node/durand
@@ -772,7 +772,7 @@
 	prereq_ids = list("adv_mecha", "adv_weaponry")
 	design_ids = list("durand_chassis", "durand_torso", "durand_head", "durand_left_arm", "durand_right_arm", "durand_left_leg", "durand_right_leg", "durand_main",
 	"durand_peri", "durand_targ", "durand_armor")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3500)
 	export_price = 5000
 
 /datum/techweb_node/phazon
@@ -782,7 +782,7 @@
 	prereq_ids = list("adv_mecha", "weaponry" , "micro_bluespace")
 	design_ids = list("phazon_chassis", "phazon_torso", "phazon_head", "phazon_left_arm", "phazon_right_arm", "phazon_left_leg", "phazon_right_leg", "phazon_main",
 	"phazon_peri", "phazon_targ", "phazon_armor")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3500)
 	export_price = 5000
 
 /datum/techweb_node/adv_mecha_tools


### PR DESCRIPTION
## About The Pull Request

-Buffs mech equipment and armour to deal more damage/AP to compete with the increased number of high-end armor and weapons VoidTest has (hvy. mining suit, syndie suits, orderable fully-auto AK47s).

-VoidTest is set in space, and resources are scarce(ish). So, buffs the mech RCS thruster to be roughly 3x more efficient.

-Buffs (plas)titanium, reinforced and mineral walls to decrease the chances of a Hulk or Mech breaking them.

!Intended to be merged only after other mech issues have been fixed!

## Why It's Good For The Game

Currently it's not worth building a mech post-bullet fix-- you're better off purchasing heavy mining suits/AK47s from cargo (AKs are full-auto and do 32 damage per shot). As mechs were originally balanced around the average threat being toolboxes with an occasional e-gun thrown in here and there, this makes mechs be slightly more capable of taking on nuke-op level opponents.

Also changes how the MK-III Ripley is obtained, it didn't make sense that simply adding a person-grade firesuit added fire immunity (and armor) to a hulking mech. Now it's a upgrade module available at exosuit fabricators after it's been researched.

## Changelog
:cl:
tweak: MK-III Firefighters are created via a upgrade module from your exosuit fabricator
balance: Buffs the MK-II/III Ripleys, mech equipment and the Gygax, Phazon and Durand to be more viable in the mid/late game
/:cl:

