### PR TITLE
Changes planet spawning rate

### DIFF
--- a/voidcrew/code/controllers/subsystem/overmap.dm
+++ b/voidcrew/code/controllers/subsystem/overmap.dm
@@ -400,5 +400,5 @@ SUBSYSTEM_DEF(overmap)
 /datum/controller/subsystem/overmap/proc/generate_probabilites()
 	for (var/path in subtypesof(/datum/overmap/planet))
 		var/datum/overmap/planet/temp_planet = new path
-		spawn_probability |= list(temp_planet.type = min(length(get_ruin_list(temp_planet.ruin_type)), temp_planet.spawn_rate))
+		spawn_probability |= list(temp_planet.type = temp_planet.spawn_rate)
 		qdel(temp_planet)


### PR DESCRIPTION
Right now it goes based off of `min(ruins, planet_spawn_rate)` aka if
there aren't enough ruins the spawn rate gets cucked. This is dumb! New
planets should be able to have people explore them, and i don't really
care if the same ruin gets explored more than one (also the only planet
this actually effects is the ice ruin, and the beach (Soon:tm:))