### PR TITLE
Rigoureux table changes

### DIFF
--- a/_maps/shuttles/shiptest/rigoureux.dmm
+++ b/_maps/shuttles/shiptest/rigoureux.dmm
@@ -187,7 +187,7 @@
 /turf/open/floor/carpet/nanoweave/beige,
 /area/ship/security)
 "dO" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/folder,
 /turf/open/floor/carpet/nanoweave,
@@ -4109,7 +4109,7 @@
 /turf/open/floor/carpet/nanoweave/purple,
 /area/ship/crew/canteen)
 "Xw" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/firealarm{
 	dir = 4;

--- a/_maps/shuttles/shiptest/rigoureux_d.dmm
+++ b/_maps/shuttles/shiptest/rigoureux_d.dmm
@@ -3552,7 +3552,7 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "Ou" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/folder,
 /obj/effect/decal/cleanable/dirt,
@@ -4423,7 +4423,7 @@
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
 "Xw" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/firealarm{
 	dir = 4;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The "bar" wood table variant? Has 1000 max integrity and can't be disassembled. This is simply unreasonable, and would make a frightening fortification if flipped on its side.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The Rigoureux and Rigoureux-D no longer have nigh indestructible tables
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
