### PR TITLE
No more dead bodies prevent planet deleting.

### DIFF
--- a/code/datums/map_zones.dm
+++ b/code/datums/map_zones.dm
@@ -527,7 +527,7 @@
 /datum/virtual_level/proc/get_mind_mobs()
 	. = list()
 	for(var/mob/living/living_mob as anything in GLOB.mob_living_list)
-		if(!living_mob.mind)
+		if(!living_mob.mind || living_mob.stat == DEAD)
 			continue
 		if(is_in_bounds(living_mob))
 			. += living_mob


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Dead mindless bodies must not prevent planet from uloading.
SSD steel count, until dead.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less unloaded plaets with dead player body somewhere
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Dead bodies no more block planet unloading
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
