### PR TITLE
Fix shuttle breaking by Fix ore_vein Destroy

### DIFF
--- a/whitesands/code/modules/mining/deepcore/ore_vein.dm
+++ b/whitesands/code/modules/mining/deepcore/ore_vein.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_EMPTY(ore_vein_landmarks)
 
 /obj/effect/landmark/ore_vein/Destroy()
 	. = ..()
-	QDEL_NULL(resource)
+	resource = null
 	if (miner)
 		miner.active_vein = null
 		miner = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ore veins fail to Destroy. That halt shuttle landing on half.

<details>
  <summary>Runtime</summary>
[23:30:01] Runtime in garbage.dm,264: bad del
  proc name: qdel (/proc/qdel)
  src: null
  call stack:
  qdel(null, 0)
  the ore vein (/obj/effect/landmark/ore_vein): Destroy(0)
  qdel(the ore vein (/obj/effect/landmark/ore_vein), 0)
  the volcanic floor (52,27,3) (/turf/open/floor/plating/asteroid/basalt/lava_land_surface): toShuttleMove(the nanoweave carpet (red) (31,150,2) (/turf/open/floor/carpet/nanoweave/red), 7, SYN-C Avid Horizon (/obj/docking_port/mobile))
  SYN-C Avid Horizon (/obj/docking_port/mobile): preflight check(/list (/list), /list (/list), /list (/list), 90)
  SYN-C Avid Horizon (/obj/docking_port/mobile): initiate docking(the Uncharted Space (/obj/docking_port/stationary), 1, 0)
  SYN-C Avid Horizon (/obj/docking_port/mobile): check()
  Shuttle (/datum/controller/subsystem/shuttle): fire(0)
  Shuttle (/datum/controller/subsystem/shuttle): ignite(0)
</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less shuttle breaking on landing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Some shuttle breaking
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
