### PR TITLE
Removes knockdown from the stunbaton

### DIFF
--- a/shiptest.dme
+++ b/shiptest.dme
@@ -3232,6 +3232,7 @@ g// DM Environment file for shiptest.dme.
 #include "voidcrew\code\game\objects\items\desk_flags.dm"
 #include "voidcrew\code\game\objects\items\fireaxe.dm"
 #include "voidcrew\code\game\objects\items\spear.dm"
+#include "voidcrew\code\game\objects\items\stunbaton.dm"
 #include "voidcrew\code\game\objects\items\circuitboards\computer_circuitboards.dm"
 #include "voidcrew\code\game\objects\items\circuitboards\machine_circuitboards.dm"
 #include "voidcrew\code\game\objects\items\devices\PDA_types.dm"

--- a/voidcrew/code/game/objects/items/stunbaton.dm
+++ b/voidcrew/code/game/objects/items/stunbaton.dm
@@ -1,0 +1,2 @@
+/obj/item/melee/baton/apply_stun_effect_end(mob/living/target)
+	return // YEAHHHH BITCH NO KNOCKDOWN


### PR DESCRIPTION
Stun combat sucks, especially when all of our combat happens in: close
quarters, and small numbers of people.
Blah blah, this makes stuns not a nearly instant win. Two clicks will
still wreck the other person, but now you have a fighting chance if you
are stunned.