### PR TITLE
Fire-proofs prophet cloak

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -251,6 +251,7 @@
 	icon_state = "herald_cloak"
 	body_parts_covered = CHEST|GROIN|ARMS
 	hit_reaction_chance = 25
+	resistance_flags = FIRE_PROOF | ACID_PROOF
 
 /obj/item/clothing/neck/cloak/herald_cloak/proc/reactionshot(mob/living/carbon/owner)
 	var/static/list/directional_shot_angles = list(0, 45, 90, 135, 180, 225, 270, 315)


### PR DESCRIPTION
## About The Pull Request

Fire-proofs Cloak of the prophet, the heralds boosted loot
(also acid-proofs it, cause why not)
## Why It's Good For The Game

It catches on fire, reducing it to ashes, which is kinda unfun, and most of the other lavaland loot is fireproof.

