### PR TITLE
Fixes Auto-Pilot access

### DIFF
--- a/voidcrew/code/game/machinery/computer/shuttle/auto_pilot.dm
+++ b/voidcrew/code/game/machinery/computer/shuttle/auto_pilot.dm
@@ -21,13 +21,16 @@
 		return TRUE
 
 /obj/machinery/computer/autopilot/ui_interact(mob/user, datum/tgui/ui)
-	if(!ship && !reload_ship())
+	if(ship.is_player_in_crew(user) || !isliving(user) || isAdminGhostAI(user))
+		if(!ship && !reload_ship())
+			return
+		ui = SStgui.try_update_ui(user, src, ui)
+		if(!ui)
+			ui = new(user, src, "ShuttleConsole", name)
+			ui.open()
+	else
+		say("ERROR: Unrecognized bio-signature detected")
 		return
-	ui = SStgui.try_update_ui(user, src, ui)
-	if(!ui)
-		ui = new(user, src, "ShuttleConsole", name)
-		ui.open()
-
 /obj/machinery/computer/autopilot/ui_data(mob/user)
 	var/list/data = list()
 	var/obj/docking_port/mobile/M = ship.shuttle


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Locks the autopilot console so that only crewmembers can use it
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stops people from semi hijacking a ship
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Bio-Lock to autopilot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
