### PR TITLE
Adds floor underneath the vault door in the dangerous research space ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
@@ -1958,7 +1958,7 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 4
 	},
-/turf/open/space/basic,
+/turf/open/floor/plasteel,
 /area/ruin/space/has_grav)
 "XX" = (
 /obj/structure/window/reinforced{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The "dangerous research" space ruin has a missing floor underneath a vault door, making it open to space, which is quite strange considering that the entire rest of the place is otherwise pressurized, as this causes it slowly lose pressure as time goes on.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The dangerous research space ruin will no longer lose pressure to a hidden missing floor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
