### PR TITLE
Ships can now grant all members an antagonist status!

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -198,6 +198,10 @@ SUBSYSTEM_DEF(mapping)
 		if(islist(data["namelists"]))
 			S.name_categories = data["namelists"]
 
+		if(istext(data["antag_datum"]))
+			var/path = "/datum/antagonist/" + data["antag_datum"]
+			S.antag_datum = text2path(path)
+
 		S.job_slots = list()
 		var/list/job_slot_list = data["job_slots"]
 		for(var/job in job_slot_list)

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -16,7 +16,10 @@
 	var/short_name
 	var/list/job_slots
 	var/list/name_categories = list("GENERAL")
-	var/prefix = "SV"
+	var/prefix = "NEU"
+
+	///The antag datum to give a player on join
+	var/antag_datum
 
 /datum/map_template/shuttle/proc/prerequisites_met()
 	return TRUE

--- a/code/modules/overmap/ships/simulated_ship_data.dm
+++ b/code/modules/overmap/ships/simulated_ship_data.dm
@@ -60,6 +60,10 @@
 	crewmembers.Add(new_cremate)
 	RegisterSignal(crewmate, list(COMSIG_MOB_DEATH, COMSIG_MOB_LOGOUT), .proc/handle_inactive_ship)
 
+	if (!isnull(source_template.antag_datum))
+		var/datum/antagonist/ship_datum = new source_template.antag_datum
+		crewmate.mind.add_antag_datum(ship_datum)
+
 /**
   * Bastardized version of GLOB.manifest.manifest_inject, but used per ship
   *


### PR DESCRIPTION
This is going to be just used for admin events, right now all that's
planned is a cultist ship. However, this opens the door for any
antagonist based theme.

For mappers:
all you have to do is add
```
"antag_datum": "(antag name here)",
```
You don't have to worry about putting the full `/datum/antagonist/...` path in, that's handled in code. As long as you get the end part right, i.e. for cult instead of `/datum/antagonist/cult` you would just put `cult`