### PR TITLE
Sets the Kugelblitz' project overseer to be an "officer", limiting it to one job

### DIFF
--- a/_maps/configs/NEU_kugelblitz.json
+++ b/_maps/configs/NEU_kugelblitz.json
@@ -9,6 +9,7 @@
 	"job_slots": {
 		"Project Overseer": {
 			"outfit": "/datum/outfit/job/ce/gec",
+			"officer": true,
 			"slots": 1
 		},
 		"Ship Engineer": {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Besides the fact that infinite project overseers is bad purely on principle, they spawn with a telebaton and a headset capable of loud mode. Plus just the fact that it IS bad on principle, the same way as having multiple captains is bad.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The kubelblitz' project overseer can no longer have slots added on the cryo console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
