### PR TITLE
Tweaks Hyena, adds Vendors and Marines to it (FIXED)

### DIFF
--- a/_maps/configs/SYN-C_hyena.json
+++ b/_maps/configs/SYN-C_hyena.json
@@ -27,7 +27,10 @@
 		"Junior Agent": {
 			"outfit": "/datum/outfit/job/assistant/syndicate/gorlex",
 			"slots": 2
-		}
+		},
+		"Syndicate Marine":{
+			"outfit": "/datum/outfit/syndicate_empty/sbc/assault",
+			"slots": 2
 	},
 	"cost": 950
 }

--- a/_maps/configs/SYN-C_hyena.json
+++ b/_maps/configs/SYN-C_hyena.json
@@ -31,6 +31,7 @@
 		"Syndicate Marine":{
 			"outfit": "/datum/outfit/syndicate_empty/sbc/assault",
 			"slots": 2
+		}
 	},
 	"cost": 950
 }

--- a/_maps/shuttles/shiptest/hyena.dmm
+++ b/_maps/shuttles/shiptest/hyena.dmm
@@ -20,8 +20,6 @@
 "bd" = (
 /obj/effect/turf_decal/industrial/outline,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/closet/crate,
-/obj/item/circuitboard/machine/mining_equipment_vendor,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/cargo)
 "bl" = (
@@ -130,6 +128,25 @@
 	dir = 10
 	},
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/pistol,
+/obj/item/gun/ballistic/automatic/pistol{
+	pixel_y = 2
+	},
+/obj/item/gun/ballistic/automatic/pistol{
+	pixel_y = -2
+	},
+/obj/item/ammo_box/c10mm,
+/obj/item/ammo_box/c10mm,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "dh" = (
@@ -241,10 +258,10 @@
 /obj/effect/turf_decal/industrial/outline,
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
+/obj/item/flashlight/lantern/syndicate,
+/obj/item/flashlight/lantern/syndicate,
 /obj/item/mining_scanner,
 /obj/item/mining_scanner,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "fi" = (
@@ -259,13 +276,6 @@
 /area/ship/maintenance/port)
 "fv" = (
 /obj/effect/turf_decal/industrial/outline,
-/obj/structure/closet/secure_closet{
-	anchored = 1;
-	icon_state = "syndicate";
-	name = "ammunition locker"
-	},
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -278,7 +288,7 @@
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
 	},
-/obj/item/disk/design_disk/ammo_c10mm,
+/obj/machinery/vending/security/marine,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "fA" = (
@@ -366,16 +376,15 @@
 /obj/item/storage/backpack/security,
 /obj/item/clothing/under/syndicate/combat,
 /obj/item/clothing/suit/armor/vest/capcarapace/syndicate,
-/obj/item/clothing/head/HoS/syndicate,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/gloves/combat,
 /obj/item/clothing/glasses/thermal/eyepatch,
+/obj/item/clothing/head/HoS/syndicate,
+/obj/item/gun/ballistic/revolver,
+/obj/item/ammo_box/a357/match,
 /obj/item/codespeak_manual/unlimited,
 /obj/item/pen/edagger,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/ammo_box/a357/match,
-/obj/item/ammo_box/a357/match,
-/obj/item/gun/ballistic/revolver,
 /turf/open/floor/carpet/black,
 /area/ship/bridge)
 "hy" = (
@@ -806,6 +815,10 @@
 	pixel_y = 5
 	},
 /obj/item/storage/toolbox/syndicate,
+/obj/item/storage/toolbox/syndicate{
+	pixel_x = -5;
+	pixel_y = -5
+	},
 /obj/item/stack/cable_coil/random,
 /obj/item/stack/cable_coil/random,
 /obj/item/stack/cable_coil/random,
@@ -819,7 +832,6 @@
 /obj/structure/sign/poster/contraband/hacking_guide{
 	pixel_y = -32
 	},
-/obj/item/stack/cable_coil/random,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "oV" = (
@@ -994,8 +1006,6 @@
 /obj/item/clothing/head/soft/yellow,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
-/obj/item/clothing/gloves/combat,
-/obj/item/clothing/gloves/combat,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "rM" = (
@@ -1134,14 +1144,6 @@
 	},
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
-	},
-/obj/item/gps,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/storage/box/emptysandbags,
-/obj/item/syndie_crusher{
-	pixel_x = 5;
-	pixel_y = -2
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
@@ -1545,14 +1547,6 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = 28
-	},
-/obj/item/gps,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/storage/box/emptysandbags,
-/obj/item/syndie_crusher{
-	pixel_x = 5;
-	pixel_y = -2
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
@@ -2440,28 +2434,7 @@
 /area/ship/maintenance/port)
 "OX" = (
 /obj/effect/turf_decal/industrial/outline,
-/obj/structure/closet/secure_closet{
-	anchored = 1;
-	icon_state = "syndicate";
-	name = "firearms locker"
-	},
-/obj/item/gun/ballistic/automatic/pistol{
-	pixel_y = 2
-	},
-/obj/item/gun/ballistic/automatic/pistol{
-	pixel_y = -2
-	},
-/obj/item/ammo_box/magazine/m10mm,
-/obj/item/ammo_box/magazine/m10mm,
-/obj/structure/sign/poster/contraband/syndicate_pistol{
-	pixel_x = 32
-	},
-/obj/machinery/button/door{
-	dir = 1;
-	id = "wreckerarmory";
-	name = "armory shutters";
-	pixel_y = -24
-	},
+/obj/machinery/vending/security/marine,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "Pn" = (
@@ -2859,8 +2832,14 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
-/obj/item/pickaxe/drill,
-/obj/item/pickaxe/drill,
+/obj/item/syndie_crusher{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/syndie_crusher{
+	pixel_x = 5;
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "VR" = (
@@ -2892,6 +2871,8 @@
 	},
 /obj/item/storage/toolbox/syndicate,
 /obj/item/wrench/combat,
+/obj/item/ammo_box/magazine/m10mm/ap,
+/obj/item/gun/ballistic/automatic/pistol,
 /obj/item/clothing/accessory/holster,
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/item/card/mining_access_card,
@@ -2899,9 +2880,6 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/item/ammo_box/magazine/m10mm/ap,
-/obj/item/ammo_box/magazine/m10mm/ap,
-/obj/item/gun/ballistic/automatic/pistol,
 /turf/open/floor/carpet/red,
 /area/ship/cargo/office)
 "Wc" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
slightly buffs the hyena, adds two vendors and two marine slots, nothing too crazy
![updatedhyena](https://user-images.githubusercontent.com/83150164/153735929-cf0ffab9-2770-4316-ad98-0c58f41cc75d.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hyena is underpowered, and seeing as NT is getting their well deserved buffs, figure its time to make the hyena stand out like it used to
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Two Marine Vendors
add: Two Marine Slots
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
