### PR TITLE
Improves the auto shipdeleter

### DIFF
--- a/code/modules/admin/verbs/shuttlepanel.dm
+++ b/code/modules/admin/verbs/shuttlepanel.dm
@@ -23,6 +23,7 @@
 	options += "Infinite Transit"
 	options += "Delete Shuttle"
 	options += "Into The Sunset (delete & greentext 'escape')"
+	options += "Cancel Queued Deletion"
 
 	var/selection = input(user, "Select where to fly [name]:", "Fly Shuttle") as null|anything in options
 	if(!selection)
@@ -32,20 +33,32 @@
 		if("Infinite Transit")
 			destination = null
 			mode = SHUTTLE_IGNITING
+			message_admins("\[SHUTTLE]: [key_name_admin(user)] has placed [name] into Infinite Transit.")
+			log_admin("\[SHUTTLE]: [key_name_admin(user)] has placed [name] into Infinite Transit.")
 			setTimer(ignitionTime)
-			message_admins("[user.key] has placed [name] into Infinite Transit.")
 
 		if("Delete Shuttle")
 			if(alert(user, "Really delete [name]?", "Delete Shuttle", "Cancel", "Really!") != "Really!")
 				return
+			message_admins("\[SHUTTLE]: [key_name_admin(user)] has deleted [name].")
+			log_admin("\[SHUTTLE]: [key_name_admin(user)] has deleted [name].")
 			jumpToNullSpace()
-			message_admins("[user.key] has deleted [name].")
 
 		if("Into The Sunset (delete & greentext 'escape')")
 			if(alert(user, "Really delete [name] and greentext escape objectives?", "Delete Shuttle", "Cancel", "Really!") != "Really!")
 				return
+			message_admins("\[SHUTTLE]: [key_name_admin(user)] has deleted [name], and granted the crew greentext.")
+			log_admin("\[SHUTTLE]: [key_name_admin(user)] has deleted [name], and granted the crew greentext.")
 			intoTheSunset()
-			message_admins("[user.key] has deleted [name], and granted the crew greentext.")
+		if("Cancel Queued Deletion")
+			if (isnull(current_ship.deletion_timer))
+				to_chat(user, "<span class='notice'>Ship not queued for deletion!</span>")
+				return
+			deltimer(current_ship.deletion_timer)
+			current_ship.deletion_timer = null
+			message_admins("\[SHUTTLE]: [key_name_admin(user)] has cancelled the deletion of [name]!")
+			log_admin("\[SHUTTLE]: [key_name_admin(user)] has cancelled the deletion of [name]!")
+
 
 		else
 			if(options[selection])

--- a/code/modules/overmap/ships/simulated_ship_data.dm
+++ b/code/modules/overmap/ships/simulated_ship_data.dm
@@ -25,10 +25,40 @@
 
 /obj/structure/overmap/ship/simulated/Destroy()
 	. = ..()
-	// clear all the weakrefs and unreg signals
+	unregister_all_crewmembers()
+
+/**
+ * Unregister a crewmate from the crewmembers list
+ *
+ * Arguments:
+ * * mob/living/carbon/human/crewmate - The mob to remove from the list of crewmembers
+ */
+/obj/structure/overmap/ship/simulated/proc/unregister_crewmember(mob/living/carbon/human/crewmate)
 	for (var/datum/weakref/member in crewmembers)
-		UnregisterSignal(member.resolve(), COMSIG_MOB_DEATH)
-		member = null
+		if (crewmate == member.resolve())
+			UnregisterSignal(member.resolve(), list(COMSIG_MOB_DEATH, COMSIG_MOB_LOGOUT))
+			member = null
+
+/**
+ * Unregister ALL crewmates from the ship
+ */
+/obj/structure/overmap/ship/simulated/proc/unregister_all_crewmembers()
+	for (var/datum/weakref/member in crewmembers)
+		if (isnull(member.resolve()))
+			member = null
+			continue
+		unregister_crewmember(member.resolve())
+
+/**
+ * Register a crewmate to the crewmembers list
+ *
+ * Arguments:
+ * * mob/living/carbon/human/crewmate - The mob to add to the list of crewmembers
+ */
+/obj/structure/overmap/ship/simulated/proc/register_cremember(mob/living/carbon/human/crewmate)
+	var/datum/weakref/new_cremate = WEAKREF(crewmate)
+	crewmembers.Add(new_cremate)
+	RegisterSignal(crewmate, list(COMSIG_MOB_DEATH, COMSIG_MOB_LOGOUT), .proc/handle_inactive_ship)
 
 /**
   * Bastardized version of GLOB.manifest.manifest_inject, but used per ship
@@ -38,10 +68,7 @@
 	set waitfor = FALSE
 	if(H.mind && (H.mind.assigned_role != H.mind.special_role))
 		manifest[H.real_name] = human_job
-
-	var/datum/weakref/new_cremate = WEAKREF(H)
-	crewmembers.Add(new_cremate)
-	RegisterSignal(H, COMSIG_MOB_DEATH, .proc/handle_inactive_ship)
+	register_cremember(H)
 
 /**
  * Check the status of the crew
@@ -52,7 +79,8 @@
 		var/mob/living/carbon/human/member = crewmember.resolve()
 		if (isnull(member)) // this crewmate is gone
 			continue
-
+		if (shuttle.z != member.z) // different z, they don't matter anymore
+			continue
 		if (member.stat <= HARD_CRIT)
 			if (isnull(member.client))
 				is_ssd = TRUE

--- a/code/modules/overmap/ships/simulated_ship_data.dm
+++ b/code/modules/overmap/ships/simulated_ship_data.dm
@@ -55,7 +55,7 @@
  * Arguments:
  * * mob/living/carbon/human/crewmate - The mob to add to the list of crewmembers
  */
-/obj/structure/overmap/ship/simulated/proc/register_cremember(mob/living/carbon/human/crewmate)
+/obj/structure/overmap/ship/simulated/proc/register_crewmember(mob/living/carbon/human/crewmate)
 	var/datum/weakref/new_cremate = WEAKREF(crewmate)
 	crewmembers.Add(new_cremate)
 	RegisterSignal(crewmate, list(COMSIG_MOB_DEATH, COMSIG_MOB_LOGOUT), .proc/handle_inactive_ship)
@@ -68,7 +68,7 @@
 	set waitfor = FALSE
 	if(H.mind && (H.mind.assigned_role != H.mind.special_role))
 		manifest[H.real_name] = human_job
-	register_cremember(H)
+	register_crewmember(H)
 
 /**
  * Check the status of the crew

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -484,7 +484,8 @@
 		underlying_area.contents += oldT
 		oldT.change_area(old_area, underlying_area)
 
-	message_admins("\[SHUTTLE]: [current_ship?.name] has been deleted!")
+	message_admins("\[SHUTTLE]: [current_ship?.name] has been turned into a ruin!")
+	log_admin("\[SHUTTLE]: [current_ship?.name] has been turned into a ruin!")
 
 	qdel(src, force=TRUE)
 


### PR DESCRIPTION
Adds some extra QOL changes, including:
- Better logging
    - Ships being deleted are now in game logs, as well admins will be notified when a ship is queued for deletion.
- Queue cancellation
    - Admins can cancel the queued deletion of a ship with the Shuttle Manipulator menu
- Going SSD triggers a check
- Crewmates on other zlevels aren't counted as living
- Some new helper procs to add to/remove from the list of crewmates

I still need to add an IC method of adding or removing from the crew but that can come later
(also fixes some logging inside the shuttle manipulator)