### PR TITLE
Fixes the mining vendor not dispensing the minin scanners

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -32,6 +32,8 @@
 		new /datum/data/mining_equipment("Jaunter",						/obj/item/wormhole_jaunter,											750),
 		new /datum/data/mining_equipment("Kinetic Crusher",				/obj/item/kinetic_crusher,											750),
 		new /datum/data/mining_equipment("Kinetic Accelerator",			/obj/item/gun/energy/kinetic_accelerator,							750),
+		new /datum/data/mining_equipment("Mining Scanner",				/obj/item/t_scanner/adv_mining_scanner/lesser,						200),
+		new /datum/data/mining_equipment("Advanced Mining Scanner",		/obj/item/t_scanner/adv_mining_scanner,								800),
 		new /datum/data/mining_equipment("Resonator",					/obj/item/resonator,												800),
 		new /datum/data/mining_equipment("Fulton Pack",					/obj/item/extraction_pack,											1000),
 		new /datum/data/mining_equipment("Lazarus Injector",			/obj/item/lazarus_injector,											1000),


### PR DESCRIPTION
## About The Pull Request 
Adds mining scanners back to the mining vendors
Fixes #206 
## Why It's Good For The Game
People can get mining scanners again
## Changelog
🆑 
fix: Fixes mining vendors not dispensing mining scanners
/🆑

