### PR TITLE
adds the ability to dig up grass tiles without placing them

### DIFF
--- a/shiptest.dme
+++ b/shiptest.dme
@@ -3237,6 +3237,7 @@ g// DM Environment file for shiptest.dme.
 #include "voidcrew\code\game\objects\items\devices\radio\radio.dm"
 #include "voidcrew\code\game\objects\items\storage\backpack.dm"
 #include "voidcrew\code\game\objects\items\storage\boxes.dm"
+#include "voidcrew\code\game\objects\items\stacks\tiles\tile_types.dm"
 #include "voidcrew\code\game\objects\structures\door_assembly_types.dm"
 #include "voidcrew\code\game\objects\structures\ghost_role_spawners.dm"
 #include "voidcrew\code\game\objects\structures\tables_racks.dm"

--- a/voidcrew/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/voidcrew/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -1,5 +1,5 @@
 /obj/item/stack/tile/grass/attackby(obj/item/item, mob/user, params)
-	if((W.tool_behaviour == TOOL_SHOVEL) && params)
+	if((item.tool_behaviour == TOOL_SHOVEL) && params)
 		to_chat(user, "<span class='notice'>You start digging up [src].</span>")
 		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
 		if(do_after(user, 2 * get_amount(), target = src))

--- a/voidcrew/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/voidcrew/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -1,0 +1,11 @@
+/obj/item/stack/tile/grass/attackby(obj/item/W, mob/user, params)
+	if((W.tool_behaviour == TOOL_SHOVEL) && params)
+		to_chat(user, "<span class='notice'>You start digging up [src].</span>")
+		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
+		if(do_after(user, 2 * get_amount(), target = src))
+			new /obj/item/stack/ore/glass(get_turf(src), 2 * get_amount())
+			user.visible_message("<span class='notice'>[user] digs up [src].</span>", "<span class='notice'>You uproot [src].</span>")
+			playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
+			qdel(src)
+	else
+		return ..()

--- a/voidcrew/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/voidcrew/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -1,4 +1,4 @@
-/obj/item/stack/tile/grass/attackby(obj/item/W, mob/user, params)
+/obj/item/stack/tile/grass/attackby(obj/item/item, mob/user, params)
 	if((W.tool_behaviour == TOOL_SHOVEL) && params)
 		to_chat(user, "<span class='notice'>You start digging up [src].</span>")
 		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives players the ability to dig a full stack of grass tiles at once without spam placing and spading them
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
less wrist pain from clicking is good for the players
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: the ability to dig up grass tile stacks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
