### PR TITLE
Adds Windoors and moves the reinforced windows 1 tile back on the Courage Class

### DIFF
--- a/_maps/shuttles/shiptest/voidcrew/courage.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/courage.dmm
@@ -1,72 +1,828 @@
-"al" = (/obj/machinery/cryopod,/obj/structure/curtain,/obj/machinery/computer/cryopod{pixel_y = 25},/turf/open/floor/pod/dark,/area/ship/crew)
-"az" = (/obj/machinery/light/small{dir = 1},/obj/effect/turf_decal/industrial/hatch/yellow{dir = 4},/obj/machinery/power/smes/engineering,/turf/open/floor/pod/dark,/area/ship/crew)
-"bo" = (/obj/machinery/power/shuttle/engine/electric{dir = 4},/obj/structure/cable{icon_state = "0-4"},/turf/open/floor/plating/airless,/area/ship/crew)
-"bN" = (/obj/machinery/atmospherics/pipe/simple/orange/hidden{dir = 10},/obj/machinery/power/terminal{dir = 1},/obj/structure/cable{icon_state = "0-2"},/turf/open/floor/plating,/area/ship/crew)
-"bZ" = (/obj/effect/turf_decal/corner/red,/turf/open/floor/plasteel/dark,/area/ship/crew)
-"dZ" = (/obj/machinery/power/shuttle/engine/fueled/plasma{dir = 4},/turf/open/floor/plating/airless,/area/ship/crew)
-"gl" = (/obj/machinery/door/airlock/hatch{id_tag = "caravansyndicate3_bolt_port"; name = "External Airlock"; normalspeed = 0; req_access_txt = "150"},/obj/docking_port/mobile{dir = 2; dwidth = 6; height = 7; name = "Syndicate Drop Ship"; port_direction = 8; preferred_direction = 4; width = 15},/obj/structure/fans/tiny,/turf/open/floor/mineral/plastitanium,/area/ship/crew)
-"ha" = (/obj/machinery/power/port_gen/pacman{anchored = 1},/obj/item/wrench,/obj/effect/decal/cleanable/dirt,/obj/structure/cable,/obj/effect/turf_decal/industrial/warning{dir = 6},/obj/machinery/atmospherics/pipe/simple/orange/hidden{dir = 9},/turf/open/floor/plating,/area/ship/crew)
-"hN" = (/obj/effect/turf_decal/corner/red{dir = 4},/obj/effect/turf_decal/corner/red,/obj/effect/turf_decal/corner/red{dir = 4},/obj/effect/turf_decal/corner/red{dir = 1},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"je" = (/obj/effect/turf_decal/corner/red{dir = 1},/obj/effect/turf_decal/corner/red{dir = 4},/obj/effect/turf_decal/corner/red{dir = 8},/obj/machinery/computer/autopilot{dir = 8},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"jk" = (/obj/machinery/holopad/emergency/command,/turf/open/floor/plasteel/dark,/area/ship/crew)
-"ka" = (/obj/machinery/atmospherics/pipe/simple/orange/hidden{dir = 4},/obj/machinery/suit_storage_unit/syndicate,/turf/open/floor/pod/dark,/area/ship/crew)
-"mG" = (/obj/structure/grille,/obj/structure/window/plasma/reinforced/plastitanium,/turf/open/floor/plating,/area/ship/crew)
-"ns" = (/obj/structure/chair/comfy/shuttle,/turf/open/floor/pod/dark,/area/ship/crew)
-"qE" = (/obj/effect/turf_decal/industrial/warning{dir = 9},/obj/machinery/stasis,/turf/open/floor/mineral/plastitanium,/area/ship/crew)
-"rz" = (/obj/structure/chair/comfy/shuttle,/obj/machinery/light/small{dir = 4},/turf/open/floor/pod/dark,/area/ship/crew)
-"rD" = (/obj/effect/turf_decal/corner/red{dir = 1},/obj/effect/turf_decal/corner/red{dir = 8},/obj/effect/turf_decal/corner/red{dir = 4},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"rU" = (/obj/structure/grille,/obj/structure/window/plasma/reinforced/plastitanium,/turf/open/floor/plasteel/dark,/area/ship/crew)
-"rV" = (/obj/machinery/suit_storage_unit/syndicate,/turf/open/floor/pod/dark,/area/ship/crew)
-"sn" = (/obj/machinery/power/apc/syndicate{dir = 8; name = "Syndicate Drop Ship APC"; pixel_y = 25},/obj/structure/cable{icon_state = "0-2"},/obj/structure/table/reinforced,/turf/open/floor/pod/dark,/area/ship/crew)
-"ss" = (/obj/effect/turf_decal/corner/red{dir = 1},/obj/effect/turf_decal/corner/red{dir = 4},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"uy" = (/obj/structure/chair/comfy/shuttle,/obj/machinery/light/small{dir = 8},/turf/open/floor/pod/dark,/area/ship/crew)
-"vw" = (/obj/structure/table/reinforced,/obj/item/storage/briefcase,/turf/open/floor/pod/dark,/area/ship/crew)
-"wH" = (/obj/structure/window/reinforced{dir = 4},/obj/machinery/atmospherics/components/unary/shuttle/heater{dir = 4},/turf/open/floor/plating/airless,/area/ship/crew)
-"xC" = (/obj/machinery/light/small{dir = 8},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"Bp" = (/obj/effect/turf_decal/corner/red,/obj/effect/turf_decal/corner/red{dir = 8},/obj/machinery/atmospherics/pipe/simple/orange/hidden,/turf/open/floor/plasteel/dark,/area/ship/crew)
-"BQ" = (/obj/effect/turf_decal/corner/red,/obj/effect/turf_decal/corner/red{dir = 8},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"Cm" = (/obj/machinery/firealarm{dir = 1; pixel_y = -26},/obj/machinery/atmospherics/pipe/simple/orange/hidden{dir = 9},/obj/machinery/suit_storage_unit/syndicate,/turf/open/floor/pod/dark,/area/ship/crew)
-"Dt" = (/obj/effect/turf_decal/industrial/warning{dir = 8},/obj/machinery/light/small,/obj/structure/table/reinforced,/obj/item/storage/backpack/duffelbag/syndie/surgery,/obj/item/defibrillator/compact/combat,/obj/item/soap/syndie,/obj/item/storage/firstaid/tactical,/obj/item/storage/firstaid/tactical,/obj/item/storage/firstaid/tactical,/turf/open/floor/mineral/plastitanium,/area/ship/crew)
-"Dx" = (/turf/open/floor/plasteel/dark,/area/ship/crew)
-"EO" = (/obj/machinery/airalarm/syndicate{pixel_y = 24},/obj/structure/table/reinforced,/turf/open/floor/pod/dark,/area/ship/crew)
-"Fa" = (/obj/effect/turf_decal/industrial/warning{dir = 10},/obj/structure/rack,/obj/item/melee/transforming/energy/sword/saber/red,/obj/item/melee/transforming/energy/sword/saber/red,/obj/item/melee/transforming/energy/sword/saber/red,/obj/item/gun/ballistic/automatic/pistol/APS,/obj/item/gun/ballistic/automatic/pistol/APS,/obj/item/gun/ballistic/automatic/pistol/APS,/obj/item/ammo_box/magazine/pistolm9mm,/obj/item/ammo_box/magazine/pistolm9mm,/obj/item/ammo_box/magazine/pistolm9mm,/obj/item/ammo_box/magazine/pistolm9mm,/obj/item/ammo_box/magazine/pistolm9mm,/obj/item/ammo_box/magazine/pistolm9mm,/obj/item/ammo_box/magazine/pistolm9mm,/obj/item/ammo_box/magazine/pistolm9mm,/obj/item/ammo_box/magazine/pistolm9mm,/obj/item/ammo_box/magazine/pistolm9mm,/obj/item/ammo_box/magazine/pistolm9mm,/obj/item/ammo_box/magazine/pistolm9mm,/obj/item/ammo_box/magazine/pistolm9mm,/turf/open/floor/mineral/plastitanium,/area/ship/crew)
-"FM" = (/obj/structure/table/reinforced,/obj/item/assembly/flash/handheld,/obj/effect/turf_decal/corner/red{dir = 1},/obj/effect/turf_decal/corner/red,/obj/effect/turf_decal/corner/red{dir = 4},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"Gx" = (/obj/structure/window/reinforced{dir = 4},/obj/machinery/power/smes/shuttle{dir = 4},/obj/structure/cable{icon_state = "0-8"},/turf/open/floor/plating/airless,/area/ship/crew)
-"GR" = (/obj/effect/turf_decal/corner/red{dir = 4},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"HB" = (/obj/effect/turf_decal/corner/red{dir = 1},/obj/effect/turf_decal/corner/red{dir = 8},/obj/machinery/computer/helm{dir = 8},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"HJ" = (/obj/effect/turf_decal/industrial/warning{dir = 8},/obj/structure/sign/warning/vacuum{pixel_y = -32},/obj/machinery/mineral/ore_redemption{dir = 8},/turf/open/floor/mineral/plastitanium,/area/ship/crew)
-"HM" = (/obj/structure/table/reinforced,/obj/machinery/light/small{dir = 8},/obj/effect/turf_decal/corner/red{dir = 1},/obj/effect/turf_decal/corner/red,/obj/effect/turf_decal/corner/red{dir = 8},/obj/machinery/microwave,/obj/effect/spawner/lootdrop/donkpockets,/obj/effect/spawner/lootdrop/donkpockets,/obj/effect/spawner/lootdrop/donkpockets,/obj/effect/spawner/lootdrop/donkpockets,/obj/effect/spawner/lootdrop/donkpockets,/obj/effect/spawner/lootdrop/donkpockets,/turf/open/floor/plasteel/dark,/area/ship/crew)
-"Ij" = (/obj/effect/turf_decal/corner/red{dir = 4},/obj/effect/turf_decal/corner/red{dir = 1},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"IU" = (/obj/machinery/atmospherics/pipe/simple/orange/hidden{dir = 10},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"Jv" = (/turf/template_noop,/area/template_noop)
-"KS" = (/obj/machinery/door/airlock/hatch{id_tag = "caravansyndicate3_bolt_starboard"; name = "External Airlock"; normalspeed = 0; req_access_txt = "150"},/obj/structure/fans/tiny,/turf/open/floor/mineral/plastitanium,/area/ship/crew)
-"Ll" = (/obj/machinery/light/small{dir = 4},/obj/structure/showcase/cyborg/assault,/turf/open/floor/pod/dark,/area/ship/crew)
-"Lq" = (/obj/effect/turf_decal/industrial/warning{dir = 8},/obj/structure/sign/warning/vacuum{pixel_y = 32},/obj/machinery/autolathe/hacked,/turf/open/floor/mineral/plastitanium,/area/ship/crew)
-"NH" = (/obj/effect/turf_decal/industrial/warning{dir = 8},/obj/machinery/light/small{dir = 1},/obj/machinery/vending/security/marine,/turf/open/floor/mineral/plastitanium,/area/ship/crew)
-"Pg" = (/obj/effect/turf_decal/corner/red{dir = 4},/obj/effect/turf_decal/corner/red,/obj/effect/turf_decal/corner/red,/obj/effect/turf_decal/corner/red{dir = 8},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"Pt" = (/obj/effect/turf_decal/industrial/warning{dir = 4},/obj/structure/closet/crate,/obj/item/stack/sheet/metal/twenty,/obj/item/stack/sheet/glass{amount = 10},/obj/item/stack/sheet/mineral/plastitanium{amount = 20},/obj/item/storage/box/lights/bulbs,/obj/item/storage/toolbox/mechanical,/obj/item/stack/sheet/mineral/plasma{amount = 20},/obj/machinery/atmospherics/pipe/manifold4w/orange/hidden,/obj/machinery/power/terminal{dir = 8},/obj/structure/cable{icon_state = "1-2"},/obj/structure/cable{icon_state = "0-2"},/obj/item/stack/sheet/mineral/plasma{amount = 20},/obj/structure/cable{icon_state = "2-4"},/turf/open/floor/plating,/area/ship/crew)
-"PJ" = (/obj/structure/table/reinforced,/obj/item/toy/plush/nukeplushie,/turf/open/floor/pod/dark,/area/ship/crew)
-"PY" = (/obj/effect/turf_decal/industrial/hatch/yellow{dir = 4},/obj/machinery/light/small,/obj/machinery/atmospherics/miner/toxins,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{dir = 4},/obj/structure/window/plasma/reinforced/spawner/east,/obj/structure/window/plasma/reinforced/spawner/north,/turf/open/floor/engine/plasma,/area/ship/crew)
-"Ri" = (/obj/structure/chair/comfy/shuttle{dir = 4},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"RB" = (/obj/effect/turf_decal/corner/red{dir = 1},/obj/effect/turf_decal/corner/red,/obj/effect/turf_decal/corner/red{dir = 8},/obj/machinery/photocopier/faxmachine/longrange,/obj/structure/table/reinforced,/turf/open/floor/plasteel/dark,/area/ship/crew)
-"Sl" = (/obj/structure/table/reinforced,/obj/machinery/light/small{dir = 8},/obj/item/paper_bin,/obj/item/folder/syndicate/red,/obj/item/pen/red,/turf/open/floor/pod/dark,/area/ship/crew)
-"Tn" = (/turf/closed/wall/mineral/plastitanium/nodiagonal,/area/ship/crew)
-"Vf" = (/obj/machinery/door/airlock/hatch{id_tag = "caravansyndicate3_bolt_port"; name = "External Airlock"; normalspeed = 0; req_access_txt = "150"},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"VA" = (/obj/structure/table/reinforced,/obj/machinery/light/small{dir = 8},/obj/effect/turf_decal/corner/red{dir = 1},/obj/effect/turf_decal/corner/red{dir = 4},/obj/effect/turf_decal/corner/red{dir = 8},/obj/item/ammo_box/a357,/obj/item/ammo_box/a357,/obj/item/ammo_box/a357,/obj/item/card/emag,/obj/item/areaeditor/shuttle,/turf/open/floor/plasteel/dark,/area/ship/crew)
-"Wr" = (/obj/effect/turf_decal/corner/red,/obj/effect/turf_decal/corner/red{dir = 4},/obj/effect/turf_decal/corner/red{dir = 8},/obj/machinery/suit_storage_unit/syndicate{name = "captain's suit storage unit"; storage_type = /obj/item/clothing/shoes/magboots/syndie; suit_type = /obj/item/clothing/suit/space/hardsuit/syndi/elite},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"YU" = (/obj/effect/turf_decal/industrial/warning{dir = 10},/obj/structure/closet/syndicate{anchored = 1},/obj/item/clothing/under/syndicate/combat,/obj/item/clothing/under/syndicate/combat,/obj/item/clothing/under/syndicate/combat,/obj/item/storage/belt/military,/obj/item/storage/belt/military,/obj/item/storage/belt/military,/obj/item/crowbar/red,/obj/item/crowbar/red,/obj/item/crowbar/red,/obj/item/clothing/mask/gas/syndicate,/obj/item/clothing/mask/gas/syndicate,/obj/item/clothing/mask/gas/syndicate,/turf/open/floor/mineral/plastitanium,/area/ship/crew)
-"ZB" = (/turf/closed/wall/mineral/plastitanium,/area/ship/crew)
-"ZI" = (/obj/effect/turf_decal/industrial/warning{dir = 9},/obj/structure/ore_box,/obj/item/storage/bag/ore,/obj/item/tank/internals/emergency_oxygen/double,/obj/item/tank/internals/emergency_oxygen/double,/obj/item/tank/internals/emergency_oxygen/double,/obj/item/tank/internals/emergency_oxygen/double,/obj/item/tank/internals/emergency_oxygen/double,/obj/item/tank/internals/emergency_oxygen/double,/obj/item/pickaxe,/obj/item/pickaxe,/obj/item/pickaxe,/turf/open/floor/mineral/plastitanium,/area/ship/crew)
-"ZJ" = (/obj/machinery/atmospherics/components/binary/pump{dir = 8; name = "fuel pump"},/obj/structure/cable{icon_state = "1-8"},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"ZK" = (/obj/effect/turf_decal/corner/red{dir = 1},/obj/effect/turf_decal/corner/red{dir = 4},/obj/structure/cable{icon_state = "1-2"},/turf/open/floor/plasteel/dark,/area/ship/crew)
-"ZZ" = (/obj/effect/turf_decal/corner/red{dir = 1},/obj/effect/turf_decal/corner/red{dir = 8},/obj/effect/turf_decal/corner/red,/obj/effect/turf_decal/corner/red{dir = 8},/turf/open/floor/plasteel/dark,/area/ship/crew)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"al" = (
+/obj/machinery/cryopod,
+/obj/structure/curtain,
+/obj/machinery/computer/cryopod{
+	pixel_y = 25
+	},
+/turf/open/floor/pod/dark,
+/area/ship/crew)
+"az" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/hatch/yellow{
+	dir = 4
+	},
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/pod/dark,
+/area/ship/crew)
+"bo" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/crew)
+"bN" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 10
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ship/crew)
+"bZ" = (
+/obj/effect/turf_decal/corner/red,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"dZ" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ship/crew)
+"gl" = (
+/obj/machinery/door/airlock/hatch{
+	id_tag = "caravansyndicate3_bolt_port";
+	name = "External Airlock";
+	normalspeed = 0;
+	req_access_txt = "150"
+	},
+/obj/docking_port/mobile{
+	dir = 2;
+	dwidth = 6;
+	height = 7;
+	name = "Syndicate Drop Ship";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 15
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/crew)
+"ha" = (
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/item/wrench,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/ship/crew)
+"hN" = (
+/obj/effect/turf_decal/corner/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/red,
+/obj/effect/turf_decal/corner/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"je" = (
+/obj/effect/turf_decal/corner/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 8
+	},
+/obj/machinery/computer/autopilot{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"jk" = (
+/obj/machinery/holopad/emergency/command,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"ka" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/pod/dark,
+/area/ship/crew)
+"mG" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ship/crew)
+"ns" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/pod/dark,
+/area/ship/crew)
+"qE" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
+/obj/machinery/stasis,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/crew)
+"rz" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/pod/dark,
+/area/ship/crew)
+"rD" = (
+/obj/effect/turf_decal/corner/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"rU" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"rV" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/pod/dark,
+/area/ship/crew)
+"sn" = (
+/obj/machinery/power/apc/syndicate{
+	dir = 8;
+	name = "Syndicate Drop Ship APC";
+	pixel_y = 25
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/pod/dark,
+/area/ship/crew)
+"ss" = (
+/obj/effect/turf_decal/corner/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"uy" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/ship/crew)
+"vw" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/briefcase,
+/turf/open/floor/pod/dark,
+/area/ship/crew)
+"wH" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/crew)
+"xC" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"Bp" = (
+/obj/effect/turf_decal/corner/red,
+/obj/effect/turf_decal/corner/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"BQ" = (
+/obj/effect/turf_decal/corner/red,
+/obj/effect/turf_decal/corner/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"Cm" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 9
+	},
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/pod/dark,
+/area/ship/crew)
+"Dt" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
+/obj/item/defibrillator/compact/combat,
+/obj/item/soap/syndie,
+/obj/item/storage/firstaid/tactical,
+/obj/item/storage/firstaid/tactical,
+/obj/item/storage/firstaid/tactical,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/crew)
+"Dx" = (
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"EO" = (
+/obj/machinery/airalarm/syndicate{
+	pixel_y = 24
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/pod/dark,
+/area/ship/crew)
+"Fa" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 10
+	},
+/obj/structure/rack,
+/obj/item/melee/transforming/energy/sword/saber/red,
+/obj/item/melee/transforming/energy/sword/saber/red,
+/obj/item/melee/transforming/energy/sword/saber/red,
+/obj/item/gun/ballistic/automatic/pistol/APS,
+/obj/item/gun/ballistic/automatic/pistol/APS,
+/obj/item/gun/ballistic/automatic/pistol/APS,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/crew)
+"FM" = (
+/obj/structure/table/reinforced,
+/obj/item/assembly/flash/handheld,
+/obj/effect/turf_decal/corner/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/red,
+/obj/effect/turf_decal/corner/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"Gx" = (
+/obj/machinery/power/smes/shuttle{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/crew)
+"GR" = (
+/obj/effect/turf_decal/corner/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"HB" = (
+/obj/effect/turf_decal/corner/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 8
+	},
+/obj/machinery/computer/helm{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"HJ" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_y = -32
+	},
+/obj/machinery/mineral/ore_redemption{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/crew)
+"HM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/red,
+/obj/effect/turf_decal/corner/red{
+	dir = 8
+	},
+/obj/machinery/microwave,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"Ij" = (
+/obj/effect/turf_decal/corner/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"IU" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"Jv" = (
+/turf/template_noop,
+/area/template_noop)
+"KS" = (
+/obj/machinery/door/airlock/hatch{
+	id_tag = "caravansyndicate3_bolt_starboard";
+	name = "External Airlock";
+	normalspeed = 0;
+	req_access_txt = "150"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/crew)
+"Ll" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/showcase/cyborg/assault,
+/turf/open/floor/pod/dark,
+/area/ship/crew)
+"Lq" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_y = 32
+	},
+/obj/machinery/autolathe/hacked,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/crew)
+"NH" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/vending/security/marine,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/crew)
+"Pg" = (
+/obj/effect/turf_decal/corner/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/red,
+/obj/effect/turf_decal/corner/red,
+/obj/effect/turf_decal/corner/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"Pt" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/item/stack/sheet/mineral/plastitanium{
+	amount = 20
+	},
+/obj/item/storage/box/lights/bulbs,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 20
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/orange/hidden,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 20
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/ship/crew)
+"PJ" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/plush/nukeplushie,
+/turf/open/floor/pod/dark,
+/area/ship/crew)
+"PY" = (
+/obj/effect/turf_decal/industrial/hatch/yellow{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/structure/window/plasma/reinforced/spawner/east,
+/obj/structure/window/plasma/reinforced/spawner/north,
+/turf/open/floor/engine/plasma,
+/area/ship/crew)
+"Ri" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"RB" = (
+/obj/effect/turf_decal/corner/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/red,
+/obj/effect/turf_decal/corner/red{
+	dir = 8
+	},
+/obj/machinery/photocopier/faxmachine/longrange,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"Sl" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/paper_bin,
+/obj/item/folder/syndicate/red,
+/obj/item/pen/red,
+/turf/open/floor/pod/dark,
+/area/ship/crew)
+"Tn" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/crew)
+"Vf" = (
+/obj/machinery/door/airlock/hatch{
+	id_tag = "caravansyndicate3_bolt_port";
+	name = "External Airlock";
+	normalspeed = 0;
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"VA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 8
+	},
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/card/emag,
+/obj/item/areaeditor/shuttle,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"Wr" = (
+/obj/effect/turf_decal/corner/red,
+/obj/effect/turf_decal/corner/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/syndicate{
+	name = "captain's suit storage unit";
+	storage_type = /obj/item/clothing/shoes/magboots/syndie;
+	suit_type = /obj/item/clothing/suit/space/hardsuit/syndi/elite
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"YU" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 10
+	},
+/obj/structure/closet/syndicate{
+	anchored = 1
+	},
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/crowbar/red,
+/obj/item/crowbar/red,
+/obj/item/crowbar/red,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/mask/gas/syndicate,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/crew)
+"ZB" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/crew)
+"ZI" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
+/obj/structure/ore_box,
+/obj/item/storage/bag/ore,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/crew)
+"ZJ" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "fuel pump"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"ZK" = (
+/obj/effect/turf_decal/corner/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"ZZ" = (
+/obj/effect/turf_decal/corner/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/red,
+/obj/effect/turf_decal/corner/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
 
 (1,1,1) = {"
-ZBTnTnTnTnTnTnTnglTnTnTnrUrUTnTnTnmGmGJv
-JvTnazsnEOalNHTnxCLqTnuynsnsrzTnHMWrmGmG
-dZwHbNZKssssFaTnDxYUTnrDIjIjhNTnDxGRRBmG
-boGxPtZJIUDxDxVfDxDxVfDxDxDxDxVfDxRiHBmG
-dZwHhaBQBpBQqETnDxZITnZZBQBQPgTnjkbZjemG
-JvTnPYkaCmrVDtTnxCHJTnSlvwPJLlTnVAFMmGmG
-ZBTnTnTnTnTnTnTnKSTnTnTnrUrUTnTnTnmGmGJv
+ZB
+Jv
+dZ
+bo
+dZ
+Jv
+ZB
+"}
+(2,1,1) = {"
+Tn
+Tn
+wH
+Gx
+wH
+Tn
+Tn
+"}
+(3,1,1) = {"
+Tn
+az
+bN
+Pt
+ha
+PY
+Tn
+"}
+(4,1,1) = {"
+Tn
+sn
+ZK
+ZJ
+BQ
+ka
+Tn
+"}
+(5,1,1) = {"
+Tn
+EO
+ss
+IU
+Bp
+Cm
+Tn
+"}
+(6,1,1) = {"
+Tn
+al
+ss
+Dx
+BQ
+rV
+Tn
+"}
+(7,1,1) = {"
+Tn
+NH
+Fa
+Dx
+qE
+Dt
+Tn
+"}
+(8,1,1) = {"
+Tn
+Tn
+Tn
+Vf
+Tn
+Tn
+Tn
+"}
+(9,1,1) = {"
+gl
+xC
+Dx
+Dx
+Dx
+xC
+KS
+"}
+(10,1,1) = {"
+Tn
+Lq
+YU
+Dx
+ZI
+HJ
+Tn
+"}
+(11,1,1) = {"
+Tn
+Tn
+Tn
+Vf
+Tn
+Tn
+Tn
+"}
+(12,1,1) = {"
+Tn
+uy
+rD
+Dx
+ZZ
+Sl
+Tn
+"}
+(13,1,1) = {"
+rU
+ns
+Ij
+Dx
+BQ
+vw
+rU
+"}
+(14,1,1) = {"
+rU
+ns
+Ij
+Dx
+BQ
+PJ
+rU
+"}
+(15,1,1) = {"
+Tn
+rz
+hN
+Dx
+Pg
+Ll
+Tn
+"}
+(16,1,1) = {"
+Tn
+Tn
+Tn
+Vf
+Tn
+Tn
+Tn
+"}
+(17,1,1) = {"
+Tn
+HM
+Dx
+Dx
+jk
+VA
+Tn
+"}
+(18,1,1) = {"
+mG
+Wr
+GR
+Ri
+bZ
+FM
+mG
+"}
+(19,1,1) = {"
+mG
+mG
+RB
+HB
+je
+mG
+mG
+"}
+(20,1,1) = {"
+Jv
+mG
+mG
+mG
+mG
+mG
+Jv
 "}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds Windoors to the Courage Class so you can repair and tinker with the thrusters
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Allows the courage class to increase the ion thrusters power without opening it up to space or landing
## Changelog
:cl:
add:windoors
moved:reinforced windows
/:cl:
![image](https://user-images.githubusercontent.com/82520990/152365431-ee7aa926-fcdb-400b-9c33-a4fef2bdc72b.png)

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
