### PR TITLE
Changes osprey cyborg endoskeleton type

### DIFF
--- a/_maps/shuttles/shiptest/osprey.dmm
+++ b/_maps/shuttles/shiptest/osprey.dmm
@@ -2617,7 +2617,6 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "rX" = (
-/obj/item/robot_suit/prebuilt,
 /obj/item/bodypart/chest/robot,
 /obj/item/bodypart/r_leg/robot,
 /obj/item/bodypart/l_leg/robot,
@@ -2637,6 +2636,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/item/robot_suit,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/construction)
 "sf" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Osprey has a "prebuilt" subtype of the cyborg endoskeleton. It does not appear assembled, and considering the rest of the parts in the box, is likely not intended to be prebuilt. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The Osprey no longer has a pre-built cyborg endoskeleton, having been traded for a normal one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
