### PR TITLE
improves the shutlte deleter even further

### DIFF
--- a/code/modules/admin/verbs/shuttlepanel.dm
+++ b/code/modules/admin/verbs/shuttlepanel.dm
@@ -23,6 +23,9 @@
 	options += "Infinite Transit"
 	options += "Delete Shuttle"
 	options += "Into The Sunset (delete & greentext 'escape')"
+	options += "Check Crew Status"
+	options += "Register All Humans Aboard the Ship into the Crewlist"
+	options += "Unregister ALL Crewmembers"
 	options += "Cancel Queued Deletion"
 
 	var/selection = input(user, "Select where to fly [name]:", "Fly Shuttle") as null|anything in options
@@ -50,6 +53,25 @@
 			message_admins("\[SHUTTLE]: [key_name_admin(user)] has deleted [name], and granted the crew greentext.")
 			log_admin("\[SHUTTLE]: [key_name_admin(user)] has deleted [name], and granted the crew greentext.")
 			intoTheSunset()
+
+		if("Check Crew Status")
+			var/result = current_ship.is_active_crew()
+			switch(result)
+				if(SHUTTLE_INACTIVE_CREW)
+					to_chat(user, "The crew is all dead!")
+				if(SHUTTLE_SSD_CREW)
+					to_chat(user, "The remaining crew members are SSD!")
+				if(SHUTTLE_ACTIVE_CREW)
+					to_chat(user, "At least one crewmember is alive and not SSD!")
+
+		if("Register All Humans Aboard the Ship into the Crewlist")
+			current_ship.register_all_crewmembers()
+			message_admins("\[SHUTTLE]: [key_name_admin(user)] has added all humans aboard [name] into the crewlist.")
+
+		if("Unregister ALL Crewmembers")
+			current_ship.unregister_all_crewmembers()
+			message_admins("\[SHUTTLE]: [key_name_admin(user)] has unregistered all crewmembers from [name].")
+
 		if("Cancel Queued Deletion")
 			if (isnull(current_ship.deletion_timer))
 				to_chat(user, "<span class='notice'>Ship not queued for deletion!</span>")
@@ -58,7 +80,6 @@
 			current_ship.deletion_timer = null
 			message_admins("\[SHUTTLE]: [key_name_admin(user)] has cancelled the deletion of [name]!")
 			log_admin("\[SHUTTLE]: [key_name_admin(user)] has cancelled the deletion of [name]!")
-
 
 		else
 			if(options[selection])

--- a/code/modules/overmap/ships/simulated.dm
+++ b/code/modules/overmap/ships/simulated.dm
@@ -98,7 +98,7 @@
 	destroy_ship()
 
 /obj/structure/overmap/ship/simulated/proc/destroy_ship(force = FALSE)
-	if (is_active_crew() == SHUTTLE_ACTIVE_CREW)
+	if ((length(shuttle.get_all_humans()) > 0) && !force)
 		return
 	shuttle.jumpToNullSpace()
 	message_admins("\[SHUTTLE]: [shuttle.name] has been deleted!")

--- a/code/modules/overmap/ships/simulated.dm
+++ b/code/modules/overmap/ships/simulated.dm
@@ -382,7 +382,7 @@
 		if (SHUTTLE_ACTIVE_CREW)
 			return
 		if (SHUTTLE_SSD_CREW)
-			addtimer(CALLBACK(src, .proc/finalize_inactive_ship, TRUE), CHECK_CREW_SSD)
+			addtimer(CALLBACK(src, .proc/finalize_inactive_ship, TRUE), CHECK_CREW_SSD, TIMER_UNIQUE)
 		if (SHUTTLE_INACTIVE_CREW)
 			finalize_inactive_ship()
 

--- a/code/modules/overmap/ships/simulated_ship_data.dm
+++ b/code/modules/overmap/ships/simulated_ship_data.dm
@@ -82,8 +82,11 @@
 /obj/structure/overmap/ship/simulated/proc/register_all_crewmembers()
 	var/list/humans = shuttle.get_all_humans()
 	for (var/mob/living/carbon/human/human_to_add as anything in humans)
-		if(!isnull(human_to_add.client))
-			register_crewmember(human_to_add)
+		if(isnull(human_to_add.client))
+			continue
+		if(is_player_in_crew(human_to_add))
+			continue
+		register_crewmember(human_to_add)
 
 /**Checks for verification before being aloud to open a console or object
   * Arguments:

--- a/code/modules/overmap/ships/simulated_ship_data.dm
+++ b/code/modules/overmap/ships/simulated_ship_data.dm
@@ -45,7 +45,6 @@
 				ex_crewmate_mind.remove_antag_datum(to_remove)
 
 			member = null
-			crewmembers.Remove(member)
 
 /**
  * Unregister ALL crewmates from the ship

--- a/code/modules/overmap/ships/simulated_ship_data.dm
+++ b/code/modules/overmap/ships/simulated_ship_data.dm
@@ -45,6 +45,7 @@
 				ex_crewmate_mind.remove_antag_datum(to_remove)
 
 			member = null
+			crewmembers.Remove(member)
 
 /**
  * Unregister ALL crewmates from the ship
@@ -55,6 +56,7 @@
 			member = null
 			continue
 		unregister_crewmember(member.resolve())
+	crewmembers = list()
 
 /**
  * Register a crewmate to the crewmembers list
@@ -81,7 +83,8 @@
 /obj/structure/overmap/ship/simulated/proc/register_all_crewmembers()
 	var/list/humans = shuttle.get_all_humans()
 	for (var/mob/living/carbon/human/human_to_add as anything in humans)
-		register_crewmember(human_to_add)
+		if(!isnull(human_to_add.client))
+			register_crewmember(human_to_add)
 
 /**Checks for verification before being aloud to open a console or object
   * Arguments:

--- a/code/modules/overmap/ships/simulated_ship_data.dm
+++ b/code/modules/overmap/ships/simulated_ship_data.dm
@@ -36,7 +36,7 @@
 	for (var/datum/weakref/member in crewmembers)
 		if (crewmate == member.resolve())
 			var/mob/living/carbon/human/ex_crewmate = member.resolve()
-			UnregisterSignal(ex_crewmate, list(COMSIG_MOB_DEATH, COMSIG_MOB_LOGOUT))
+			UnregisterSignal(ex_crewmate, COMSIG_MOB_DEATH)
 
 			remove_faction_hud(FACTION_HUD_GENERAL, ex_crewmate)
 			var/datum/mind/ex_crewmate_mind = ex_crewmate.mind
@@ -65,13 +65,24 @@
 /obj/structure/overmap/ship/simulated/proc/register_crewmember(mob/living/carbon/human/crewmate)
 	var/datum/weakref/new_cremate = WEAKREF(crewmate)
 	crewmembers.Add(new_cremate)
-	RegisterSignal(crewmate, list(COMSIG_MOB_DEATH, COMSIG_MOB_LOGOUT), .proc/handle_inactive_ship)
+	RegisterSignal(crewmate, COMSIG_MOB_DEATH, .proc/handle_inactive_ship)
 	//Adds a faction hud to a newplayer documentation in _HELPERS/game.dm
 	add_faction_hud(FACTION_HUD_GENERAL, prefix, crewmate)
 
 	if (!isnull(source_template.antag_datum))
 		var/datum/antagonist/ship_datum = new source_template.antag_datum
 		crewmate.mind.add_antag_datum(ship_datum)
+
+/**
+ * ##register_all_crewmembers
+ *
+ * Takes all of the living humans on the ship and adds them as a crewmember
+ */
+/obj/structure/overmap/ship/simulated/proc/register_all_crewmembers()
+	var/list/humans = shuttle.get_all_humans()
+	for (var/mob/living/carbon/human/human_to_add as anything in humans)
+		register_crewmember(human_to_add)
+
 /**Checks for verification before being aloud to open a console or object
   * Arguments:
   * mob/living/carbon/human/crewmate - The mob being checked for access
@@ -81,6 +92,7 @@
 		if (crewmate == member.resolve())
 			return TRUE
 	return FALSE
+
 /**
   * Bastardized version of GLOB.manifest.manifest_inject, but used per ship
   *

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -454,6 +454,20 @@
 		WARNING("shuttle \"[name]\" could not enter transit space. S0=[S0 ? S0.name : "null"] S1=[S1 ? S1.name : "null"]")
 
 /**
+ * ##get_all_humans
+ *
+ * Returns a list of all the humans on the ship
+ */
+/obj/docking_port/mobile/proc/get_all_humans()
+	var/list/humans_to_add = list()
+	var/list/all_turfs = return_ordered_turfs(x, y, z, dir)
+	for (var/turf/turf as anything in all_turfs)
+		var/mob/living/carbon/human/human_to_add = locate() in turf.contents
+		if (!isnull(human_to_add))
+			humans_to_add.Add(human_to_add)
+	return humans_to_add
+
+/**
  * Scuttle the ship
  *
  * Delete all of the areas, and delete any cryopods

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -473,7 +473,7 @@
  * Delete all of the areas, and delete any cryopods
  */
 /obj/docking_port/mobile/proc/mothball()
-	if (current_ship?.is_active_crew() == SHUTTLE_ACTIVE_CREW)
+	if(length(get_all_humans()) > 0)
 		return
 	var/obj/docking_port/stationary/current_dock = get_docked()
 


### PR DESCRIPTION
Going SSD will no longer trigger the system 
More QOL:
Added to the shuttle manipulator:
- Check the crew status, will tell you if there are any people alive, or if they're all dead/ssd
- Register All humans into the crewmember, will find every human on the ship and add them to the crew
- Unregister all crewmembers will delete every crewmember from the crewlist

Stops duplicate refs being added when registering all members.
Also fixes half of the issue for empty ships being queued for deletion repeadtedly.