### PR TITLE
Fixes some harddels

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/firebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/firebot.dm
@@ -48,13 +48,12 @@
 	extinguish_fires = FALSE
 	extinguish_people = TRUE
 
-/mob/living/simple_animal/bot/firebot/rockplanet/Initialize()
-	. = ..()
+/mob/living/simple_animal/bot/firebot/rockplanet/create_extinguisher()
 	internal_ext = new /obj/item/extinguisher(src)
 	internal_ext.chem = /datum/reagent/clf3 //Refill the internal extinguisher with liquid fire
 	internal_ext.power = 3
 	internal_ext.safety = FALSE
-	internal_ext.precision = FALSE
+	internal_ext.precision = TRUE
 	internal_ext.max_water = INFINITY
 	internal_ext.refill()
 
@@ -68,6 +67,10 @@
 	prev_access = access_card.access
 
 	create_extinguisher()
+
+/mob/living/simple_animal/bot/firebot/Destroy()
+	QDEL_NULL(internal_ext)
+	return ..()
 
 /mob/living/simple_animal/bot/firebot/bot_reset()
 	create_extinguisher()

--- a/whitesands/code/modules/mining/deepcore/drill.dm
+++ b/whitesands/code/modules/mining/deepcore/drill.dm
@@ -19,6 +19,12 @@
 	. = ..()
 	container.max_amount = 4000 //Give the drill some room to buffer mats, but not much
 
+/obj/machinery/deepcore/drill/Destroy()
+	. = ..()
+	if (active_vein)
+		active_vein.miner = null
+		active_vein = null
+
 /obj/machinery/deepcore/drill/interact(mob/user, special_state)
 	. = ..()
 	if(machine_stat & BROKEN)
@@ -73,9 +79,8 @@
 
 /obj/machinery/deepcore/drill/proc/mineOre()
 	var/list/extracted = active_vein.extract_ore()
-	for(var/O in extracted)
-		var/datum/material/M = O
-		container.insert_amount_mat(extracted[M], M)
+	for(var/datum/material/material as anything in extracted)
+		container.insert_amount_mat(extracted[material], material)
 	return TRUE
 
 /obj/machinery/deepcore/drill/proc/dropOre(datum/material/M, amount)
@@ -87,6 +92,7 @@
 	var/obj/effect/landmark/ore_vein/vein = locate() in deployed_zone
 	if(vein)
 		active_vein = vein
+		active_vein.miner = src
 		return vein
 	else
 		return FALSE

--- a/whitesands/code/modules/mining/deepcore/ore_vein.dm
+++ b/whitesands/code/modules/mining/deepcore/ore_vein.dm
@@ -4,6 +4,7 @@ GLOBAL_LIST_EMPTY(ore_vein_landmarks)
 	name = "ore vein"
 	var/datum/material/resource
 	var/material_rate = 0
+	var/obj/machinery/deepcore/drill/miner
 
 /obj/effect/landmark/ore_vein/Initialize(mapload, var/datum/material/mat)
 	. = ..()
@@ -29,6 +30,14 @@ GLOBAL_LIST_EMPTY(ore_vein_landmarks)
 	resource = M
 	if((!material_rate) && ores_list[M])
 		material_rate = ores_list[M]
+
+/obj/effect/landmark/ore_vein/Destroy()
+	. = ..()
+	QDEL_NULL(resource)
+	if (miner)
+		miner.active_vein = null
+		miner = null
+	GLOB.ore_vein_landmarks -= src
 
 /obj/effect/landmark/ore_vein/proc/extract_ore() //Called by deepcore drills, returns a list of keyed ore stacks by amount
 	var/list/ores = list()


### PR DESCRIPTION
Fixes bot and ore vein harddels. Theres still SOME harddels on all simple bots, because they're not properly being cleared from the global hud lists, however after testing for the last 2 hours I couldn't figure out how to properly clear it.