### PR TITLE
Adds colors to overmap ships based off faction

### DIFF
--- a/code/modules/overmap/ships/_ships.dm
+++ b/code/modules/overmap/ships/_ships.dm
@@ -191,6 +191,7 @@
 	var/turf/T = locate(nx,ny,z)
 	if(T)
 		forceMove(T)
+
 /**
  * Burns the engines in one direction, accelerating in that direction.
  * Unsimulated ships use the acceleration_speed var, simulated ships check eacch engine's thrust and fuel.

--- a/code/modules/overmap/ships/_ships.dm
+++ b/code/modules/overmap/ships/_ships.dm
@@ -191,7 +191,6 @@
 	var/turf/T = locate(nx,ny,z)
 	if(T)
 		forceMove(T)
-
 /**
  * Burns the engines in one direction, accelerating in that direction.
  * Unsimulated ships use the acceleration_speed var, simulated ships check eacch engine's thrust and fuel.

--- a/code/modules/overmap/ships/simulated.dm
+++ b/code/modules/overmap/ships/simulated.dm
@@ -60,6 +60,7 @@
 	name = shuttle.name
 	source_template = _source_template
 	prefix = source_template.prefix
+	update_ship_color()
 	calculate_mass()
 #ifdef UNIT_TESTS
 	set_ship_name("[source_template]")
@@ -353,6 +354,20 @@
 	name = "[prefix] [copytext(name, fixed_name)]"
 	set_ship_name(name, ignore_cooldown = TRUE)
 	update_crew_hud()
+	update_ship_color()
+/**
+  * Updates the ships icon to make it easier to distinguish between factions
+  */
+/obj/structure/overmap/ship/simulated/proc/update_ship_color()
+	if(prefix == "SYN-C")
+		color = "#ff0000"
+	if(prefix == "NT-C")
+		color = "#0000FF"
+	if(prefix == "KOS")
+		color = "#4b0101"
+	if (prefix == "NEU")
+		color = "#3f3f3f"
+	add_atom_colour(color, FIXED_COLOUR_PRIORITY)
 /**
   *The proc for actually updating the hud calls from faction_datum
   */
@@ -385,7 +400,6 @@
 			addtimer(CALLBACK(src, .proc/finalize_inactive_ship, TRUE), CHECK_CREW_SSD)
 		if (SHUTTLE_INACTIVE_CREW)
 			finalize_inactive_ship()
-
 /**
  * Go through the different statuses of the ship, and choose the proper deletion method of the ship
  *

--- a/code/modules/overmap/ships/simulated.dm
+++ b/code/modules/overmap/ships/simulated.dm
@@ -337,6 +337,7 @@
 	for(var/area/shuttle_area as anything in shuttle.shuttle_areas)
 		shuttle_area.rename_area("[new_name] [initial(shuttle_area.name)]")
 	return TRUE
+
 /**
   *Sets the ships faction and updates the crews huds
   */
@@ -355,19 +356,22 @@
 	set_ship_name(name, ignore_cooldown = TRUE)
 	update_crew_hud()
 	update_ship_color()
+
 /**
   * Updates the ships icon to make it easier to distinguish between factions
   */
 /obj/structure/overmap/ship/simulated/proc/update_ship_color()
-	if(prefix == "SYN-C")
-		color = "#ff0000"
-	if(prefix == "NT-C")
-		color = "#0000FF"
-	if(prefix == "KOS")
-		color = "#4b0101"
-	if (prefix == "NEU")
-		color = "#3f3f3f"
+	switch(prefix)
+		if("SYN-C")
+			color = "#F10303"
+		if("NT-C")
+			color = "#115188"
+		if("KOS")
+			color = "#6E0202"
+		if("NEU")
+			color = "#DDDDDD"
 	add_atom_colour(color, FIXED_COLOUR_PRIORITY)
+
 /**
   *The proc for actually updating the hud calls from faction_datum
   */
@@ -400,6 +404,7 @@
 			addtimer(CALLBACK(src, .proc/finalize_inactive_ship, TRUE), CHECK_CREW_SSD)
 		if (SHUTTLE_INACTIVE_CREW)
 			finalize_inactive_ship()
+
 /**
  * Go through the different statuses of the ship, and choose the proper deletion method of the ship
  *


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds Colors to ships based off faction, this lets you quickly determine if the ship flying to a planet is an enemy or not so you can pursue
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Helps encourage PvP between enemy factions aswell as faction to faction interaction later down the line
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
![image](https://user-images.githubusercontent.com/82520990/153703673-08970e33-ed36-4185-a9de-cd489f1e3051.png)

## Changelog
:cl:
add: Overmap ship coloring
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
