### PR TITLE
Increases Time Until First Vote, and Payout per 10

### DIFF
--- a/code/__DEFINES/~whitesands_defines/metacoin.dm
+++ b/code/__DEFINES/~whitesands_defines/metacoin.dm
@@ -11,4 +11,4 @@
 /// Rewarded when you don't survive the round, but stick around till the end
 //#define METACOIN_NOTSURVIVE_REWARD 100 VOID CREW EDIT
 /// Rewarded when you are alive and active for 10 minutes
-#define METACOIN_TENMINUTELIVING_REWARD 25
+#define METACOIN_TENMINUTELIVING_REWARD 20

--- a/code/__DEFINES/~whitesands_defines/metacoin.dm
+++ b/code/__DEFINES/~whitesands_defines/metacoin.dm
@@ -11,4 +11,4 @@
 /// Rewarded when you don't survive the round, but stick around till the end
 //#define METACOIN_NOTSURVIVE_REWARD 100 VOID CREW EDIT
 /// Rewarded when you are alive and active for 10 minutes
-#define METACOIN_TENMINUTELIVING_REWARD 20
+#define METACOIN_TENMINUTELIVING_REWARD 25

--- a/code/__DEFINES/~whitesands_defines/metacoin.dm
+++ b/code/__DEFINES/~whitesands_defines/metacoin.dm
@@ -11,4 +11,4 @@
 /// Rewarded when you don't survive the round, but stick around till the end
 //#define METACOIN_NOTSURVIVE_REWARD 100 VOID CREW EDIT
 /// Rewarded when you are alive and active for 10 minutes
-#define METACOIN_TENMINUTELIVING_REWARD 15
+#define METACOIN_TENMINUTELIVING_REWARD 25

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -119,8 +119,7 @@
 //WS Begin - Autotranfer vote
 
 /datum/config_entry/number/vote_autotransfer_initial //length of time before the first autotransfer vote is called (deciseconds, default 2 hours)
-	config_entry_value = 72000
-	integer = FALSE
+	config_entry_value = 126000 //VOIDCREW EDIT
 	min_val = 0
 
 /datum/config_entry/number/vote_autotransfer_interval //length of time to wait before subsequent autotransfer votes (deciseconds, default 30 minutes)

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -120,6 +120,7 @@
 
 /datum/config_entry/number/vote_autotransfer_initial //length of time before the first autotransfer vote is called (deciseconds, default 2 hours)
 	config_entry_value = 126000 //VOIDCREW EDIT
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/vote_autotransfer_interval //length of time to wait before subsequent autotransfer votes (deciseconds, default 30 minutes)

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -119,7 +119,7 @@
 //WS Begin - Autotranfer vote
 
 /datum/config_entry/number/vote_autotransfer_initial //length of time before the first autotransfer vote is called (deciseconds, default 2 hours)
-	config_entry_value = 126000 //VOIDCREW EDIT
+	config_entry_value = 72000
 	integer = FALSE
 	min_val = 0
 

--- a/whitesands/code/modules/metacoin/metacoin.dm
+++ b/whitesands/code/modules/metacoin/metacoin.dm
@@ -40,12 +40,13 @@
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)]: Modified [key_name(C)]'s [metacoin_name] ([log_text])</span>")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Modify Metabalance") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/* VOIDCREW EDIT
 /client/proc/process_endround_metacoin(is_speed_round, round_duration)
 	if(!mob)	return
 	var/mob/M = mob
 	if(M.mind && !isnewplayer(M))
 		if(M.stat != DEAD && !isbrain(M))
-			inc_metabalance(METACOIN_ESCAPE_REWARD(is_speed_round, round_duration), reason="Survived the shift.")
+			inc_metabalance(METACOIN_ESCAPE_REWARD(is_speed_round, round_duration), reason="Survived the shift.") */
 /*
 VOID CREW EDIT
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the First Vote to 3 1/2 hours 
Also increases the Payout per 10 minutes to 20
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently on the low end we get 280 coins at 2:10 shifts. This isn't enough money to buy any ships except the pill which isn't healthy. Currently the average cost of a ship is 606 coins. Earning half of that per shift at the low end doesn't feel good to me so i raised the per 10 to 20 and first vote time to compensate. Now on the low end we get around 520 coins. Which allows you to buy a larger amount of ships. 
The alternative is to re-balance the costs of all the ships, but to do that we would probably have to come up with a convention for determining price.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
changed: transfer vote to 126000
changed METACOIN_TENMINUTELIVING_REWARD  to 20
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
