### PR TITLE
Lets bedsheet start ghetto surgery

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -12,6 +12,7 @@ LINEN BINS
 	righthand_file = 'icons/mob/inhands/misc/bedsheet_righthand.dmi'
 	icon_state = "sheetwhite"
 	item_state = "sheetwhite"
+	item_flags = SURGICAL_TOOL
 	slot_flags = ITEM_SLOT_NECK
 	layer = MOB_LAYER
 	throwforce = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds SURGICAL_TOOL item flag to bedsheets, meaning you can start surgeries with them

## Why It's Good For The Game

Starting surgeries with a surgical tool instead of drapes is great, but it means you can't actually start a ghetto surgery without a proper tool, which completely defeats the point of ghetto surgery. I feel like adding SURGICAL_TOOL to every single ghetto surgery tool might cause some issues, but doing it to bedsheets seems pretty harmless, so there

## Changelog
:cl:

tweak: bedsheet can start surgery

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
![surgery](https://user-images.githubusercontent.com/21028062/152741931-3b0d56a7-5d77-494f-afd1-d2e5875ac0e9.PNG)

