### PR TITLE
Fixes an edge case where no overmap objects will generate

### DIFF
--- a/voidcrew/code/controllers/subsystem/overmap.dm
+++ b/voidcrew/code/controllers/subsystem/overmap.dm
@@ -106,6 +106,8 @@ SUBSYSTEM_DEF(overmap)
 	var/path
 	startype = pick(SMALLSTAR, MEDSTAR, TWOSTAR, BIGSTAR)
 	switch (startype)
+		if (SMALLSTAR)
+			path = new /obj/structure/overmap/star
 		if (TWOSTAR)
 			path = new /obj/structure/overmap/star/big/binary
 		if (MEDSTAR)


### PR DESCRIPTION
I think I had something that would originally default to this, but I
ended up removing it