### PR TITLE
Adds an autolathe to the TrunkTide

### DIFF
--- a/_maps/shuttles/shiptest/trunktide.dmm
+++ b/_maps/shuttles/shiptest/trunktide.dmm
@@ -197,6 +197,9 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/structure/frame/machine,
+/obj/item/storage/box/stockparts/basic,
+/obj/item/circuitboard/machine/autolathe,
 /turf/open/floor/plasteel,
 /area/ship/maintenance/fore)
 "gh" = (
@@ -1031,7 +1034,9 @@
 /turf/open/floor/plasteel,
 /area/ship/maintenance/fore)
 "Da" = (
-/obj/machinery/door/poddoor/shutters,
+/obj/machinery/door/poddoor/shutters{
+	id = "Mcargotide"
+	},
 /turf/open/floor/plasteel,
 /area/ship/maintenance/central)
 "Dh" = (
@@ -1046,6 +1051,7 @@
 "DF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/can,
+/obj/structure/frame/machine,
 /turf/open/floor/plasteel,
 /area/ship/maintenance/fore)
 "DV" = (


### PR DESCRIPTION
## About The Pull Request

Fixes the TT-class lacking an autolathe, stock parts or the board to make one. It's a Tide-class so it needs some DIY skills. (Adds a autolathe board and a box of stock parts.) Also, fixes the ore silo shutters.

![TrunkTideAutolathe](https://user-images.githubusercontent.com/61243846/154923211-cbdd04f3-a7b2-42a6-96ed-0adb17b74be8.png)


## Changelog
:cl:
tweak: You can make meaningful progress in a TrunkTide class now!
/:cl:
