### PR TITLE
Makes the Boyardee-B class more viable

### DIFF
--- a/_maps/shuttles/shiptest/boyardee.dmm
+++ b/_maps/shuttles/shiptest/boyardee.dmm
@@ -1,9 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ab" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/crew/canteen)
 "as" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer4,
 /obj/structure/disposalpipe/junction{
@@ -17,13 +12,6 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew)
-"bj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/conveyor_switch/oneway,
-/turf/open/floor/engine/airless,
-/area/ship/external)
 "bk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/airalarm/all_access{
@@ -147,6 +135,13 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew)
+"cN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/conveyor_switch/oneway,
+/turf/open/floor/engine/airless,
+/area/ship/external)
 "cT" = (
 /obj/machinery/processor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -171,6 +166,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
+"da" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ship/construction)
 "dh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -265,6 +269,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
+"dZ" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/ship/construction)
 "eg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -318,14 +339,6 @@
 "fs" = (
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
-"fz" = (
-/obj/machinery/chem_master,
-/obj/effect/turf_decal/box,
-/obj/machinery/airalarm/all_access{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/construction)
 "fG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -358,9 +371,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
-"fU" = (
-/turf/closed/wall/r_wall,
-/area/ship/crew/janitor)
 "gi" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plasteel/dark,
@@ -371,29 +381,6 @@
 /obj/item/storage/pill_bottle/dice,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"gG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/ship/cargo)
-"gK" = (
-/obj/machinery/vending/wardrobe/jani_wardrobe{
-	density = 0;
-	pixel_y = 29
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono,
-/area/ship/crew/janitor)
 "gN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -407,27 +394,9 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"gP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor{
-	id = "windowlockdown"
-	},
-/turf/open/floor/plating,
-/area/ship/crew/janitor)
 "gX" = (
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"hg" = (
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/engine/airless,
-/area/ship/external)
 "hk" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/dark,
@@ -521,6 +490,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
+"jO" = (
+/obj/structure/closet/secure_closet/chemical{
+	req_access = list()
+	},
+/obj/item/clothing/suit/toggle/labcoat/chemist,
+/obj/item/clothing/under/rank/medical/chemist/junior_chemist,
+/obj/item/clothing/under/rank/medical/chemist/junior_chemist/skirt,
+/obj/item/storage/bag/chemistry,
+/obj/item/clothing/head/beret/chem,
+/obj/effect/turf_decal/box,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
+/obj/item/storage/box/syringes/variety,
+/turf/open/floor/plasteel/dark,
+/area/ship/construction)
 "kr" = (
 /obj/structure/sign/warning/chemdiamond,
 /turf/closed/wall,
@@ -531,13 +517,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
-"kN" = (
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/mono,
-/area/ship/crew/janitor)
 "kS" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/corner/neutral{
@@ -565,6 +544,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"ls" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/ship/crew/hydroponics)
 "ly" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
@@ -614,6 +597,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"lI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor{
+	id = "windowlockdown"
+	},
+/turf/open/floor/plating,
+/area/ship/construction)
 "lJ" = (
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew/canteen)
@@ -666,34 +656,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
+"mn" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew/janitor)
 "mr" = (
 /turf/closed/wall,
 /area/ship/crew/hydroponics)
-"mA" = (
-/obj/machinery/button/door{
-	id = "boyardeejanitor";
-	name = "Janitoral Access";
-	pixel_x = -26;
-	pixel_y = -4
-	},
-/obj/vehicle/ridden/janicart,
-/obj/item/key/janitor,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = -27;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/box,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/mono,
-/area/ship/crew/janitor)
 "mH" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable/yellow{
@@ -818,15 +786,13 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ship/storage)
-"oN" = (
-/obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
-/area/ship/construction)
 "oO" = (
 /obj/structure/chair/wood,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"oX" = (
+/turf/closed/wall/r_wall,
+/area/ship/construction)
 "ph" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -865,28 +831,6 @@
 /obj/machinery/status_display/shuttle,
 /turf/closed/wall/r_wall,
 /area/ship/bridge)
-"py" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ship/construction)
-"pI" = (
-/obj/machinery/door/window/westleft,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/ship/construction)
 "pN" = (
 /obj/machinery/atmospherics/components/binary/valve/digital,
 /obj/structure/cable{
@@ -906,6 +850,15 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
+"qc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 1
+	},
+/turf/open/floor/engine/airless,
+/area/ship/external)
 "qg" = (
 /obj/machinery/atmospherics/components/unary/tank/toxins{
 	dir = 1
@@ -927,7 +880,7 @@
 	},
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew)
-"qL" = (
+"qx" = (
 /obj/machinery/chem_heater,
 /obj/effect/turf_decal/box,
 /obj/structure/table/reinforced,
@@ -993,19 +946,21 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
-"rY" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 8
-	},
+"sa" = (
 /turf/open/floor/engine/airless,
 /area/ship/external)
 "sg" = (
 /turf/closed/wall,
 /area/ship/storage)
+"si" = (
+/obj/effect/turf_decal/box,
+/obj/structure/bed/dogbed/runtime,
+/mob/living/simple_animal/pet/cat/Runtime,
+/obj/item/storage/box/lights/mixed,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "sp" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/corner/neutral{
@@ -1099,6 +1054,11 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"uI" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen)
 "uR" = (
 /turf/closed/wall,
 /area/ship/crew)
@@ -1137,9 +1097,15 @@
 /obj/item/reagent_containers/food/condiment/peppermill,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
-"vt" = (
-/turf/closed/wall,
-/area/ship/crew/janitor)
+"vD" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/shower{
+	pixel_y = 13
+	},
+/obj/structure/curtain,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/ship/construction)
 "vI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -1174,17 +1140,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
-"wf" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/door/window/westleft,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 8
-	},
-/turf/open/floor/engine/airless,
-/area/ship/external)
 "wh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1301,13 +1256,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/ship/cargo)
-"ys" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor{
-	id = "windowlockdown"
-	},
-/turf/open/floor/plating,
-/area/ship/construction)
 "yF" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/clothing/under/rank/civilian/hydroponics,
@@ -1360,6 +1308,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
+"zD" = (
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "zM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1401,6 +1356,19 @@
 "Ag" = (
 /turf/closed/wall/r_wall,
 /area/ship/cargo)
+"Ap" = (
+/obj/item/storage/belt/janitor/full,
+/obj/structure/janitorialcart,
+/obj/item/watertank/janitor,
+/obj/item/mop,
+/obj/item/storage/bag/trash,
+/obj/effect/turf_decal/box,
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "Ar" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light,
@@ -1508,6 +1476,14 @@
 /obj/item/reagent_containers/glass/rag,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
+"BV" = (
+/obj/machinery/chem_master,
+/obj/effect/turf_decal/box,
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/construction)
 "Ce" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1793,23 +1769,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
-"Fw" = (
-/obj/structure/closet/secure_closet/chemical{
-	req_access = list()
-	},
-/obj/item/clothing/suit/toggle/labcoat/chemist,
-/obj/item/clothing/under/rank/medical/chemist/junior_chemist,
-/obj/item/clothing/under/rank/medical/chemist/junior_chemist/skirt,
-/obj/item/storage/bag/chemistry,
-/obj/item/clothing/head/beret/chem,
-/obj/effect/turf_decal/box,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
-/obj/item/storage/box/syringes/variety,
-/turf/open/floor/plasteel/dark,
-/area/ship/construction)
 "FA" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor/border_only{
@@ -1843,6 +1802,9 @@
 "FN" = (
 /turf/closed/wall,
 /area/ship/bridge)
+"FO" = (
+/turf/closed/wall,
+/area/ship/crew/janitor)
 "FR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1883,6 +1845,12 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
+"GJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ship/external)
 "GO" = (
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
@@ -2002,15 +1970,6 @@
 /obj/item/toy/cards/deck/cas/black,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"IS" = (
-/obj/effect/turf_decal/box,
-/obj/structure/bed/dogbed/runtime,
-/mob/living/simple_animal/pet/cat/Runtime,
-/obj/item/storage/box/lights/mixed,
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
-/turf/open/floor/plasteel/mono,
-/area/ship/crew/janitor)
 "IW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -2053,15 +2012,6 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
-"Jm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 1
-	},
-/turf/open/floor/engine/airless,
-/area/ship/external)
 "Jw" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/corner/neutral{
@@ -2110,12 +2060,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
-"JM" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/crew/canteen)
 "JR" = (
 /turf/closed/wall/r_wall,
 /area/ship/crew)
@@ -2181,12 +2125,6 @@
 "Lj" = (
 /turf/open/floor/plasteel/mono/white,
 /area/ship/bridge)
-"LV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/ship/external)
 "LX" = (
 /obj/effect/turf_decal/corner/neutral{
 	dir = 1
@@ -2242,6 +2180,12 @@
 	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/bridge)
+"Mz" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen)
 "MI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -2254,6 +2198,31 @@
 	},
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew/canteen)
+"MY" = (
+/obj/machinery/button/door{
+	id = "boyardeejanitor";
+	name = "Janitorial Access";
+	pixel_x = -26;
+	pixel_y = -4
+	},
+/obj/vehicle/ridden/janicart,
+/obj/item/key/janitor,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -27;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "Nc" = (
 /obj/effect/turf_decal/box,
 /obj/item/radio/intercom{
@@ -2262,10 +2231,6 @@
 /obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/dark,
 /area/ship/storage)
-"Ne" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel,
-/area/ship/crew/hydroponics)
 "Ng" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /obj/effect/turf_decal/corner/neutral{
@@ -2290,9 +2255,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
-"Nl" = (
-/turf/open/floor/engine/airless,
-/area/ship/external)
 "Nv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -2390,21 +2352,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
-"PW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/carpet/nanoweave,
-/area/ship/crew/canteen)
 "PX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/cable{
@@ -2422,6 +2369,16 @@
 /obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plasteel/mono,
 /area/ship/bridge)
+"Qh" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/ship/external)
 "Qn" = (
 /obj/machinery/airalarm/all_access{
 	dir = 1;
@@ -2583,19 +2540,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ship/maintenance)
-"Tk" = (
-/obj/item/storage/belt/janitor/full,
-/obj/structure/janitorialcart,
-/obj/item/watertank/janitor,
-/obj/item/mop,
-/obj/item/storage/bag/trash,
-/obj/effect/turf_decal/box,
-/obj/machinery/airalarm/all_access{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/mono,
-/area/ship/crew/janitor)
 "Tl" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2688,6 +2632,21 @@
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plating,
 /area/ship/maintenance)
+"Uf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/carpet/nanoweave,
+/area/ship/crew/canteen)
 "Uq" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
@@ -2744,6 +2703,19 @@
 /obj/machinery/door/airlock/freezer,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
+"UF" = (
+/obj/machinery/door/window/westleft,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/ship/construction)
 "Vm" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/nutrient/ez{
@@ -2765,9 +2737,6 @@
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden,
 /turf/open/floor/plating,
 /area/ship/maintenance)
-"VI" = (
-/turf/closed/wall/r_wall,
-/area/ship/construction)
 "VO" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	piping_layer = 2
@@ -2820,22 +2789,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
-"Xr" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/machinery/shower{
-	pixel_y = 13
-	},
-/obj/structure/curtain,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel,
-/area/ship/construction)
 "Xv" = (
 /obj/item/radio/intercom{
 	pixel_x = 27
 	},
 /obj/machinery/button/door{
 	id = "boyardeejanitor";
-	name = "Janitoral Access";
+	name = "Janitorial  Access";
 	pixel_x = 5;
 	pixel_y = -24
 	},
@@ -2843,26 +2803,50 @@
 /obj/machinery/mineral/ore_redemption,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
+"XJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ship/cargo)
 "XP" = (
 /turf/closed/wall,
 /area/ship/cargo)
-"Ya" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+"XS" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/disposaloutlet{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -24
+/turf/open/floor/engine/airless,
+/area/ship/external)
+"XV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor{
+	id = "windowlockdown"
 	},
-/turf/open/floor/plasteel,
-/area/ship/construction)
+/turf/open/floor/plating,
+/area/ship/crew/janitor)
+"Yd" = (
+/obj/machinery/vending/wardrobe/jani_wardrobe{
+	density = 0;
+	pixel_y = 29
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "Yn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -2896,6 +2880,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew/canteen)
+"YZ" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/dark,
+/area/ship/construction)
 "Zz" = (
 /obj/machinery/cryopod{
 	dir = 1
@@ -2935,6 +2924,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"ZX" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/door/window/westleft,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/ship/external)
 
 (1,1,1) = {"
 vZ
@@ -3192,14 +3192,14 @@ vZ
 vZ
 xr
 lJ
-PW
+Uf
 Bg
 gX
 oO
 IO
 up
 Ld
-JM
+Mz
 uR
 Mm
 tR
@@ -3255,7 +3255,7 @@ vZ
 vZ
 xr
 lJ
-PW
+Uf
 Bg
 sp
 Ow
@@ -3276,10 +3276,10 @@ vZ
 vZ
 cC
 dl
-PW
+Uf
 hk
 sp
-ab
+uI
 NM
 NM
 Hs
@@ -3336,7 +3336,7 @@ TD
 vZ
 "}
 (20,1,1) = {"
-Nl
+sa
 Ag
 AW
 wh
@@ -3360,7 +3360,7 @@ vZ
 as
 cp
 nc
-gG
+XJ
 tP
 FN
 np
@@ -3378,7 +3378,7 @@ DZ
 vZ
 "}
 (22,1,1) = {"
-LV
+GJ
 yk
 Ba
 DB
@@ -3399,7 +3399,7 @@ DZ
 vZ
 "}
 (23,1,1) = {"
-bj
+cN
 yk
 dW
 fM
@@ -3420,7 +3420,7 @@ TD
 vZ
 "}
 (24,1,1) = {"
-Jm
+qc
 Ag
 Uv
 jN
@@ -3434,14 +3434,14 @@ cA
 Lj
 Cx
 lg
-Ne
+ls
 GG
 EH
 DZ
 vZ
 "}
 (25,1,1) = {"
-wf
+ZX
 Ag
 nA
 qq
@@ -3462,11 +3462,11 @@ DZ
 vZ
 "}
 (26,1,1) = {"
-rY
-fU
+Qh
+mn
 rj
-vt
-vt
+FO
+FO
 px
 Dd
 Lj
@@ -3476,19 +3476,19 @@ Sf
 Lj
 dM
 TD
-Xr
-pI
+vD
+UF
 Eo
-VI
+oX
 vZ
 "}
 (27,1,1) = {"
-hg
-gP
+XS
+XV
 sD
-mA
-IS
-fU
+MY
+si
+mn
 of
 lG
 ph
@@ -3496,20 +3496,20 @@ ph
 ph
 Ng
 of
-VI
-oN
-py
-Fw
-ys
+oX
+YZ
+da
+jO
+lI
 vZ
 "}
 (28,1,1) = {"
 vZ
-fU
-gK
-kN
-Tk
-fU
+mn
+Yd
+zD
+Ap
+mn
 Cu
 Cu
 ep
@@ -3517,20 +3517,20 @@ AA
 OJ
 Cu
 Cu
-VI
-fz
-Ya
-qL
-ys
+oX
+BV
+dZ
+qx
+lI
 vZ
 "}
 (29,1,1) = {"
 vZ
-fU
-gP
-gP
-fU
-fU
+mn
+XV
+XV
+mn
+mn
 vZ
 Cu
 Cu
@@ -3538,10 +3538,10 @@ Cu
 Cu
 Cu
 vZ
-VI
-VI
-VI
-VI
-VI
+oX
+oX
+oX
+oX
+oX
 vZ
 "}

--- a/_maps/shuttles/shiptest/boyardee.dmm
+++ b/_maps/shuttles/shiptest/boyardee.dmm
@@ -1,10 +1,15 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ab" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen)
 "as" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer4,
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/airless,
 /area/ship/external)
 "ay" = (
 /obj/structure/chair/office{
@@ -12,6 +17,13 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew)
+"bj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/conveyor_switch/oneway,
+/turf/open/floor/engine/airless,
+/area/ship/external)
 "bk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/airalarm/all_access{
@@ -24,23 +36,6 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
-"bp" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/ship/construction)
 "bv" = (
 /obj/machinery/smartfridge/drinks,
 /turf/closed/wall,
@@ -81,16 +76,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
-"ch" = (
-/obj/machinery/vending/wardrobe/jani_wardrobe{
-	density = 0;
-	pixel_y = 29
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono,
-/area/ship/crew/janitor)
 "cl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -308,25 +293,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"ez" = (
-/obj/machinery/door/window/westleft,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/ship/construction)
-"eM" = (
-/obj/machinery/conveyor_switch/oneway{
-	pixel_y = -12
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external)
 "eS" = (
 /obj/machinery/door/poddoor{
 	id = "windowlockdown"
@@ -349,14 +315,17 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/hydroponics)
-"fm" = (
-/obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
-/area/ship/construction)
 "fs" = (
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
+"fz" = (
+/obj/machinery/chem_master,
+/obj/effect/turf_decal/box,
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/construction)
 "fG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -389,6 +358,9 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
+"fU" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew/janitor)
 "gi" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plasteel/dark,
@@ -399,6 +371,29 @@
 /obj/item/storage/pill_bottle/dice,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"gG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"gK" = (
+/obj/machinery/vending/wardrobe/jani_wardrobe{
+	density = 0;
+	pixel_y = 29
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "gN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -412,22 +407,27 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"gP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor{
+	id = "windowlockdown"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/janitor)
 "gX" = (
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"hh" = (
-/obj/item/storage/belt/janitor/full,
-/obj/structure/janitorialcart,
-/obj/item/watertank/janitor,
-/obj/item/mop,
-/obj/item/storage/bag/trash,
-/obj/effect/turf_decal/box,
-/obj/machinery/airalarm/all_access{
-	dir = 1;
-	pixel_y = -24
+"hg" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/disposaloutlet{
+	dir = 8
 	},
-/turf/open/floor/plasteel/mono,
-/area/ship/crew/janitor)
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/ship/external)
 "hk" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/dark,
@@ -531,6 +531,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
+"kN" = (
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "kS" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/corner/neutral{
@@ -659,24 +666,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
-"mm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/carpet/nanoweave,
-/area/ship/crew/canteen)
 "mr" = (
 /turf/closed/wall,
 /area/ship/crew/hydroponics)
+"mA" = (
+/obj/machinery/button/door{
+	id = "boyardeejanitor";
+	name = "Janitoral Access";
+	pixel_x = -26;
+	pixel_y = -4
+	},
+/obj/vehicle/ridden/janicart,
+/obj/item/key/janitor,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -27;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "mH" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable/yellow{
@@ -801,8 +818,10 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ship/storage)
-"os" = (
-/turf/closed/wall/r_wall,
+"oN" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/dark,
 /area/ship/construction)
 "oO" = (
 /obj/structure/chair/wood,
@@ -846,6 +865,28 @@
 /obj/machinery/status_display/shuttle,
 /turf/closed/wall/r_wall,
 /area/ship/bridge)
+"py" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ship/construction)
+"pI" = (
+/obj/machinery/door/window/westleft,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/ship/construction)
 "pN" = (
 /obj/machinery/atmospherics/components/binary/valve/digital,
 /obj/structure/cable{
@@ -886,13 +927,12 @@
 	},
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew)
-"qS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor{
-	id = "windowlockdown"
-	},
-/turf/open/floor/plating,
-/area/ship/crew/janitor)
+"qL" = (
+/obj/machinery/chem_heater,
+/obj/effect/turf_decal/box,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/ship/construction)
 "qU" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
@@ -927,9 +967,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
-"rt" = (
-/turf/closed/wall/r_wall,
-/area/ship/crew/janitor)
 "rB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -956,6 +993,16 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
+"rY" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/ship/external)
 "sg" = (
 /turf/closed/wall,
 /area/ship/storage)
@@ -988,16 +1035,6 @@
 "sU" = (
 /turf/closed/wall,
 /area/ship/crew/canteen)
-"sY" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external)
 "tq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -1100,6 +1137,9 @@
 /obj/item/reagent_containers/food/condiment/peppermill,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
+"vt" = (
+/turf/closed/wall,
+/area/ship/crew/janitor)
 "vI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -1134,6 +1174,17 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
+"wf" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/door/window/westleft,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/ship/external)
 "wh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1250,14 +1301,12 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/ship/cargo)
-"yt" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"ys" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor{
+	id = "windowlockdown"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/ship/construction)
 "yF" = (
 /obj/structure/closet/crate/hydroponics,
@@ -1291,12 +1340,6 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
-"zg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external)
 "zl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -1700,15 +1743,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
-"EA" = (
-/obj/effect/turf_decal/box,
-/obj/structure/bed/dogbed/runtime,
-/mob/living/simple_animal/pet/cat/Runtime,
-/obj/item/storage/box/lights/mixed,
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
-/turf/open/floor/plasteel/mono,
-/area/ship/crew/janitor)
 "EF" = (
 /obj/effect/turf_decal/corner/neutral{
 	dir = 1
@@ -1759,6 +1793,23 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
+"Fw" = (
+/obj/structure/closet/secure_closet/chemical{
+	req_access = list()
+	},
+/obj/item/clothing/suit/toggle/labcoat/chemist,
+/obj/item/clothing/under/rank/medical/chemist/junior_chemist,
+/obj/item/clothing/under/rank/medical/chemist/junior_chemist/skirt,
+/obj/item/storage/bag/chemistry,
+/obj/item/clothing/head/beret/chem,
+/obj/effect/turf_decal/box,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
+/obj/item/storage/box/syringes/variety,
+/turf/open/floor/plasteel/dark,
+/area/ship/construction)
 "FA" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor/border_only{
@@ -1822,17 +1873,6 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/canteen)
-"GD" = (
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external)
 "GG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1843,13 +1883,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
-"GM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor{
-	id = "windowlockdown"
-	},
-/turf/open/floor/plating,
-/area/ship/construction)
 "GO" = (
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
@@ -1908,12 +1941,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
-"HQ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/crew/canteen)
 "HY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1925,19 +1952,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
-"Ia" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/ship/cargo)
 "In" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
@@ -1988,6 +2002,15 @@
 /obj/item/toy/cards/deck/cas/black,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"IS" = (
+/obj/effect/turf_decal/box,
+/obj/structure/bed/dogbed/runtime,
+/mob/living/simple_animal/pet/cat/Runtime,
+/obj/item/storage/box/lights/mixed,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "IW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -2022,11 +2045,6 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/hydroponics)
-"Ji" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/crew/canteen)
 "Jj" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/drinkingglasses,
@@ -2035,6 +2053,15 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
+"Jm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 1
+	},
+/turf/open/floor/engine/airless,
+/area/ship/external)
 "Jw" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/corner/neutral{
@@ -2083,6 +2110,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
+"JM" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen)
 "JR" = (
 /turf/closed/wall/r_wall,
 /area/ship/crew)
@@ -2106,23 +2139,6 @@
 	},
 /turf/open/floor/plasteel/mono,
 /area/ship/bridge)
-"Kn" = (
-/obj/structure/closet/secure_closet/chemical{
-	req_access = list()
-	},
-/obj/item/clothing/suit/toggle/labcoat/chemist,
-/obj/item/clothing/under/rank/medical/chemist/junior_chemist,
-/obj/item/clothing/under/rank/medical/chemist/junior_chemist/skirt,
-/obj/item/storage/bag/chemistry,
-/obj/item/clothing/head/beret/chem,
-/obj/effect/turf_decal/box,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
-/obj/item/storage/box/syringes/variety,
-/turf/open/floor/plasteel/dark,
-/area/ship/construction)
 "KJ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -2155,9 +2171,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plating,
 /area/ship/maintenance)
-"KP" = (
-/turf/closed/wall,
-/area/ship/crew/janitor)
 "Ld" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -2165,13 +2178,15 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"Lf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel,
-/area/ship/crew/hydroponics)
 "Lj" = (
 /turf/open/floor/plasteel/mono/white,
 /area/ship/bridge)
+"LV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ship/external)
 "LX" = (
 /obj/effect/turf_decal/corner/neutral{
 	dir = 1
@@ -2227,31 +2242,6 @@
 	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/bridge)
-"Mw" = (
-/obj/machinery/button/door{
-	id = "boyardeejanitor";
-	name = "Janitoral Access";
-	pixel_x = -26;
-	pixel_y = -4
-	},
-/obj/vehicle/ridden/janicart,
-/obj/item/key/janitor,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = -27;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/box,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/mono,
-/area/ship/crew/janitor)
 "MI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -2272,6 +2262,10 @@
 /obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/dark,
 /area/ship/storage)
+"Ne" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/ship/crew/hydroponics)
 "Ng" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /obj/effect/turf_decal/corner/neutral{
@@ -2296,6 +2290,9 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
+"Nl" = (
+/turf/open/floor/engine/airless,
+/area/ship/external)
 "Nv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -2355,14 +2352,6 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"OW" = (
-/obj/machinery/chem_master,
-/obj/effect/turf_decal/box,
-/obj/machinery/airalarm/all_access{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/construction)
 "Pa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -2376,17 +2365,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew/canteen)
-"Pf" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/door/window/westleft,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external)
 "PE" = (
 /obj/structure/toilet{
 	dir = 1
@@ -2412,6 +2390,21 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
+"PW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/carpet/nanoweave,
+/area/ship/crew/canteen)
 "PX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/cable{
@@ -2590,6 +2583,19 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ship/maintenance)
+"Tk" = (
+/obj/item/storage/belt/janitor/full,
+/obj/structure/janitorialcart,
+/obj/item/watertank/janitor,
+/obj/item/mop,
+/obj/item/storage/bag/trash,
+/obj/effect/turf_decal/box,
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "Tl" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2666,12 +2672,6 @@
 "TD" = (
 /turf/closed/wall/r_wall,
 /area/ship/crew/hydroponics)
-"TK" = (
-/obj/machinery/chem_heater,
-/obj/effect/turf_decal/box,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/ship/construction)
 "TL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -2765,6 +2765,9 @@
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden,
 /turf/open/floor/plating,
 /area/ship/maintenance)
+"VI" = (
+/turf/closed/wall/r_wall,
+/area/ship/construction)
 "VO" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	piping_layer = 2
@@ -2798,13 +2801,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
-"WL" = (
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/mono,
-/area/ship/crew/janitor)
 "WP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -2824,7 +2820,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
-"Xm" = (
+"Xr" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/shower{
 	pixel_y = 13
@@ -2850,6 +2846,23 @@
 "XP" = (
 /turf/closed/wall,
 /area/ship/cargo)
+"Ya" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/ship/construction)
 "Yn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -2922,15 +2935,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"ZZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external)
 
 (1,1,1) = {"
 vZ
@@ -3188,14 +3192,14 @@ vZ
 vZ
 xr
 lJ
-mm
+PW
 Bg
 gX
 oO
 IO
 up
 Ld
-HQ
+JM
 uR
 Mm
 tR
@@ -3251,7 +3255,7 @@ vZ
 vZ
 xr
 lJ
-mm
+PW
 Bg
 sp
 Ow
@@ -3272,10 +3276,10 @@ vZ
 vZ
 cC
 dl
-mm
+PW
 hk
 sp
-Ji
+ab
 NM
 NM
 Hs
@@ -3332,7 +3336,7 @@ TD
 vZ
 "}
 (20,1,1) = {"
-eM
+Nl
 Ag
 AW
 wh
@@ -3356,7 +3360,7 @@ vZ
 as
 cp
 nc
-Ia
+gG
 tP
 FN
 np
@@ -3374,7 +3378,7 @@ DZ
 vZ
 "}
 (22,1,1) = {"
-zg
+LV
 yk
 Ba
 DB
@@ -3395,7 +3399,7 @@ DZ
 vZ
 "}
 (23,1,1) = {"
-zg
+bj
 yk
 dW
 fM
@@ -3416,7 +3420,7 @@ TD
 vZ
 "}
 (24,1,1) = {"
-ZZ
+Jm
 Ag
 Uv
 jN
@@ -3430,14 +3434,14 @@ cA
 Lj
 Cx
 lg
-Lf
+Ne
 GG
 EH
 DZ
 vZ
 "}
 (25,1,1) = {"
-Pf
+wf
 Ag
 nA
 qq
@@ -3458,11 +3462,11 @@ DZ
 vZ
 "}
 (26,1,1) = {"
-sY
-rt
+rY
+fU
 rj
-KP
-KP
+vt
+vt
 px
 Dd
 Lj
@@ -3472,19 +3476,19 @@ Sf
 Lj
 dM
 TD
-Xm
-ez
+Xr
+pI
 Eo
-os
+VI
 vZ
 "}
 (27,1,1) = {"
-GD
-qS
+hg
+gP
 sD
-Mw
-EA
-rt
+mA
+IS
+fU
 of
 lG
 ph
@@ -3492,20 +3496,20 @@ ph
 ph
 Ng
 of
-os
-fm
-yt
-Kn
-GM
+VI
+oN
+py
+Fw
+ys
 vZ
 "}
 (28,1,1) = {"
 vZ
-rt
-ch
-WL
-hh
-rt
+fU
+gK
+kN
+Tk
+fU
 Cu
 Cu
 ep
@@ -3513,20 +3517,20 @@ AA
 OJ
 Cu
 Cu
-os
-OW
-bp
-TK
-GM
+VI
+fz
+Ya
+qL
+ys
 vZ
 "}
 (29,1,1) = {"
 vZ
-rt
-qS
-qS
-rt
-rt
+fU
+gP
+gP
+fU
+fU
 vZ
 Cu
 Cu
@@ -3534,10 +3538,10 @@ Cu
 Cu
 Cu
 vZ
-os
-os
-os
-os
-os
+VI
+VI
+VI
+VI
+VI
 vZ
 "}

--- a/_maps/shuttles/shiptest/boyardee.dmm
+++ b/_maps/shuttles/shiptest/boyardee.dmm
@@ -1,6 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "as" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer4,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/ship/external)
 "ay" = (
@@ -21,6 +24,23 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
+"bp" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/ship/construction)
 "bv" = (
 /obj/machinery/smartfridge/drinks,
 /turf/closed/wall,
@@ -61,6 +81,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
+"ch" = (
+/obj/machinery/vending/wardrobe/jani_wardrobe{
+	density = 0;
+	pixel_y = 29
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "cl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -75,6 +105,7 @@
 	pixel_x = -24;
 	pixel_y = 24
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew)
 "cp" = (
@@ -83,6 +114,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/fans/tiny,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "cq" = (
@@ -123,6 +155,10 @@
 /obj/machinery/airalarm/all_access{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/ship/crew)
@@ -192,6 +228,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "dH" = (
@@ -226,6 +263,21 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/button/door{
+	id = "cargoblastdoors";
+	name = "Blast Door Control";
+	pixel_x = 24;
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "eg" = (
@@ -237,6 +289,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew/canteen)
@@ -253,6 +308,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"ez" = (
+/obj/machinery/door/window/westleft,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/ship/construction)
+"eM" = (
+/obj/machinery/conveyor_switch/oneway{
+	pixel_y = -12
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external)
 "eS" = (
 /obj/machinery/door/poddoor{
 	id = "windowlockdown"
@@ -275,6 +349,11 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/hydroponics)
+"fm" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/dark,
+/area/ship/construction)
 "fs" = (
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
@@ -298,15 +377,16 @@
 /turf/open/floor/plasteel/mono/white,
 /area/ship/bridge)
 "fM" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "gi" = (
@@ -335,6 +415,19 @@
 "gX" = (
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"hh" = (
+/obj/item/storage/belt/janitor/full,
+/obj/structure/janitorialcart,
+/obj/item/watertank/janitor,
+/obj/item/mop,
+/obj/item/storage/bag/trash,
+/obj/effect/turf_decal/box,
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "hk" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/dark,
@@ -343,6 +436,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew/canteen)
 "hs" = (
@@ -445,6 +539,7 @@
 /obj/effect/turf_decal/corner/neutral{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "lg" = (
@@ -473,19 +568,10 @@
 /turf/open/floor/plating,
 /area/ship/maintenance)
 "lD" = (
-/obj/structure/rack,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe/silver,
-/obj/item/pickaxe/silver,
-/obj/item/clothing/head/hardhat/mining,
-/obj/item/clothing/head/hardhat/mining,
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/gps{
-	gpstag = "NTREC1";
-	pixel_x = -9;
-	pixel_y = 7
+/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
@@ -537,6 +623,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "me" = (
@@ -570,6 +659,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
+"mm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/carpet/nanoweave,
+/area/ship/crew/canteen)
 "mr" = (
 /turf/closed/wall,
 /area/ship/crew/hydroponics)
@@ -595,6 +699,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "ng" = (
@@ -610,7 +715,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/kitchen/knife/butcher,
+/obj/item/kitchen/knife/butcher,
+/obj/item/sharpener,
+/obj/item/sharpener,
 /turf/open/floor/plasteel/mono/white,
 /area/ship/bridge)
 "np" = (
@@ -623,6 +731,15 @@
 "nA" = (
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
@@ -670,6 +787,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew/canteen)
 "om" = (
@@ -681,6 +801,9 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ship/storage)
+"os" = (
+/turf/closed/wall/r_wall,
+/area/ship/construction)
 "oO" = (
 /obj/structure/chair/wood,
 /turf/open/floor/wood,
@@ -715,6 +838,8 @@
 	icon_state = "2-8"
 	},
 /obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plating,
 /area/ship/maintenance)
 "px" = (
@@ -747,9 +872,7 @@
 /turf/open/floor/plating,
 /area/ship/maintenance)
 "qq" = (
-/obj/machinery/mineral/ore_redemption,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/ship/cargo)
 "qu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -763,6 +886,13 @@
 	},
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew)
+"qS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor{
+	id = "windowlockdown"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/janitor)
 "qU" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
@@ -770,9 +900,20 @@
 /turf/open/floor/plating,
 /area/ship/maintenance)
 "rj" = (
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/dark,
-/area/ship/cargo)
+/obj/machinery/door/poddoor/shutters{
+	id = "boyardeejanitor"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "rm" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -786,6 +927,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
+"rt" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew/janitor)
 "rB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -800,6 +944,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/observer_start,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew)
 "rH" = (
@@ -823,12 +970,17 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "sD" = (
-/obj/machinery/door/poddoor{
-	id = "windowlockdown"
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ship/cargo)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "sI" = (
 /obj/machinery/status_display/shuttle,
 /turf/closed/wall,
@@ -836,6 +988,16 @@
 "sU" = (
 /turf/closed/wall,
 /area/ship/crew/canteen)
+"sY" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external)
 "tq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -958,6 +1120,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "vZ" = (
@@ -980,6 +1143,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
@@ -1043,10 +1209,13 @@
 /obj/structure/closet/secure_closet/bar{
 	req_access = null
 	},
-/obj/item/gun/ballistic/shotgun/doublebarrel,
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/gun/ballistic/shotgun/doublebarrel,
+/obj/item/storage/firstaid/advanced,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
 "xS" = (
@@ -1081,12 +1250,34 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/ship/cargo)
-"yF" = (
-/obj/effect/turf_decal/corner/neutral{
-	dir = 4
+"yt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ship/construction)
+"yF" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/clothing/under/rank/civilian/hydroponics,
+/obj/item/clothing/under/rank/civilian/hydroponics/skirt,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/plant_analyzer,
+/obj/item/plant_analyzer,
+/obj/item/plant_analyzer,
 /obj/effect/turf_decal/corner/neutral{
 	dir = 1
+	},
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/corner/neutral{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/hydroponics)
@@ -1100,6 +1291,12 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
+"zg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external)
 "zl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -1124,6 +1321,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "zP" = (
@@ -1418,6 +1616,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "DG" = (
@@ -1486,24 +1685,9 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/canteen)
 "Eo" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/clothing/under/rank/civilian/hydroponics,
-/obj/item/clothing/under/rank/civilian/hydroponics/skirt,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/item/plant_analyzer,
-/obj/item/plant_analyzer,
-/obj/item/plant_analyzer,
-/obj/effect/turf_decal/corner/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
-/area/ship/crew/hydroponics)
+/obj/structure/sign/departments/chemistry,
+/turf/closed/wall,
+/area/ship/construction)
 "Ex" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer2{
 	dir = 1;
@@ -1516,6 +1700,15 @@
 	},
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
+"EA" = (
+/obj/effect/turf_decal/box,
+/obj/structure/bed/dogbed/runtime,
+/mob/living/simple_animal/pet/cat/Runtime,
+/obj/item/storage/box/lights/mixed,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "EF" = (
 /obj/effect/turf_decal/corner/neutral{
 	dir = 1
@@ -1600,9 +1793,14 @@
 /turf/closed/wall,
 /area/ship/bridge)
 "FR" = (
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
@@ -1624,15 +1822,34 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/canteen)
-"GG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+"GD" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/disposaloutlet{
 	dir = 8
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external)
+"GG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
+"GM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor{
+	id = "windowlockdown"
+	},
+/turf/open/floor/plating,
+/area/ship/construction)
 "GO" = (
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
@@ -1691,6 +1908,12 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
+"HQ" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen)
 "HY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1702,6 +1925,19 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
+"Ia" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ship/cargo)
 "In" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
@@ -1729,6 +1965,9 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/shuttle,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "IJ" = (
@@ -1760,6 +1999,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew/canteen)
 "IX" = (
@@ -1777,8 +2019,14 @@
 /obj/effect/turf_decal/corner/neutral{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/hydroponics)
+"Ji" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen)
 "Jj" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/drinkingglasses,
@@ -1788,7 +2036,6 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
 "Jw" = (
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/corner/neutral{
 	dir = 1
@@ -1796,6 +2043,28 @@
 /obj/effect/turf_decal/corner/neutral{
 	dir = 4
 	},
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe/silver,
+/obj/item/pickaxe/silver,
+/obj/item/clothing/head/hardhat/mining,
+/obj/item/clothing/head/hardhat/mining,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/gps{
+	gpstag = "NTREC1";
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/gps{
+	gpstag = "NTREC1";
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/structure/closet/wall/orange{
+	pixel_x = -26
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "JF" = (
@@ -1811,6 +2080,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "JR" = (
@@ -1836,6 +2106,23 @@
 	},
 /turf/open/floor/plasteel/mono,
 /area/ship/bridge)
+"Kn" = (
+/obj/structure/closet/secure_closet/chemical{
+	req_access = list()
+	},
+/obj/item/clothing/suit/toggle/labcoat/chemist,
+/obj/item/clothing/under/rank/medical/chemist/junior_chemist,
+/obj/item/clothing/under/rank/medical/chemist/junior_chemist/skirt,
+/obj/item/storage/bag/chemistry,
+/obj/item/clothing/head/beret/chem,
+/obj/effect/turf_decal/box,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
+/obj/item/storage/box/syringes/variety,
+/turf/open/floor/plasteel/dark,
+/area/ship/construction)
 "KJ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -1868,6 +2155,9 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plating,
 /area/ship/maintenance)
+"KP" = (
+/turf/closed/wall,
+/area/ship/crew/janitor)
 "Ld" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1875,6 +2165,10 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"Lf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/ship/crew/hydroponics)
 "Lj" = (
 /turf/open/floor/plasteel/mono/white,
 /area/ship/bridge)
@@ -1885,8 +2179,9 @@
 /obj/effect/turf_decal/corner/neutral{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
@@ -1914,6 +2209,7 @@
 /obj/item/radio/intercom{
 	pixel_x = 27
 	},
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/wood,
 /area/ship/crew)
 "Mo" = (
@@ -1931,6 +2227,31 @@
 	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/bridge)
+"Mw" = (
+/obj/machinery/button/door{
+	id = "boyardeejanitor";
+	name = "Janitoral Access";
+	pixel_x = -26;
+	pixel_y = -4
+	},
+/obj/vehicle/ridden/janicart,
+/obj/item/key/janitor,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -27;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "MI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -2034,6 +2355,14 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"OW" = (
+/obj/machinery/chem_master,
+/obj/effect/turf_decal/box,
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/construction)
 "Pa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -2044,8 +2373,20 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew/canteen)
+"Pf" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/door/window/westleft,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external)
 "PE" = (
 /obj/structure/toilet{
 	dir = 1
@@ -2076,6 +2417,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew)
 "Qa" = (
@@ -2152,6 +2494,8 @@
 /obj/item/multitool,
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
 /obj/item/multitool,
 /turf/open/floor/plating,
 /area/ship/maintenance)
@@ -2322,6 +2666,12 @@
 "TD" = (
 /turf/closed/wall/r_wall,
 /area/ship/crew/hydroponics)
+"TK" = (
+/obj/machinery/chem_heater,
+/obj/effect/turf_decal/box,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/ship/construction)
 "TL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -2364,11 +2714,14 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "cargoblastdoors";
-	name = "Blast Door Control";
-	pixel_x = 24;
-	pixel_y = 24
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
@@ -2442,8 +2795,16 @@
 /obj/effect/turf_decal/corner/neutral{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
+"WL" = (
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/crew/janitor)
 "WP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -2463,19 +2824,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
+"Xm" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/shower{
+	pixel_y = 13
+	},
+/obj/structure/curtain,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/ship/construction)
 "Xv" = (
 /obj/item/radio/intercom{
 	pixel_x = 27
 	},
+/obj/machinery/button/door{
+	id = "boyardeejanitor";
+	name = "Janitoral Access";
+	pixel_x = 5;
+	pixel_y = -24
+	},
+/obj/structure/ore_box,
+/obj/machinery/mineral/ore_redemption,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "XP" = (
 /turf/closed/wall,
 /area/ship/cargo)
 "Yn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2483,6 +2858,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
 "Yx" = (
@@ -2504,6 +2880,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew/canteen)
 "Zz" = (
@@ -2542,8 +2919,18 @@
 /obj/structure/chair/stool/bar{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"ZZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external)
 
 (1,1,1) = {"
 vZ
@@ -2603,7 +2990,7 @@ me
 me
 xh
 xh
-dV
+dH
 tM
 dH
 yi
@@ -2801,14 +3188,14 @@ vZ
 vZ
 xr
 lJ
-MI
+mm
 Bg
 gX
 oO
 IO
 up
 Ld
-NM
+HQ
 uR
 Mm
 tR
@@ -2864,7 +3251,7 @@ vZ
 vZ
 xr
 lJ
-MI
+mm
 Bg
 sp
 Ow
@@ -2885,10 +3272,10 @@ vZ
 vZ
 cC
 dl
-MI
+mm
 hk
 sp
-ng
+Ji
 NM
 NM
 Hs
@@ -2945,7 +3332,7 @@ TD
 vZ
 "}
 (20,1,1) = {"
-yi
+eM
 Ag
 AW
 wh
@@ -2969,7 +3356,7 @@ vZ
 as
 cp
 nc
-DB
+Ia
 tP
 FN
 np
@@ -2987,7 +3374,7 @@ DZ
 vZ
 "}
 (22,1,1) = {"
-yi
+zg
 yk
 Ba
 DB
@@ -3008,7 +3395,7 @@ DZ
 vZ
 "}
 (23,1,1) = {"
-yi
+zg
 yk
 dW
 fM
@@ -3029,8 +3416,8 @@ TD
 vZ
 "}
 (24,1,1) = {"
-yi
-yk
+ZZ
+Ag
 Uv
 jN
 jv
@@ -3043,14 +3430,14 @@ cA
 Lj
 Cx
 lg
-fs
+Lf
 GG
 EH
 DZ
 vZ
 "}
 (25,1,1) = {"
-yi
+Pf
 Ag
 nA
 qq
@@ -3071,11 +3458,11 @@ DZ
 vZ
 "}
 (26,1,1) = {"
-vZ
-Ag
+sY
+rt
 rj
-Ag
-Ag
+KP
+KP
 px
 Dd
 Lj
@@ -3085,19 +3472,19 @@ Sf
 Lj
 dM
 TD
-TD
-TD
+Xm
+ez
 Eo
-TD
+os
 vZ
 "}
 (27,1,1) = {"
-vZ
-Ag
+GD
+qS
 sD
-Ag
-vZ
-of
+Mw
+EA
+rt
 of
 lG
 ph
@@ -3105,20 +3492,20 @@ ph
 ph
 Ng
 of
-of
-vZ
-TD
-DZ
-TD
+os
+fm
+yt
+Kn
+GM
 vZ
 "}
 (28,1,1) = {"
 vZ
-vZ
-vZ
-vZ
-vZ
-vZ
+rt
+ch
+WL
+hh
+rt
 Cu
 Cu
 ep
@@ -3126,20 +3513,20 @@ AA
 OJ
 Cu
 Cu
-vZ
-vZ
-vZ
-vZ
-vZ
+os
+OW
+bp
+TK
+GM
 vZ
 "}
 (29,1,1) = {"
 vZ
-vZ
-vZ
-vZ
-vZ
-vZ
+rt
+qS
+qS
+rt
+rt
 vZ
 Cu
 Cu
@@ -3147,10 +3534,10 @@ Cu
 Cu
 Cu
 vZ
-vZ
-vZ
-vZ
-vZ
-vZ
+os
+os
+os
+os
+os
 vZ
 "}

--- a/_maps/shuttles/shiptest/boyardee.dmm
+++ b/_maps/shuttles/shiptest/boyardee.dmm
@@ -129,10 +129,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/machinery/vending/hydroseeds,
 /turf/open/floor/wood,
 /area/ship/crew)
 "cN" = (
@@ -563,6 +560,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/structure/sign/warning/vacuum{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "lG" = (
@@ -934,9 +934,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/observer_start,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew)
 "rH" = (
@@ -1044,7 +1041,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/vending/hydroseeds,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_x = 32
+	},
 /turf/open/floor/wood,
 /area/ship/crew)
 "up" = (
@@ -2136,6 +2139,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/structure/sign/warning/vacuum{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "Mj" = (
@@ -2357,7 +2363,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew)
 "Qa" = (

--- a/_maps/shuttles/shiptest/boyardee_b.dmm
+++ b/_maps/shuttles/shiptest/boyardee_b.dmm
@@ -120,10 +120,6 @@
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/crew)
-"cW" = (
-/obj/machinery/status_display/shuttle,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/bridge)
 "cY" = (
 /obj/machinery/door/window/eastright,
 /obj/structure/extinguisher_cabinet{
@@ -280,15 +276,6 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
-"gs" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/obj/machinery/door/window/northright,
-/obj/item/gun/energy/laser/scatter,
-/obj/item/gun/energy/taser,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/security/armory)
 "gN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -302,6 +289,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
+"gQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "hp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -318,6 +314,20 @@
 /obj/machinery/suit_storage_unit/mining/eva,
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/pod/dark,
+/area/ship/cargo)
+"hw" = (
+/obj/structure/closet/secure_closet/wall{
+	icon_state = "sec_wall";
+	name = "safe";
+	pixel_y = -31;
+	req_one_access = list(25,1)
+	},
+/obj/item/stack/sheet/mineral/silver/fifty,
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/ship/cargo)
 "hB" = (
 /obj/structure/sink/kitchen{
@@ -458,18 +468,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
-"jH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ship/security/armory)
 "jK" = (
 /obj/machinery/status_display/shuttle,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -505,18 +503,10 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
-"kt" = (
-/obj/machinery/smartfridge/bloodbank/preloaded{
-	density = 0;
-	pixel_x = -32
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
+"kw" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/security/armory)
 "kD" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner/east,
@@ -697,6 +687,18 @@
 "mx" = (
 /turf/closed/wall,
 /area/ship/crew/canteen)
+"my" = (
+/obj/machinery/smartfridge/bloodbank/preloaded{
+	density = 0;
+	pixel_x = -32
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "mz" = (
 /obj/machinery/computer/helm{
 	dir = 8
@@ -718,6 +720,22 @@
 /obj/item/stack/sheet/mineral/plasma/five,
 /turf/open/floor/plating,
 /area/ship/maintenance)
+"mP" = (
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = -26
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "na" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -800,14 +818,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
-"pd" = (
-/obj/machinery/airalarm/all_access{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/suit_storage_unit/syndicate,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/security/armory)
 "pg" = (
 /obj/machinery/firealarm{
 	pixel_y = -28
@@ -914,6 +924,11 @@
 "qB" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/cargo)
+"qJ" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/canteen)
 "qU" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
@@ -923,7 +938,7 @@
 "rj" = (
 /obj/machinery/stasis,
 /obj/machinery/button/door{
-	id = b-class-medbay-windows;
+	id = "bclassmedbaywindows";
 	name = "Medbay Privacy Shutters";
 	pixel_x = -26;
 	pixel_y = -5
@@ -946,6 +961,14 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
+"rx" = (
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/security/armory)
 "rB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -1008,6 +1031,16 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew)
+"ud" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/security/armory)
 "uB" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/drinkingglasses,
@@ -1031,10 +1064,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
-"uU" = (
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
 "vb" = (
 /obj/effect/turf_decal/box,
 /obj/item/reagent_containers/food/condiment/enzyme,
@@ -1134,6 +1163,19 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
+"wu" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/rack,
+/obj/item/storage/firstaid/advanced,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/tactical,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/door/window/northleft,
+/obj/item/holosign_creator/medical,
+/obj/structure/cable,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "wB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1144,6 +1186,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"wE" = (
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "wF" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/nuke,
@@ -1291,16 +1337,27 @@
 "Bd" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/crew)
+"Bf" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "Bg" = (
 /obj/structure/chair/wood{
 	dir = 1
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
-"Bn" = (
-/obj/machinery/suit_storage_unit/syndicate,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/security/armory)
 "BE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -1439,11 +1496,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
-"DN" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/canteen)
 "DO" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -1508,6 +1560,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"FE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/security/armory)
 "FI" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
@@ -1558,15 +1619,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/cargo)
-"GO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
 "GT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1619,18 +1671,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
-"He" = (
-/obj/machinery/airalarm/all_access{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/syndie/surgery,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/door/window/northleft,
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
 "HD" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -1672,14 +1712,8 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
-"IG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/mineral/plastitanium,
+"IE" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/security/armory)
 "IJ" = (
 /obj/machinery/door/airlock/external,
@@ -1695,21 +1729,6 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
-"IT" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/bridge)
 "IW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1755,6 +1774,19 @@
 /obj/item/gun/ballistic/shotgun/automatic/combat/compact,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"Jy" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced/spawner/west,
+/obj/item/gun/ballistic/derringer,
+/obj/item/gun/ballistic/derringer,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/obj/machinery/door/window/northright,
+/obj/item/disk/design_disk/ammo_38_hunting,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/security/armory)
 "JF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1831,16 +1863,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
-"LG" = (
-/obj/machinery/power/apc/auto_name/east,
+"LB" = (
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ship/security/armory)
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "Mj" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1915,19 +1946,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
-"Nn" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/rack,
-/obj/item/storage/firstaid/advanced,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/tactical,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/door/window/northleft,
-/obj/item/holosign_creator/medical,
-/obj/structure/cable,
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
 "Nw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/structure/chair/wood{
@@ -1949,6 +1967,10 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"Oc" = (
+/obj/machinery/status_display/shuttle,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/bridge)
 "Of" = (
 /obj/structure/toilet{
 	dir = 1
@@ -1966,19 +1988,6 @@
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/canteen)
-"Ot" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced/spawner/west,
-/obj/item/gun/ballistic/derringer,
-/obj/item/gun/ballistic/derringer,
-/obj/item/ammo_box/c38,
-/obj/item/ammo_box/c38,
-/obj/item/ammo_box/c38,
-/obj/item/ammo_box/c38,
-/obj/machinery/door/window/northright,
-/obj/item/disk/design_disk/ammo_38_hunting,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/security/armory)
 "OD" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/plasteel/mono/white,
@@ -1992,9 +2001,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
-"OQ" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ship/security/armory)
 "OV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -2007,15 +2013,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
-"OY" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
 "Pa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -2028,6 +2025,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
+"Pd" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/door/window/northright,
+/obj/item/gun/energy/laser/scatter,
+/obj/item/gun/energy/taser,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/security/armory)
 "Pk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -2195,20 +2201,18 @@
 /obj/machinery/status_display/shuttle,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/canteen)
-"RD" = (
-/obj/structure/closet/secure_closet/wall{
-	icon_state = "sec_wall";
-	name = "safe";
-	pixel_y = -31;
-	req_one_access = list(25,1)
-	},
-/obj/item/stack/sheet/mineral/silver/fifty,
+"RH" = (
 /obj/machinery/airalarm/all_access{
-	dir = 8;
-	pixel_x = 24
+	dir = 1;
+	pixel_y = -24
 	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/cargo)
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/door/window/northleft,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "Sa" = (
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
@@ -2244,6 +2248,18 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
+"SJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/security/armory)
 "SQ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -2510,7 +2526,7 @@
 "Xd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor{
-	id = b-class-medbay-windows
+	id = "bclassmedbaywindows"
 	},
 /turf/open/floor/plating,
 /area/ship/medical)
@@ -2527,22 +2543,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/cargo)
-"Xu" = (
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_x = -26
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
 "Xv" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/medical)
@@ -2824,7 +2824,7 @@ vZ
 vZ
 aa
 Sa
-DN
+qJ
 TL
 Qn
 uM
@@ -3163,7 +3163,7 @@ Ym
 fM
 Co
 mg
-IT
+Bf
 ZN
 TF
 Rh
@@ -3194,7 +3194,7 @@ vb
 Ap
 Fl
 GG
-RD
+hw
 Ap
 vZ
 "}
@@ -3204,7 +3204,7 @@ GU
 Xv
 Xv
 Xv
-cW
+Oc
 PN
 ES
 Ia
@@ -3223,8 +3223,8 @@ vZ
 vZ
 Xd
 rj
-Xu
-kt
+mP
+my
 jb
 om
 ES
@@ -3233,19 +3233,19 @@ Po
 ES
 ES
 Eu
-OQ
-Bn
-jH
+IE
+kw
+SJ
 kD
-OQ
+IE
 vZ
 "}
 (27,1,1) = {"
 vZ
 Xd
 OD
-GO
-He
+gQ
+RH
 GU
 vv
 Ua
@@ -3254,19 +3254,19 @@ vh
 vh
 Hb
 vv
-OQ
-Bn
-IG
-gs
-OQ
+IE
+kw
+FE
+Pd
+IE
 vZ
 "}
 (28,1,1) = {"
 vZ
 Xd
-uU
-OY
-Nn
+wE
+LB
+wu
 GU
 Mp
 Mp
@@ -3275,11 +3275,11 @@ mz
 GV
 Mp
 Mp
-OQ
-pd
-LG
-Ot
-OQ
+IE
+rx
+ud
+Jy
+IE
 vZ
 "}
 (29,1,1) = {"
@@ -3296,10 +3296,10 @@ Mp
 Mp
 Mp
 vZ
-OQ
-OQ
-OQ
-OQ
-OQ
+IE
+IE
+IE
+IE
+IE
 vZ
 "}

--- a/_maps/shuttles/shiptest/boyardee_b.dmm
+++ b/_maps/shuttles/shiptest/boyardee_b.dmm
@@ -10,10 +10,6 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer4,
 /turf/open/floor/plating/airless,
 /area/ship/external)
-"au" = (
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
 "ay" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -51,9 +47,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/storage)
-"bX" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ship/security/armory)
 "ce" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -127,16 +120,15 @@
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/crew)
+"cW" = (
+/obj/machinery/status_display/shuttle,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/bridge)
 "cY" = (
 /obj/machinery/door/window/eastright,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/canteen)
-"dc" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
 "dl" = (
@@ -191,18 +183,6 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
-"ei" = (
-/obj/machinery/smartfridge/bloodbank/preloaded{
-	density = 0;
-	pixel_x = -32
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
 "eV" = (
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
@@ -300,6 +280,15 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
+"gs" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/door/window/northright,
+/obj/item/gun/energy/laser/scatter,
+/obj/item/gun/energy/taser,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/security/armory)
 "gN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -392,16 +381,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
-"iU" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ship/security/armory)
 "jb" = (
 /obj/machinery/door/airlock/medical/glass,
 /obj/structure/cable{
@@ -468,19 +447,6 @@
 /obj/item/toy/cards/deck/syndicate,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"jr" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced/spawner/west,
-/obj/item/gun/ballistic/derringer,
-/obj/item/gun/ballistic/derringer,
-/obj/item/ammo_box/c38,
-/obj/item/ammo_box/c38,
-/obj/item/ammo_box/c38,
-/obj/item/ammo_box/c38,
-/obj/machinery/door/window/northright,
-/obj/item/disk/design_disk/ammo_38_hunting,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/security/armory)
 "jv" = (
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/pod/dark,
@@ -492,6 +458,18 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
+"jH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/security/armory)
 "jK" = (
 /obj/machinery/status_display/shuttle,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -527,6 +505,18 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
+"kt" = (
+/obj/machinery/smartfridge/bloodbank/preloaded{
+	density = 0;
+	pixel_x = -32
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "kD" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner/east,
@@ -750,14 +740,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"nA" = (
-/obj/machinery/airalarm/all_access{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/suit_storage_unit/syndicate,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/security/armory)
 "nF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/cable/yellow{
@@ -818,6 +800,14 @@
 /obj/structure/chair/wood,
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
+"pd" = (
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/security/armory)
 "pg" = (
 /obj/machinery/firealarm{
 	pixel_y = -28
@@ -979,20 +969,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
-"rZ" = (
-/obj/structure/closet/secure_closet/wall{
-	icon_state = "sec_wall";
-	name = "safe";
-	pixel_y = -31;
-	req_one_access = list(25,1)
-	},
-/obj/item/stack/sheet/mineral/silver/fifty,
-/obj/machinery/airalarm/all_access{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/cargo)
 "sg" = (
 /obj/machinery/smartfridge/drinks,
 /turf/closed/wall,
@@ -1007,10 +983,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/cargo)
-"sR" = (
-/obj/machinery/suit_storage_unit/syndicate,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/security/armory)
 "tq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -1059,21 +1031,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
-"uV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/bridge)
+"uU" = (
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "vb" = (
 /obj/effect/turf_decal/box,
 /obj/item/reagent_containers/food/condiment/enzyme,
@@ -1336,17 +1297,9 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
-"Bx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/mineral/plastitanium,
+"Bn" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ship/security/armory)
 "BE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1486,6 +1439,11 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
+"DN" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/canteen)
 "DO" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -1587,15 +1545,6 @@
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
-"Gr" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
 "GG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1609,6 +1558,15 @@
 	},
 /turf/open/floor/plating,
 /area/ship/cargo)
+"GO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "GT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1661,6 +1619,18 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
+"He" = (
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/door/window/northleft,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "HD" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -1702,6 +1672,15 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
+"IG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/security/armory)
 "IJ" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1716,6 +1695,21 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
+"IT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "IW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1830,15 +1824,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
-"Lc" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser/iot,
-/obj/machinery/door/window/northright,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/security/armory)
 "Ld" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1846,6 +1831,16 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
+"LG" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/security/armory)
 "Mj" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1920,13 +1915,17 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
-"No" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
+"Nn" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/rack,
+/obj/item/storage/firstaid/advanced,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/tactical,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/door/window/northleft,
+/obj/item/holosign_creator/medical,
+/obj/structure/cable,
 /turf/open/floor/plasteel/mono/white,
 /area/ship/medical)
 "Nw" = (
@@ -1967,6 +1966,19 @@
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/canteen)
+"Ot" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced/spawner/west,
+/obj/item/gun/ballistic/derringer,
+/obj/item/gun/ballistic/derringer,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/obj/machinery/door/window/northright,
+/obj/item/disk/design_disk/ammo_38_hunting,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/security/armory)
 "OD" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/plasteel/mono/white,
@@ -1980,6 +1992,9 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
+"OQ" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ship/security/armory)
 "OV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -1992,6 +2007,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
+"OY" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "Pa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -2130,18 +2154,6 @@
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/plating,
 /area/ship/maintenance)
-"QV" = (
-/obj/machinery/airalarm/all_access{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/syndie/surgery,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/door/window/northleft,
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
 "Rf" = (
 /obj/machinery/status_display/shuttle,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -2183,6 +2195,20 @@
 /obj/machinery/status_display/shuttle,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/canteen)
+"RD" = (
+/obj/structure/closet/secure_closet/wall{
+	icon_state = "sec_wall";
+	name = "safe";
+	pixel_y = -31;
+	req_one_access = list(25,1)
+	},
+/obj/item/stack/sheet/mineral/silver/fifty,
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/cargo)
 "Sa" = (
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
@@ -2270,15 +2296,6 @@
 "Tr" = (
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
-"TC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ship/security/armory)
 "TF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2347,22 +2364,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"Ub" = (
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_x = -26
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
 "Uq" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
@@ -2457,19 +2458,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
-"VB" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/rack,
-/obj/item/storage/firstaid/advanced,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/tactical,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/door/window/northleft,
-/obj/item/holosign_creator/medical,
-/obj/structure/cable,
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
 "VO" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	piping_layer = 2
@@ -2539,6 +2527,22 @@
 	},
 /turf/open/floor/plating,
 /area/ship/cargo)
+"Xu" = (
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = -26
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "Xv" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/medical)
@@ -2632,10 +2636,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
-"Zl" = (
-/obj/machinery/status_display/shuttle,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/bridge)
 "Zz" = (
 /obj/machinery/cryopod{
 	dir = 1
@@ -2824,7 +2824,7 @@ vZ
 vZ
 aa
 Sa
-dc
+DN
 TL
 Qn
 uM
@@ -3163,7 +3163,7 @@ Ym
 fM
 Co
 mg
-uV
+IT
 ZN
 TF
 Rh
@@ -3194,7 +3194,7 @@ vb
 Ap
 Fl
 GG
-rZ
+RD
 Ap
 vZ
 "}
@@ -3204,7 +3204,7 @@ GU
 Xv
 Xv
 Xv
-Zl
+cW
 PN
 ES
 Ia
@@ -3223,8 +3223,8 @@ vZ
 vZ
 Xd
 rj
-Ub
-ei
+Xu
+kt
 jb
 om
 ES
@@ -3233,19 +3233,19 @@ Po
 ES
 ES
 Eu
-bX
-sR
-Bx
+OQ
+Bn
+jH
 kD
-bX
+OQ
 vZ
 "}
 (27,1,1) = {"
 vZ
 Xd
 OD
-No
-QV
+GO
+He
 GU
 vv
 Ua
@@ -3254,19 +3254,19 @@ vh
 vh
 Hb
 vv
-bX
-sR
-TC
-Lc
-bX
+OQ
+Bn
+IG
+gs
+OQ
 vZ
 "}
 (28,1,1) = {"
 vZ
 Xd
-au
-Gr
-VB
+uU
+OY
+Nn
 GU
 Mp
 Mp
@@ -3275,11 +3275,11 @@ mz
 GV
 Mp
 Mp
-bX
-nA
-iU
-jr
-bX
+OQ
+pd
+LG
+Ot
+OQ
 vZ
 "}
 (29,1,1) = {"
@@ -3296,10 +3296,10 @@ Mp
 Mp
 Mp
 vZ
-bX
-bX
-bX
-bX
-bX
+OQ
+OQ
+OQ
+OQ
+OQ
 vZ
 "}

--- a/_maps/shuttles/shiptest/boyardee_b.dmm
+++ b/_maps/shuttles/shiptest/boyardee_b.dmm
@@ -10,6 +10,10 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer4,
 /turf/open/floor/plating/airless,
 /area/ship/external)
+"au" = (
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "ay" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -32,10 +36,6 @@
 "bq" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/storage)
-"bL" = (
-/obj/machinery/suit_storage_unit/syndicate,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/deepstorage/armory)
 "bM" = (
 /obj/machinery/airalarm/all_access{
 	dir = 8;
@@ -51,6 +51,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/storage)
+"bX" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ship/security/armory)
 "ce" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -131,6 +134,11 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
+"dc" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/canteen)
 "dl" = (
 /obj/machinery/light{
 	dir = 1
@@ -183,6 +191,18 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
+"ei" = (
+/obj/machinery/smartfridge/bloodbank/preloaded{
+	density = 0;
+	pixel_x = -32
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "eV" = (
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
@@ -372,8 +392,23 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
+"iU" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/security/armory)
 "jb" = (
 /obj/machinery/door/airlock/medical/glass,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/medical)
 "jh" = (
@@ -407,9 +442,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/closet/syndicate{
-	name = "dusty armory closet"
-	},
 /obj/item/clothing/under/suit/waiter,
 /obj/item/clothing/under/suit/waiter,
 /obj/item/clothing/under/suit/waiter,
@@ -423,6 +455,12 @@
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/shoes/laceup,
 /obj/effect/turf_decal/box,
+/obj/structure/closet/secure_closet/wall{
+	icon_state = "sec_wall";
+	name = "safe";
+	pixel_y = -31;
+	req_one_access = list(25,1)
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "jq" = (
@@ -430,6 +468,19 @@
 /obj/item/toy/cards/deck/syndicate,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"jr" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced/spawner/west,
+/obj/item/gun/ballistic/derringer,
+/obj/item/gun/ballistic/derringer,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/obj/machinery/door/window/northright,
+/obj/item/disk/design_disk/ammo_38_hunting,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/security/armory)
 "jv" = (
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/pod/dark,
@@ -476,20 +527,6 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
-"kj" = (
-/obj/structure/closet/secure_closet/wall{
-	icon_state = "sec_wall";
-	name = "safe";
-	pixel_y = -31;
-	req_one_access = list(25,1)
-	},
-/obj/item/stack/sheet/mineral/silver/fifty,
-/obj/machinery/airalarm/all_access{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/cargo)
 "kD" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner/east,
@@ -596,6 +633,12 @@
 	gpstag = "SYNTROOPSHIP1";
 	pixel_x = -9;
 	pixel_y = 7
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -27
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
@@ -707,12 +750,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"nz" = (
-/obj/machinery/vending/wallmed{
-	pixel_x = -26
+"nA" = (
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/security/armory)
 "nF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/cable/yellow{
@@ -758,18 +803,21 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
 "om" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ship/medical)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "oO" = (
 /obj/structure/chair/wood,
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
-"oX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ship/security/armory)
 "pg" = (
 /obj/machinery/firealarm{
 	pixel_y = -28
@@ -884,6 +932,16 @@
 /area/ship/maintenance)
 "rj" = (
 /obj/machinery/stasis,
+/obj/machinery/button/door{
+	id = b-class-medbay-windows;
+	name = "Medbay Privacy Shutters";
+	pixel_x = -26;
+	pixel_y = -5
+	},
+/obj/item/radio/intercom{
+	pixel_x = -26;
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/medical)
 "rr" = (
@@ -921,9 +979,20 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
-"rQ" = (
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
+"rZ" = (
+/obj/structure/closet/secure_closet/wall{
+	icon_state = "sec_wall";
+	name = "safe";
+	pixel_y = -31;
+	req_one_access = list(25,1)
+	},
+/obj/item/stack/sheet/mineral/silver/fifty,
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/cargo)
 "sg" = (
 /obj/machinery/smartfridge/drinks,
 /turf/closed/wall,
@@ -938,6 +1007,10 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/cargo)
+"sR" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/security/armory)
 "tq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -963,9 +1036,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew)
-"ua" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ship/security/armory)
 "uB" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/drinkingglasses,
@@ -989,10 +1059,21 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
-"uS" = (
-/obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/mineral/plastitanium,
-/area/ship/security/armory)
+"uV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "vb" = (
 /obj/effect/turf_decal/box,
 /obj/item/reagent_containers/food/condiment/enzyme,
@@ -1013,8 +1094,8 @@
 	pixel_x = 24;
 	pixel_y = -24
 	},
-/obj/structure/closet/secure_closet/freezer/fridge{
-	pixel_y = -26
+/obj/structure/closet/secure_closet/freezer/wall{
+	pixel_y = -31
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
@@ -1060,14 +1141,6 @@
 "vv" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/bridge)
-"vA" = (
-/obj/machinery/airalarm/all_access{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/suit_storage_unit/syndicate,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/security/armory)
 "vZ" = (
 /turf/template_noop,
 /area/template_noop)
@@ -1207,14 +1280,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"zI" = (
-/obj/machinery/button/door{
-	id = b-class-medbay-windows;
-	name = "Medbay Privacy Shutters";
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
 "zM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1271,6 +1336,18 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
+"Bx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/security/armory)
 "BE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -1293,18 +1370,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ship/crew)
-"BR" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced/spawner/west,
-/obj/item/gun/ballistic/derringer,
-/obj/item/gun/ballistic/derringer,
-/obj/item/ammo_box/c38,
-/obj/item/ammo_box/c38,
-/obj/item/ammo_box/c38,
-/obj/item/ammo_box/c38,
-/obj/machinery/door/window/northright,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/security/armory)
 "BV" = (
 /obj/structure/chair/wood,
 /turf/open/floor/carpet/black,
@@ -1439,13 +1504,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew)
-"Et" = (
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/bridge)
 "Eu" = (
 /obj/machinery/firealarm{
 	pixel_y = -28
@@ -1457,30 +1515,9 @@
 "EE" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/storage)
-"EN" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/rack,
-/obj/item/storage/firstaid/advanced,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/tactical,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/door/window/northleft,
-/obj/item/holosign_creator/medical,
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
 "ES" = (
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"EZ" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser/iot,
-/obj/machinery/door/window/northright,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/security/armory)
 "Fl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -1550,6 +1587,15 @@
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
+"Gr" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "GG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1576,11 +1622,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew)
 "GU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor{
-	id = b-class-medbay-windows
-	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/medical)
 "GV" = (
 /obj/machinery/computer/autopilot{
@@ -1633,6 +1675,9 @@
 	dir = 1
 	},
 /obj/structure/ore_box,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
 "HY" = (
@@ -1707,13 +1752,13 @@
 /obj/item/clothing/under/rank/civilian/bartender/skirt,
 /obj/item/clothing/suit/apron/purple_bartender,
 /obj/item/toy/figure/bartender,
-/obj/item/gun/ballistic/shotgun/automatic/combat/compact,
 /obj/item/storage/box/lethalshot,
 /obj/item/storage/box/lethalshot,
-/obj/item/storage/belt/bandolier,
 /obj/item/storage/box/rubbershot,
 /obj/item/storage/box/rubbershot,
 /obj/item/card/emag,
+/obj/item/storage/belt/bandolier,
+/obj/item/gun/ballistic/shotgun/automatic/combat/compact,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "JF" = (
@@ -1785,6 +1830,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
+"Lc" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser/iot,
+/obj/machinery/door/window/northright,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/security/armory)
 "Ld" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1866,6 +1920,15 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
+"No" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "Nw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/structure/chair/wood{
@@ -1873,18 +1936,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
-"NQ" = (
-/obj/machinery/airalarm/all_access{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/syndie/surgery,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/door/window/northleft,
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
 "NT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/industrial/warning{
@@ -1953,15 +2004,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
-"Pi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ship/security/armory)
 "Pk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1996,9 +2038,17 @@
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
 "PN" = (
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/mono/white,
-/area/ship/medical)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "PV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -2080,6 +2130,18 @@
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/plating,
 /area/ship/maintenance)
+"QV" = (
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/door/window/northleft,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "Rf" = (
 /obj/machinery/status_display/shuttle,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -2105,6 +2167,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ship/cargo)
@@ -2205,6 +2270,15 @@
 "Tr" = (
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
+"TC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/security/armory)
 "TF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2273,6 +2347,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"Ub" = (
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = -26
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "Uq" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
@@ -2367,6 +2457,19 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
+"VB" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/rack,
+/obj/item/storage/firstaid/advanced,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/tactical,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/door/window/northleft,
+/obj/item/holosign_creator/medical,
+/obj/structure/cable,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "VO" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	piping_layer = 2
@@ -2403,10 +2506,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/cargo)
-"WS" = (
-/obj/machinery/status_display/shuttle,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/bridge)
 "WU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -2421,10 +2520,12 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "Xd" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid,
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/canteen)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor{
+	id = b-class-medbay-windows
+	},
+/turf/open/floor/plating,
+/area/ship/medical)
 "Xg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -2531,6 +2632,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
+"Zl" = (
+/obj/machinery/status_display/shuttle,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/bridge)
 "Zz" = (
 /obj/machinery/cryopod{
 	dir = 1
@@ -2719,7 +2824,7 @@ vZ
 vZ
 aa
 Sa
-Xd
+dc
 TL
 Qn
 uM
@@ -3058,7 +3163,7 @@ Ym
 fM
 Co
 mg
-ZN
+uV
 ZN
 TF
 Rh
@@ -3079,7 +3184,7 @@ HF
 jN
 jv
 FA
-ES
+PN
 ES
 ng
 Ob
@@ -3089,18 +3194,18 @@ vb
 Ap
 Fl
 GG
-kj
+rZ
 Ap
 vZ
 "}
 (25,1,1) = {"
 yi
-om
+GU
 Xv
 Xv
 Xv
-WS
-ES
+Zl
+PN
 ES
 Ia
 wB
@@ -3116,32 +3221,32 @@ vZ
 "}
 (26,1,1) = {"
 vZ
-GU
+Xd
 rj
-zI
-nz
+Ub
+ei
 jb
-ES
+om
 ES
 ES
 Po
 ES
-Et
+ES
 Eu
-ua
-bL
-Pi
+bX
+sR
+Bx
 kD
-ua
+bX
 vZ
 "}
 (27,1,1) = {"
 vZ
-GU
+Xd
 OD
-rQ
-NQ
-om
+No
+QV
+GU
 vv
 Ua
 vh
@@ -3149,20 +3254,20 @@ vh
 vh
 Hb
 vv
-ua
-bL
-oX
-EZ
-ua
+bX
+sR
+TC
+Lc
+bX
 vZ
 "}
 (28,1,1) = {"
 vZ
+Xd
+au
+Gr
+VB
 GU
-PN
-rQ
-EN
-om
 Mp
 Mp
 mr
@@ -3170,20 +3275,20 @@ mz
 GV
 Mp
 Mp
-ua
-vA
-uS
-BR
-ua
+bX
+nA
+iU
+jr
+bX
 vZ
 "}
 (29,1,1) = {"
 vZ
+Xd
+Xd
+Xd
+Xd
 GU
-GU
-GU
-GU
-om
 vZ
 Mp
 Mp
@@ -3191,10 +3296,10 @@ Mp
 Mp
 Mp
 vZ
-ua
-ua
-ua
-ua
-ua
+bX
+bX
+bX
+bX
+bX
 vZ
 "}

--- a/_maps/shuttles/shiptest/boyardee_b.dmm
+++ b/_maps/shuttles/shiptest/boyardee_b.dmm
@@ -23,17 +23,6 @@
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
-"aK" = (
-/obj/effect/spawner/lootdrop/maintenance/six,
-/obj/structure/closet/secure_closet/wall{
-	icon_state = "sec_wall";
-	name = "safe";
-	pixel_y = -31;
-	req_one_access = list(25,1)
-	},
-/obj/item/stack/sheet/mineral/gold/fifty,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/cargo)
 "bl" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/box,
@@ -43,6 +32,10 @@
 "bq" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/storage)
+"bL" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/deepstorage/armory)
 "bM" = (
 /obj/machinery/airalarm/all_access{
 	dir = 8;
@@ -380,9 +373,9 @@
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
 "jb" = (
-/obj/machinery/status_display/shuttle,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ship/bridge)
+/obj/machinery/door/airlock/medical/glass,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/medical)
 "jh" = (
 /obj/machinery/door/airlock/external,
 /obj/docking_port/mobile{
@@ -414,6 +407,22 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/closet/syndicate{
+	name = "dusty armory closet"
+	},
+/obj/item/clothing/under/suit/waiter,
+/obj/item/clothing/under/suit/waiter,
+/obj/item/clothing/under/suit/waiter,
+/obj/item/clothing/under/suit/waiter,
+/obj/item/clothing/under/suit/waiter,
+/obj/item/clothing/under/suit/waiter,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "jq" = (
@@ -422,10 +431,6 @@
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "jv" = (
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
@@ -457,6 +462,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
+/obj/machinery/mineral/ore_redemption,
+/obj/effect/turf_decal/box,
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
 "kg" = (
@@ -469,19 +476,29 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
-"kD" = (
-/obj/structure/safe/floor,
-/obj/item/clothing/suit/space/hardsuit/syndi,
-/obj/item/ammo_box/magazine/m10mm,
-/obj/item/melee/transforming/energy/sword/saber/blue,
-/obj/item/ammo_box/magazine/m10mm,
-/obj/item/ammo_box/c10mm,
-/obj/item/stamp/syndicate,
-/obj/item/paper{
-	info = "PROPERTY OF THE SYNDICATE - RETURN IF LOST"
+"kj" = (
+/obj/structure/closet/secure_closet/wall{
+	icon_state = "sec_wall";
+	name = "safe";
+	pixel_y = -31;
+	req_one_access = list(25,1)
 	},
-/turf/open/floor/plating,
+/obj/item/stack/sheet/mineral/silver/fifty,
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/ship/cargo)
+"kD" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced/spawner/east,
+/obj/item/gun/energy/laser/retro,
+/obj/item/gun/energy/laser/retro,
+/obj/item/gun/energy/laser/retro,
+/obj/machinery/door/window/northright,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/security/armory)
 "kH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -679,8 +696,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk/over,
-/obj/structure/table/wood/reinforced,
-/obj/item/stack/spacecash/c100,
+/obj/machinery/ore_silo,
+/obj/item/multitool/syndie,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "ng" = (
@@ -690,6 +707,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"nz" = (
+/obj/machinery/vending/wallmed{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "nF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/cable/yellow{
@@ -707,16 +730,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
-"oc" = (
-/obj/item/stack/sheet/mineral/gold/fifty,
-/obj/structure/closet/secure_closet/wall{
-	icon_state = "sec_wall";
-	name = "safe";
-	pixel_y = -31;
-	req_one_access = list(25,1)
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/cargo)
 "og" = (
 /obj/structure/sink{
 	dir = 4;
@@ -745,28 +758,18 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
 "om" = (
-/obj/structure/closet/syndicate{
-	name = "dusty armory closet"
-	},
-/obj/effect/turf_decal/box,
-/obj/item/clothing/under/suit/waiter,
-/obj/item/clothing/under/suit/waiter,
-/obj/item/clothing/under/suit/waiter,
-/obj/item/clothing/under/suit/waiter,
-/obj/item/clothing/under/suit/waiter,
-/obj/item/clothing/under/suit/waiter,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ship/medical)
 "oO" = (
 /obj/structure/chair/wood,
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
+"oX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/security/armory)
 "pg" = (
 /obj/machinery/firealarm{
 	pixel_y = -28
@@ -797,6 +800,8 @@
 	icon_state = "2-8"
 	},
 /obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plating,
 /area/ship/maintenance)
 "pE" = (
@@ -856,14 +861,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
-"qq" = (
-/obj/machinery/mineral/ore_redemption,
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/turf/open/floor/pod/dark,
-/area/ship/cargo)
 "qu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -886,9 +883,9 @@
 /turf/open/floor/plating,
 /area/ship/maintenance)
 "rj" = (
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/dark,
-/area/ship/cargo)
+/obj/machinery/stasis,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "rr" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks{
@@ -924,6 +921,9 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
+"rQ" = (
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "sg" = (
 /obj/machinery/smartfridge/drinks,
 /turf/closed/wall,
@@ -963,6 +963,9 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew)
+"ua" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ship/security/armory)
 "uB" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/drinkingglasses,
@@ -986,20 +989,34 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
+"uS" = (
+/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/security/armory)
 "vb" = (
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -24
-	},
-/obj/structure/closet/secure_closet/freezer/wall{
-	pixel_y = -31
-	},
+/obj/effect/turf_decal/box,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
 /obj/item/storage/box/ingredients/wildcard,
 /obj/item/storage/box/ingredients/wildcard,
 /obj/item/storage/box/ingredients/wildcard,
 /obj/item/storage/box/ingredients/wildcard,
 /obj/item/seeds/wheat,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/obj/structure/closet/secure_closet/freezer/fridge{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "vf" = (
 /obj/machinery/power/terminal{
@@ -1043,6 +1060,14 @@
 "vv" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/bridge)
+"vA" = (
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/security/armory)
 "vZ" = (
 /turf/template_noop,
 /area/template_noop)
@@ -1147,17 +1172,6 @@
 /obj/item/table_bell,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"yH" = (
-/obj/item/stack/sheet/mineral/gold/fifty,
-/obj/effect/spawner/lootdrop/maintenance/six,
-/obj/structure/closet/secure_closet/wall{
-	icon_state = "sec_wall";
-	name = "safe";
-	pixel_y = -31;
-	req_one_access = list(25,1)
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/cargo)
 "yJ" = (
 /mob/living/carbon/monkey/punpun,
 /turf/open/floor/plasteel/dark,
@@ -1193,6 +1207,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"zI" = (
+/obj/machinery/button/door{
+	id = b-class-medbay-windows;
+	name = "Medbay Privacy Shutters";
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "zM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1271,6 +1293,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ship/crew)
+"BR" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced/spawner/west,
+/obj/item/gun/ballistic/derringer,
+/obj/item/gun/ballistic/derringer,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/obj/machinery/door/window/northright,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/security/armory)
 "BV" = (
 /obj/structure/chair/wood,
 /turf/open/floor/carpet/black,
@@ -1405,6 +1439,13 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew)
+"Et" = (
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "Eu" = (
 /obj/machinery/firealarm{
 	pixel_y = -28
@@ -1416,17 +1457,38 @@
 "EE" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/storage)
+"EN" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/rack,
+/obj/item/storage/firstaid/advanced,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/tactical,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/door/window/northleft,
+/obj/item/holosign_creator/medical,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "ES" = (
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"EZ" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser/iot,
+/obj/machinery/door/window/northright,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ship/security/armory)
 "Fl" = (
-/obj/item/stack/sheet/mineral/gold/fifty,
-/obj/effect/spawner/lootdrop/maintenance/six,
-/obj/structure/closet/secure_closet/wall{
-	icon_state = "sec_wall";
-	name = "safe";
-	pixel_y = 31;
-	req_one_access = list(25,1)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/vending/security{
+	density = 0;
+	pixel_y = 31
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/cargo)
@@ -1489,13 +1551,16 @@
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
 "GG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk/over,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ship/cargo)
 "GT" = (
@@ -1511,12 +1576,12 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew)
 "GU" = (
-/obj/machinery/door/window{
-	dir = 4;
-	req_one_access_txt = "25"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor{
+	id = b-class-medbay-windows
 	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/cargo)
+/turf/open/floor/plating,
+/area/ship/medical)
 "GV" = (
 /obj/machinery/computer/autopilot{
 	dir = 8
@@ -1567,12 +1632,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "cargoblastdoors";
-	name = "Blast Door Control";
-	pixel_x = 24;
-	pixel_y = 24
-	},
+/obj/structure/ore_box,
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
 "HY" = (
@@ -1584,9 +1644,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk/over,
-/obj/structure/table/wood/reinforced,
 /obj/machinery/light/floor,
-/obj/item/toy/redbutton,
+/obj/machinery/computer/bank_machine,
+/obj/item/card/id/departmental_budget/car,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "Ia" = (
@@ -1638,13 +1698,22 @@
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
-/obj/item/gun/ballistic/shotgun/bulldog/unrestricted{
-	spawnwithmagazine = 0
-	},
-/obj/item/ammo_box/magazine/m12g{
-	ammo_type = /obj/item/ammo_casing/shotgun/beanbag;
-	name = "shotgun magazine (12g beanbag slugs)"
-	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/stack/cable_coil,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/clothing/under/rank/civilian/bartender,
+/obj/item/clothing/under/rank/civilian/bartender/purple,
+/obj/item/clothing/under/rank/civilian/bartender/skirt,
+/obj/item/clothing/suit/apron/purple_bartender,
+/obj/item/toy/figure/bartender,
+/obj/item/gun/ballistic/shotgun/automatic/combat/compact,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/belt/bandolier,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/item/card/emag,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "JF" = (
@@ -1687,6 +1756,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/recharger,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "KJ" = (
@@ -1803,6 +1873,18 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen)
+"NQ" = (
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/door/window/northleft,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "NT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/industrial/warning{
@@ -1835,12 +1917,9 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/canteen)
 "OD" = (
-/obj/machinery/door/poddoor{
-	id = "windowlockdown"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ship/cargo)
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "OI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1874,6 +1953,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
+"Pi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/security/armory)
 "Pk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1908,22 +1996,9 @@
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
 "PN" = (
-/obj/structure/closet/secure_closet/freezer/fridge/open,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/box,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/storage/box/ingredients/wildcard,
-/obj/item/storage/box/ingredients/wildcard,
-/obj/item/storage/box/ingredients/wildcard,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
 "PV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1997,12 +2072,12 @@
 "QR" = (
 /obj/item/storage/toolbox/electrical,
 /obj/item/storage/toolbox/electrical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
 /obj/item/multitool,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/storage/toolbox/syndicate,
 /turf/open/floor/plating,
 /area/ship/maintenance)
 "Rf" = (
@@ -2021,11 +2096,16 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Rm" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/structure/catwalk/over,
+/obj/machinery/door/airlock/vault{
+	req_one_access = list(25,1)
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ship/cargo)
 "Rq" = (
@@ -2038,12 +2118,6 @@
 /obj/machinery/status_display/shuttle,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/canteen)
-"RS" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 5
-	},
-/turf/open/floor/pod/dark,
-/area/ship/cargo)
 "Sa" = (
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
@@ -2140,7 +2214,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/pizzabox,
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/fire,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "TH" = (
@@ -2328,6 +2403,10 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/cargo)
+"WS" = (
+/obj/machinery/status_display/shuttle,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/bridge)
 "WU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -2342,37 +2421,26 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "Xd" = (
-/obj/machinery/airalarm/all_access{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/item/radio/intercom{
-	pixel_y = 20
-	},
-/obj/item/card/id/departmental_budget/car,
-/obj/machinery/computer/bank_machine,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/cargo)
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/canteen)
 "Xg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk/over,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ship/cargo)
 "Xv" = (
-/obj/item/radio/intercom{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 6
-	},
-/turf/open/floor/pod/dark,
-/area/ship/cargo)
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/medical)
 "XE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -2405,12 +2473,15 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/button/door{
+	id = "cargoblastdoors";
+	name = "Blast Door Control";
+	pixel_x = 24;
+	pixel_y = 24
+	},
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
 "Yn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2421,6 +2492,9 @@
 /obj/structure/catwalk/over,
 /obj/structure/table/wood/reinforced,
 /obj/item/stack/spacecash/c100,
+/obj/item/stack/spacecash/c100,
+/obj/item/toy/redbutton,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "Yr" = (
@@ -2430,6 +2504,7 @@
 	},
 /obj/item/storage/box/donkpockets,
 /obj/effect/spawner/lootdrop/donkpockets,
+/obj/item/pizzabox,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "Yx" = (
@@ -2463,17 +2538,13 @@
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/crew)
 "ZE" = (
-/obj/item/gun/ballistic/automatic/pistol{
-	spawnwithmagazine = 0
-	},
-/obj/item/stack/sheet/mineral/gold/fifty,
-/obj/effect/spawner/lootdrop/maintenance/six,
 /obj/structure/closet/secure_closet/wall{
 	icon_state = "sec_wall";
 	name = "safe";
 	pixel_y = -31;
 	req_one_access = list(25,1)
 	},
+/obj/item/stack/sheet/mineral/silver/fifty,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/cargo)
 "ZF" = (
@@ -2648,7 +2719,7 @@ vZ
 vZ
 aa
 Sa
-In
+Xd
 TL
 Qn
 uM
@@ -2913,7 +2984,7 @@ vv
 Vm
 Wv
 ZI
-aK
+ZE
 Ap
 vZ
 "}
@@ -2932,7 +3003,7 @@ hB
 pR
 vv
 Ap
-Fl
+sy
 QH
 ZE
 Ap
@@ -2955,7 +3026,7 @@ Cs
 Ap
 sy
 na
-oc
+ZE
 Ap
 vZ
 "}
@@ -2976,7 +3047,7 @@ jn
 Ap
 WP
 HY
-yH
+ZE
 Ap
 vZ
 "}
@@ -2997,13 +3068,13 @@ JM
 eZ
 Xg
 Yn
-yH
+ZE
 Ap
 vZ
 "}
 (24,1,1) = {"
 yi
-yk
+Ap
 HF
 jN
 jv
@@ -3018,18 +3089,18 @@ vb
 Ap
 Fl
 GG
-oc
+kj
 Ap
 vZ
 "}
 (25,1,1) = {"
 yi
-Ap
-RS
-qq
+om
 Xv
-xe
-PN
+Xv
+Xv
+WS
+ES
 ES
 Ia
 wB
@@ -3037,40 +3108,40 @@ ES
 ES
 bl
 Ap
-Xd
+Ap
 Rm
-GU
+Ap
 Ap
 vZ
 "}
 (26,1,1) = {"
 vZ
-Ap
+GU
 rj
-Ap
-Ap
+zI
+nz
 jb
-om
+ES
 ES
 ES
 Po
 ES
-ES
+Et
 Eu
-Ap
-Ap
-Ap
+ua
+bL
+Pi
 kD
-Ap
+ua
 vZ
 "}
 (27,1,1) = {"
 vZ
-Ap
+GU
 OD
-Ap
-vZ
-vv
+rQ
+NQ
+om
 vv
 Ua
 vh
@@ -3078,20 +3149,20 @@ vh
 vh
 Hb
 vv
-vv
-vZ
-Ap
-Ap
-Ap
+ua
+bL
+oX
+EZ
+ua
 vZ
 "}
 (28,1,1) = {"
 vZ
-vZ
-vZ
-vZ
-vZ
-vZ
+GU
+PN
+rQ
+EN
+om
 Mp
 Mp
 mr
@@ -3099,20 +3170,20 @@ mz
 GV
 Mp
 Mp
-vZ
-vZ
-vZ
-vZ
-vZ
+ua
+vA
+uS
+BR
+ua
 vZ
 "}
 (29,1,1) = {"
 vZ
-vZ
-vZ
-vZ
-vZ
-vZ
+GU
+GU
+GU
+GU
+om
 vZ
 Mp
 Mp
@@ -3120,10 +3191,10 @@ Mp
 Mp
 Mp
 vZ
-vZ
-vZ
-vZ
-vZ
-vZ
+ua
+ua
+ua
+ua
+ua
 vZ
 "}

--- a/_maps/shuttles/shiptest/hyena.dmm
+++ b/_maps/shuttles/shiptest/hyena.dmm
@@ -20,6 +20,8 @@
 "bd" = (
 /obj/effect/turf_decal/industrial/outline,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/item/circuitboard/machine/mining_equipment_vendor,
+/obj/structure/closet/crate,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/cargo)
 "bl" = (
@@ -258,10 +260,13 @@
 /obj/effect/turf_decal/industrial/outline,
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
 /obj/item/flashlight/lantern/syndicate,
 /obj/item/flashlight/lantern/syndicate,
-/obj/item/mining_scanner,
-/obj/item/mining_scanner,
+/obj/item/flashlight/lantern/syndicate,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "fi" = (
@@ -1145,6 +1150,12 @@
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
 	},
+/obj/item/storage/box/emptysandbags,
+/obj/item/syndie_crusher{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/gps/mining,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "tI" = (
@@ -1548,6 +1559,12 @@
 	dir = 1;
 	pixel_y = 28
 	},
+/obj/item/storage/box/emptysandbags,
+/obj/item/syndie_crusher{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/gps/mining,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "zZ" = (
@@ -2832,14 +2849,8 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
-/obj/item/syndie_crusher{
-	pixel_x = 5;
-	pixel_y = -2
-	},
-/obj/item/syndie_crusher{
-	pixel_x = 5;
-	pixel_y = 6
-	},
+/obj/item/pickaxe/drill,
+/obj/item/pickaxe/drill,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "VR" = (
@@ -2880,6 +2891,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/item/disk/design_disk/ammo_c10mm,
 /turf/open/floor/carpet/red,
 /area/ship/cargo/office)
 "Wc" = (

--- a/voidcrew/code/game/objects/structures/crates_lockers/closets/secure/misc.dm
+++ b/voidcrew/code/game/objects/structures/crates_lockers/closets/secure/misc.dm
@@ -18,6 +18,7 @@
 	new /obj/item/clothing/under/rank/security/head_of_security/skirt(src)
 	new /obj/item/clothing/under/rank/security/head_of_security/alt(src)
 	new /obj/item/clothing/under/rank/security/head_of_security/alt/skirt(src)
+	new /obj/item/clothing/suit/space/hardsuit/security/hos(src)
 	new /obj/item/clothing/head/HoS(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses/eyepatch(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses/gars/supergars(src)
@@ -37,9 +38,9 @@
 	new /obj/item/storage/photo_album/HoS(src)
 
 /obj/structure/closet/secure_closet/pilot_officer // Snowflake map item for VoidTest
-	name = "/proper pilot officer's locker"
+	name = "\proper pilot officer's locker"
 	desc = "A storage unit containing useful equipment for a spacecraft pilot or mechanic."
-	req_access = list(ACCESS_SECURITY)
+	req_one_access = list(ACCESS_SECURITY, ACCESS_MINERAL_STOREROOM)
 	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/pilot_officer/PopulateContents()


### PR DESCRIPTION
## About The Pull Request

- Adds an Armory to the Boyardee-B class. The armory includes 3 basic blood-red suits, some laser guns and .38 derringers.
- Adds a small infirmary with medkits and advanced surgical tools.
- Puts an ore silo in the vault, removes the safe and random junk spawns, adds two red toolboxes and assorted materials.
- Replaces the bartender's syndicate shotgun with a compact combat shotty and adds a few boxes of buckshot
- Tartarus's HoS has their own hardsuit now.
- Minor tweaks to the Hyena (Adds a few GPS units, drills, moves syndie cleavers to the miner's locker, adds a few basic automatic ore scanners)


![Boyardee-B](https://user-images.githubusercontent.com/61243846/154837707-937404e9-91c1-48fb-a576-98129579636d.png)



## Why It's Good For The Game

Currently the Boyardee-B is severely lacking in weapons, equipment and useful materials compared to other, cheaper ships (looking at you, Spitfire/Delivery ship). For 750 metacoins it feels like a blackpill-class with more space. This'll hopefully make it more playable without making it a dedicated combat ship.

## Changelog
:cl:
balance: Adds a small armory/medbay to the Boyardee for basic healthcare and self-defense, tweaks a few item spawns.
/:cl:
