### PR TITLE
Removes fake lattice from jungle_hangar map, makes shutters fair

### DIFF
--- a/voidcrew/_maps/RandomRuins/JungleRuins/jungle_hangar.dmm
+++ b/voidcrew/_maps/RandomRuins/JungleRuins/jungle_hangar.dmm
@@ -32,7 +32,6 @@
 /area/ruin/unpowered)
 "jb" = (
 /obj/structure/closet/firecloset,
-/obj/effect/decal/fakelattice,
 /turf/open/floor/plating,
 /area/ruin/powered)
 "jx" = (
@@ -82,7 +81,6 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/under/costume/mech_suit/white,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice,
 /turf/open/floor/plating,
 /area/ruin/powered)
 "sL" = (
@@ -103,7 +101,6 @@
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice,
 /turf/open/floor/plating,
 /area/ruin/powered)
 "xt" = (
@@ -123,14 +120,12 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice,
 /turf/open/floor/plating,
 /area/ruin/powered)
 "zC" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/plasma,
-/obj/effect/decal/fakelattice,
 /turf/open/floor/plating,
 /area/ruin/powered)
 "Ad" = (
@@ -152,7 +147,6 @@
 /area/ruin/powered)
 "HM" = (
 /obj/structure/closet/emcloset,
-/obj/effect/decal/fakelattice,
 /turf/open/floor/plating,
 /area/ruin/powered)
 "Jd" = (
@@ -161,7 +155,6 @@
 /area/ruin/powered)
 "LS" = (
 /obj/machinery/door/poddoor/shutters/preopen,
-/obj/effect/decal/fakelattice,
 /turf/open/floor/plating,
 /area/ruin/powered)
 "LZ" = (
@@ -189,7 +182,6 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/under/costume/mech_suit,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice,
 /turf/open/floor/plating,
 /area/ruin/powered)
 "SG" = (
@@ -228,8 +220,7 @@
 /turf/open/floor/plating,
 /area/ruin/powered)
 "Xv" = (
-/obj/machinery/door/poddoor/shutters/indestructible,
-/obj/effect/decal/fakelattice,
+/obj/machinery/door/poddoor/shutters,
 /turf/open/floor/plating,
 /area/ruin/powered)
 "Xy" = (
@@ -240,7 +231,6 @@
 "XF" = (
 /obj/effect/decal/cleanable/plasma,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/fakelattice,
 /obj/structure/mecha_wreckage/ripley/mkii,
 /turf/open/floor/plating,
 /area/ruin/powered)
@@ -251,12 +241,10 @@
 "YQ" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/under/costume/mech_suit/blue,
-/obj/effect/decal/fakelattice,
 /turf/open/floor/plating,
 /area/ruin/powered)
 "Zc" = (
 /obj/structure/mecha_wreckage/marauder,
-/obj/effect/decal/fakelattice,
 /turf/open/floor/plating,
 /area/ruin/powered)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Jungle_hangar map had fake, impassible lattice. They're decals why the hell are they impassible? It no longer has them
Removed the indestructible shutters, replaced them with normal ones. Why indestructible? What sense is that?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The jungle_hangar ruin no longer has impassible fake lattice, nor indestructible shutters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
