### PR TITLE
[TM] makes the shuttle designator non printable

### DIFF
--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -102,6 +102,7 @@
 	category = list("Tool Designs")
 	departmental_flags =  DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
 
+/*
 /datum/design/rapid_shuttle_designator
 	name = "Rapid Shuttle Designator"
 	desc = "A tool that can be used to designate a shuttle for a shuttle launch."
@@ -111,6 +112,7 @@
 	build_path = /obj/item/shuttle_creator
 	category = list("Tool Designs")
 	departmental_flags =  DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
+*/
 
 /////////////////////////////////////////
 //////////////Alien Tools////////////////

--- a/whitesands/code/modules/research/techweb/all_nodes.dm
+++ b/whitesands/code/modules/research/techweb/all_nodes.dm
@@ -13,7 +13,7 @@
 	display_name = "Basic Shuttle Research"
 	description = "Research the technology required to create and use basic shuttles."
 	prereq_ids = list("bluespace_travel", "adv_engi")
-	design_ids = list("engine_plasma", "engine_ion", "engine_heater", "engine_smes", "shuttle_helm", "rapid_shuttle_designator")
+	design_ids = list("engine_plasma", "engine_ion", "engine_heater", "engine_smes", "shuttle_helm") //, "rapid_shuttle_designator")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 


### PR DESCRIPTION
This is one of the reasons behind the join button breaking, it creates a custom shuttle without all the proper vars, thus `LateChoices` runtimes and breaks the button.