### PR TITLE
Adds xenobio crate to supply console.

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1579,6 +1579,20 @@
 	crate_type = /obj/structure/closet/crate/secure/science
 	dangerous = TRUE
 
+/datum/supply_pack/science/xenobio
+	name = "Xenobiology Lab Crate"
+	desc = "In case a freak accident has rendered the xenobiology lab non-functional! Contains two grey slime extracts, some plasma, and the required circuit boards to set up your xenobiology lab up and running! Requires Xenobiology access to open."
+	cost = 10000
+	access = ACCESS_XENOBIOLOGY
+	contains = list(/obj/item/slime_extract/grey,
+					/obj/item/slime_extract/grey,
+					/obj/item/reagent_containers/syringe/plasma,
+					/obj/item/circuitboard/computer/xenobiology,
+					/obj/item/circuitboard/machine/monkey_recycler,
+					/obj/item/circuitboard/machine/processor/slime)
+	crate_name = "xenobiology starter crate"
+	crate_type = /obj/structure/closet/crate/secure/science
+
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Service //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1579,20 +1579,6 @@
 	crate_type = /obj/structure/closet/crate/secure/science
 	dangerous = TRUE
 
-/datum/supply_pack/science/xenobio
-	name = "Xenobiology Lab Crate"
-	desc = "In case a freak accident has rendered the xenobiology lab non-functional! Contains two grey slime extracts, some plasma, and the required circuit boards to set up your xenobiology lab up and running! Requires Xenobiology access to open."
-	cost = 10000
-	access = ACCESS_XENOBIOLOGY
-	contains = list(/obj/item/slime_extract/grey,
-					/obj/item/slime_extract/grey,
-					/obj/item/reagent_containers/syringe/plasma,
-					/obj/item/circuitboard/computer/xenobiology,
-					/obj/item/circuitboard/machine/monkey_recycler,
-					/obj/item/circuitboard/machine/processor/slime)
-	crate_name = "xenobiology starter crate"
-	crate_type = /obj/structure/closet/crate/secure/science
-
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Service //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -3249,6 +3249,7 @@ g// DM Environment file for shiptest.dme.
 #include "voidcrew\code\modules\antagonists\disease\disease_abilities.dm"
 #include "voidcrew\code\modules\antagonists\ert\ert.dm"
 #include "voidcrew\code\modules\atmospherics\gasmixtures\immutable_mixtures.dm"
+#include "voidcrew\code\modules\cargo\packs.dm"
 #include "voidcrew\code\modules\client\preferences.dm"
 #include "voidcrew\code\modules\clothing\head\berets.dm"
 #include "voidcrew\code\modules\clothing\head\helmet.dm"

--- a/voidcrew/code/modules/cargo/packs.dm
+++ b/voidcrew/code/modules/cargo/packs.dm
@@ -1,0 +1,17 @@
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Science /////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_pack/science/xenobio
+	name = "Xenobiology Lab Crate"
+	desc = "In case a freak accident has rendered the xenobiology lab non-functional! Contains two grey slime extracts, some plasma, and the required circuit boards to set up your xenobiology lab up and running! Requires Xenobiology access to open."
+	cost = 10000
+	access = ACCESS_XENOBIOLOGY
+	contains = list(/obj/item/slime_extract/grey,
+					/obj/item/slime_extract/grey,
+					/obj/item/reagent_containers/syringe/plasma,
+					/obj/item/circuitboard/computer/xenobiology,
+					/obj/item/circuitboard/machine/monkey_recycler,
+					/obj/item/circuitboard/machine/processor/slime)
+	crate_name = "xenobiology starter crate"
+	crate_type = /obj/structure/closet/crate/secure/science


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds xenobiology crate which can be bought for 10000 credits by using a supply console.
The crate requires xenobiology access to unlock and contains 2 grey slime extracts, one syringe of plasma and the boards required to set up a xenobio lab (monkey recycler, slime processor and xenobio console), parts not included.

Ported from
https://github.com/BeeStation/BeeStation-Hornet/pull/3452

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes xenobiology more accessible ~~and allows more people to make ghetto xenobio labs~~

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Hardly
add: Xenobiology crate can now be bought for 10000 credits by using a supply console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
