### PR TITLE
Moves around piping on the scrapper-b, adds a couple useful things it was missing

### DIFF
--- a/_maps/shuttles/shiptest/scrapper_b.dmm
+++ b/_maps/shuttles/shiptest/scrapper_b.dmm
@@ -162,19 +162,7 @@
 /turf/open/floor/pod/light,
 /area/ship/bridge)
 "by" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = -20
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/science)
 "bA" = (
@@ -316,16 +304,11 @@
 /obj/machinery/door/airlock/hatch{
 	name = "external access hatch"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/docking_port/mobile{
 	dir = 8;
 	port_direction = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/science)
 "dR" = (
@@ -796,7 +779,16 @@
 /turf/open/floor/pod/light,
 /area/ship/bridge)
 "lt" = (
-/turf/open/floor/plasteel/tech,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/pod/light,
 /area/ship/cargo)
 "lA" = (
 /obj/structure/window/plasma/reinforced/plastitanium,
@@ -852,10 +844,11 @@
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "mB" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/pod/light,
 /area/ship/cargo)
 "mF" = (
 /obj/machinery/airalarm/all_access{
@@ -911,17 +904,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/hallway/central)
 "nq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/pod/light,
-/area/ship/cargo)
+/obj/machinery/vending/wardrobe/robo_wardrobe,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/science)
 "ny" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -967,6 +952,9 @@
 /area/ship/crew/canteen)
 "nQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/mono/white,
@@ -1117,13 +1105,7 @@
 /obj/machinery/door/airlock/hatch{
 	name = "external access hatch"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1473,6 +1455,9 @@
 	input_dir = 8;
 	output_dir = 4
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "ur" = (
@@ -1589,12 +1574,20 @@
 /turf/open/floor/pod/light,
 /area/ship/hallway/fore)
 "uU" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/pod/light,
-/area/ship/cargo)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/science)
 "uV" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -1678,9 +1671,11 @@
 /turf/open/floor/pod/light,
 /area/ship/crew/dorm)
 "xh" = (
-/obj/machinery/vending/wardrobe/robo_wardrobe,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/science)
+/obj/structure/closet/secure_closet/freezer/kitchen/wall{
+	dir = 4
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/maintenance/starboard)
 "xk" = (
 /obj/structure/frame/machine,
 /obj/item/stock_parts/scanning_module,
@@ -1946,20 +1941,11 @@
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "zB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/science)
+/turf/open/floor/plating,
+/area/ship/engineering/electrical)
 "zG" = (
 /obj/machinery/holopad/emergency/command,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -2085,12 +2071,6 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/starboard)
-"BE" = (
-/obj/structure/closet/secure_closet/freezer/kitchen/wall{
-	dir = 4
-	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/starboard)
 "BJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -2103,12 +2083,6 @@
 	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/science)
-"BO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/electrical)
 "BQ" = (
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 1
@@ -2196,12 +2170,6 @@
 	},
 /turf/open/floor/pod/light,
 /area/ship/science/robotics)
-"Df" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/plasteel/mono/white,
-/area/ship/science)
 "Dh" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 1
@@ -2284,16 +2252,11 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/science)
 "Es" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/science)
 "Ey" = (
@@ -2626,16 +2589,7 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 4
-	},
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/science)
 "Iv" = (
@@ -2950,15 +2904,6 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/science)
 "Lv" = (
@@ -3191,12 +3136,6 @@
 	},
 /turf/open/floor/pod/light,
 /area/ship/maintenance/starboard)
-"NK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plasteel/mono/white,
-/area/ship/science)
 "NO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech/techmaint,
@@ -3835,7 +3774,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/science)
 "UC" = (
@@ -4085,7 +4026,7 @@
 /area/ship/engineering/atmospherics)
 "Yy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/science)
@@ -4746,7 +4687,7 @@ PC
 eN
 eN
 eN
-xh
+nq
 ed
 dT
 RS
@@ -4757,7 +4698,7 @@ sC
 RS
 Mb
 Ra
-BO
+zB
 AN
 va
 WZ
@@ -4777,7 +4718,7 @@ DY
 OM
 Ui
 UG
-uU
+mB
 Zq
 nT
 br
@@ -4809,14 +4750,14 @@ ap
 DL
 DL
 DL
-lt
+TW
 tF
 DY
-nq
+lt
 pR
 Ph
 pR
-nq
+lt
 GY
 eN
 eN
@@ -4847,14 +4788,14 @@ ap
 Sr
 Sr
 Sr
-mB
+TW
 ug
 DY
-nq
+lt
 DO
 Ph
 DO
-nq
+lt
 ep
 eN
 eN
@@ -4885,7 +4826,7 @@ aC
 Sr
 Sr
 Sr
-lt
+TW
 Gv
 DY
 Kc
@@ -4902,7 +4843,7 @@ KX
 Ed
 NV
 Yy
-NK
+NV
 Lg
 tf
 SZ
@@ -4940,12 +4881,12 @@ NV
 BJ
 NV
 nQ
-Df
+NV
 DB
 tf
 tf
 gQ
-BE
+xh
 zZ
 yA
 hp
@@ -4975,7 +4916,7 @@ Ep
 Gs
 LP
 LP
-zB
+uU
 Ud
 Ur
 Es

--- a/_maps/shuttles/shiptest/scrapper_b.dmm
+++ b/_maps/shuttles/shiptest/scrapper_b.dmm
@@ -2722,10 +2722,6 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_x = -30;
-	pixel_y = 30
-	},
 /turf/open/floor/pod/light,
 /area/ship/hallway/central)
 "JQ" = (

--- a/_maps/shuttles/shiptest/scrapper_b.dmm
+++ b/_maps/shuttles/shiptest/scrapper_b.dmm
@@ -731,16 +731,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/toilet)
 "ky" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/pod/light,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "kz" = (
 /obj/effect/landmark/start/shaft_miner,
@@ -815,11 +806,10 @@
 /turf/open/floor/pod/light,
 /area/ship/bridge)
 "lt" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/pod/light,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "lA" = (
 /obj/structure/window/plasma/reinforced/plastitanium,
@@ -875,9 +865,17 @@
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "mB" = (
-/obj/machinery/vending/wardrobe/robo_wardrobe,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/science)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/pod/light,
+/area/ship/cargo)
 "mF" = (
 /obj/machinery/airalarm/all_access{
 	dir = 8;
@@ -948,20 +946,12 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/hallway/central)
 "nq" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/science)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/pod/light,
+/area/ship/cargo)
 "ny" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -1524,10 +1514,9 @@
 /area/ship/engineering/engine)
 "ug" = (
 /obj/machinery/mineral/ore_redemption{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
+	dir = 4;
+	input_dir = 8;
+	output_dir = 4
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
@@ -1645,11 +1634,9 @@
 /turf/open/floor/pod/light,
 /area/ship/hallway/fore)
 "uU" = (
-/obj/structure/closet/secure_closet/freezer/kitchen/wall{
-	dir = 4
-	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/starboard)
+/obj/machinery/vending/wardrobe/robo_wardrobe,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/science)
 "uV" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -1733,11 +1720,20 @@
 /turf/open/floor/pod/light,
 /area/ship/crew/dorm)
 "xh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/ship/engineering/electrical)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/science)
 "xk" = (
 /obj/structure/frame/machine,
 /obj/item/stock_parts/scanning_module,
@@ -1999,6 +1995,12 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
+"zB" = (
+/obj/structure/closet/secure_closet/freezer/kitchen/wall{
+	dir = 4
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/maintenance/starboard)
 "zG" = (
 /obj/machinery/holopad/emergency/command,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -2124,6 +2126,12 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/starboard)
+"BE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/electrical)
 "BJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -4795,7 +4803,7 @@ PC
 eN
 eN
 eN
-mB
+uU
 ed
 dT
 RS
@@ -4806,7 +4814,7 @@ sC
 RS
 Mb
 Ra
-xh
+BE
 AN
 va
 WZ
@@ -4826,7 +4834,7 @@ DY
 OM
 Ui
 UG
-lt
+nq
 Zq
 nT
 br
@@ -4858,14 +4866,14 @@ ap
 DL
 DL
 DL
-DL
+ky
 tF
 DY
-ky
+mB
 pR
 Ph
 pR
-ky
+mB
 GY
 eN
 eN
@@ -4896,14 +4904,14 @@ ap
 Sr
 Sr
 Sr
-Sr
+lt
 ug
 DY
-ky
+mB
 DO
 Ph
 DO
-ky
+mB
 ep
 eN
 eN
@@ -4934,7 +4942,7 @@ aC
 Sr
 Sr
 Sr
-Sr
+ky
 Gv
 DY
 Kc
@@ -4994,7 +5002,7 @@ DB
 tf
 tf
 gQ
-uU
+zB
 zZ
 yA
 hp
@@ -5024,7 +5032,7 @@ Ep
 Gs
 LP
 LP
-nq
+xh
 Ud
 Ur
 Es

--- a/_maps/shuttles/shiptest/scrapper_b.dmm
+++ b/_maps/shuttles/shiptest/scrapper_b.dmm
@@ -731,18 +731,14 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/toilet)
 "ky" = (
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/pod/light,
+/area/ship/hallway/central)
 "kz" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/pod/light,
 /area/ship/hallway/central)
@@ -760,12 +756,6 @@
 /area/ship/cargo)
 "kH" = (
 /obj/effect/turf_decal/siding/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 4
 	},
 /turf/open/floor/pod/light,
@@ -806,9 +796,6 @@
 /turf/open/floor/pod/light,
 /area/ship/bridge)
 "lt" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "lA" = (
@@ -865,16 +852,10 @@
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "mB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/pod/light,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "mF" = (
 /obj/machinery/airalarm/all_access{
@@ -885,19 +866,6 @@
 /obj/item/research_notes,
 /turf/open/floor/carpet/royalblue,
 /area/ship/construction)
-"mH" = (
-/obj/effect/landmark/start/shaft_miner,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/pod/light,
-/area/ship/hallway/central)
 "mN" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -940,16 +908,18 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/hallway/central)
 "nq" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "ny" = (
@@ -1108,9 +1078,6 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/hallway/central)
 "oX" = (
@@ -1183,18 +1150,9 @@
 /turf/closed/wall/mineral/plastitanium/overspace,
 /area/ship/engineering/engine)
 "pC" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/effect/landmark/start/shaft_miner,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
 	},
 /turf/open/floor/pod/light,
 /area/ship/hallway/central)
@@ -1374,9 +1332,6 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/hallway/central)
 "rY" = (
@@ -1443,14 +1398,14 @@
 /turf/open/floor/eighties,
 /area/ship/crew/canteen)
 "sP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/airlock/external{
-	icon = 'icons/obj/doors/blastdoor.dmi'
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/pod/light,
 /area/ship/hallway/central)
 "sX" = (
@@ -1634,9 +1589,12 @@
 /turf/open/floor/pod/light,
 /area/ship/hallway/fore)
 "uU" = (
-/obj/machinery/vending/wardrobe/robo_wardrobe,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/science)
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/pod/light,
+/area/ship/cargo)
 "uV" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -1720,18 +1678,7 @@
 /turf/open/floor/pod/light,
 /area/ship/crew/dorm)
 "xh" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+/obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/science)
 "xk" = (
@@ -1776,13 +1723,18 @@
 /turf/open/floor/pod/light,
 /area/ship/science/robotics)
 "xS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
@@ -1958,9 +1910,7 @@
 /turf/open/floor/pod/light,
 /area/ship/science/robotics)
 "zs" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/pod/light,
 /area/ship/hallway/central)
 "zv" = (
@@ -1996,11 +1946,20 @@
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "zB" = (
-/obj/structure/closet/secure_closet/freezer/kitchen/wall{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/science)
 "zG" = (
 /obj/machinery/holopad/emergency/command,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -2127,11 +2086,11 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/starboard)
 "BE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/structure/closet/secure_closet/freezer/kitchen/wall{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/ship/engineering/electrical)
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/maintenance/starboard)
 "BJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -2144,6 +2103,12 @@
 	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/science)
+"BO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/electrical)
 "BQ" = (
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 1
@@ -2238,9 +2203,11 @@
 /turf/open/floor/plasteel/mono/white,
 /area/ship/science)
 "Dh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
@@ -2331,15 +2298,8 @@
 /area/ship/science)
 "Ey" = (
 /obj/machinery/suit_storage_unit/mining/eva,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/hallway/central)
@@ -2504,7 +2464,7 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/starboard)
 "Gh" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/pod/light,
 /area/ship/hallway/central)
 "Gs" = (
@@ -2515,7 +2475,9 @@
 /area/ship/science)
 "Gt" = (
 /obj/effect/turf_decal/siding/yellow,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -2637,14 +2599,13 @@
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Ij" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/airlock/external{
-	icon = 'icons/obj/doors/blastdoor.dmi'
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/pod/light,
 /area/ship/hallway/central)
 "Is" = (
@@ -2732,6 +2693,14 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
+"IH" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/pod/light,
+/area/ship/cargo)
 "IJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/eighties,
@@ -2797,12 +2766,6 @@
 /area/ship/construction)
 "JO" = (
 /obj/effect/turf_decal/siding/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 8
 	},
 /obj/machinery/advanced_airlock_controller{
@@ -3205,9 +3168,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/airlock/external{
-	icon = 'icons/obj/doors/blastdoor.dmi'
-	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external,
 /turf/open/floor/pod/light,
 /area/ship/hallway/central)
 "NG" = (
@@ -3284,12 +3246,8 @@
 /area/ship/crew/canteen)
 "Ox" = (
 /obj/effect/turf_decal/siding/yellow,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -3509,8 +3467,9 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/hallway/central)
@@ -3532,17 +3491,11 @@
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "Ri" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/external{
-	icon = 'icons/obj/doors/blastdoor.dmi'
-	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/pod/light,
 /area/ship/hallway/central)
 "Rl" = (
@@ -3849,11 +3802,8 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/pod/light,
 /area/ship/hallway/central)
@@ -4078,13 +4028,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"Xe" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/pod/light,
-/area/ship/cargo)
 "XE" = (
 /obj/structure/closet/emcloset,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -4641,7 +4584,7 @@ no
 QY
 DL
 DY
-Ox
+Gt
 QZ
 VN
 yP
@@ -4714,9 +4657,9 @@ GK
 NC
 zs
 Gh
-Gh
+ky
 Ij
-DY
+IH
 Ox
 QZ
 VN
@@ -4751,10 +4694,10 @@ PF
 GK
 NC
 kH
-mH
+pC
 pC
 Ri
-Xe
+DY
 Gt
 VN
 VN
@@ -4803,7 +4746,7 @@ PC
 eN
 eN
 eN
-uU
+xh
 ed
 dT
 RS
@@ -4814,7 +4757,7 @@ sC
 RS
 Mb
 Ra
-BE
+BO
 AN
 va
 WZ
@@ -4834,7 +4777,7 @@ DY
 OM
 Ui
 UG
-nq
+uU
 Zq
 nT
 br
@@ -4866,14 +4809,14 @@ ap
 DL
 DL
 DL
-ky
+lt
 tF
 DY
-mB
+nq
 pR
 Ph
 pR
-mB
+nq
 GY
 eN
 eN
@@ -4904,14 +4847,14 @@ ap
 Sr
 Sr
 Sr
-lt
+mB
 ug
 DY
-mB
+nq
 DO
 Ph
 DO
-mB
+nq
 ep
 eN
 eN
@@ -4942,7 +4885,7 @@ aC
 Sr
 Sr
 Sr
-ky
+lt
 Gv
 DY
 Kc
@@ -5002,7 +4945,7 @@ DB
 tf
 tf
 gQ
-zB
+BE
 zZ
 yA
 hp
@@ -5032,7 +4975,7 @@ Ep
 Gs
 LP
 LP
-xh
+zB
 Ud
 Ur
 Es

--- a/_maps/shuttles/shiptest/scrapper_b.dmm
+++ b/_maps/shuttles/shiptest/scrapper_b.dmm
@@ -115,6 +115,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "br" = (
@@ -132,6 +138,15 @@
 	},
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
@@ -174,7 +189,7 @@
 "bC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
@@ -222,9 +237,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -322,12 +335,7 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
 	},
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
+/obj/structure/frame/machine,
 /turf/open/floor/pod/light,
 /area/ship/storage)
 "dT" = (
@@ -427,7 +435,9 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "fS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -481,7 +491,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "2-4"
 	},
 /turf/open/floor/pod/light,
 /area/ship/bridge)
@@ -500,19 +510,14 @@
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "gt" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "gJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/pod/light,
 /area/ship/science/robotics)
@@ -542,6 +547,9 @@
 /obj/effect/landmark/start/research_director,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/pod/light,
 /area/ship/science/robotics)
 "hp" = (
@@ -577,9 +585,6 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "if" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -636,10 +641,6 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/bridge)
 "iF" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/computer/robotics,
 /obj/machinery/light{
 	dir = 1
@@ -669,14 +670,18 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/pod/light,
 /area/ship/science/robotics)
 "je" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/modular_computer/console/preset/research,
 /turf/open/floor/carpet/royalblue,
 /area/ship/construction)
@@ -726,14 +731,14 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/toilet)
 "ky" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
@@ -756,6 +761,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
@@ -807,17 +815,12 @@
 /turf/open/floor/pod/light,
 /area/ship/bridge)
 "lt" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/mono/white,
-/area/ship/science)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/pod/light,
+/area/ship/cargo)
 "lA" = (
 /obj/structure/window/plasma/reinforced/plastitanium,
 /obj/structure/grille,
@@ -828,9 +831,6 @@
 "lL" = (
 /obj/structure/chair/office/light{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/construction)
@@ -852,12 +852,13 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/techfloor,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "ml" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -874,13 +875,9 @@
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "mB" = (
-/obj/structure/ore_box,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/pod/dark,
-/area/ship/cargo)
+/obj/machinery/vending/wardrobe/robo_wardrobe,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/science)
 "mF" = (
 /obj/machinery/airalarm/all_access{
 	dir = 8;
@@ -920,9 +917,6 @@
 /area/ship/engineering/electrical)
 "mX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/construction)
 "ng" = (
@@ -954,16 +948,20 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/hallway/central)
 "nq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/turf/open/floor/eighties,
-/area/ship/crew/canteen)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/science)
 "ny" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -986,6 +984,12 @@
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "nO" = (
@@ -996,17 +1000,14 @@
 	dir = 4
 	},
 /obj/machinery/light/dim,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/eighties,
 /area/ship/crew/canteen)
 "nQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
+	dir = 4
 	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/science)
@@ -1016,11 +1017,17 @@
 	},
 /obj/effect/turf_decal/corner_techfloor_grid,
 /obj/effect/turf_decal/techfloor/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "nU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/deepfryer,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/starboard)
 "nV" = (
@@ -1046,21 +1053,17 @@
 "od" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/science)
 "oh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1069,6 +1072,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/techfloor,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "ol" = (
@@ -1079,6 +1088,10 @@
 /area/ship/crew/dorm)
 "ov" = (
 /obj/effect/turf_decal/techfloor,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/pod/light,
 /area/ship/bridge)
 "oD" = (
@@ -1115,9 +1128,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1132,6 +1143,10 @@
 /mob/living/simple_animal/crab/Coffee,
 /obj/structure/bed/dogbed/runtime{
 	name = "Coffee's bed"
+	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/construction)
@@ -1160,15 +1175,6 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/science)
 "pr" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/closet/crate/bin,
 /turf/open/floor/pod/light,
 /area/ship/crew/dorm)
@@ -1221,7 +1227,10 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
@@ -1248,10 +1257,6 @@
 "qv" = (
 /obj/structure/closet/crate{
 	name = "Custodial Crate"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /obj/item/mop,
 /obj/item/mop,
@@ -1293,7 +1298,6 @@
 /obj/item/radio,
 /obj/item/radio,
 /obj/effect/turf_decal/box,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
 "qE" = (
@@ -1311,9 +1315,6 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
@@ -1323,18 +1324,23 @@
 /turf/open/floor/pod/light,
 /area/ship/bridge)
 "qM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/construction)
 "qN" = (
 /obj/effect/turf_decal/techfloor/orange,
-/obj/structure/closet/crate/bin,
+/obj/machinery/computer/monitor{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/pod/light,
 /area/ship/storage)
 "qR" = (
@@ -1349,23 +1355,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/starboard)
-"rr" = (
-/obj/effect/turf_decal/siding/yellow,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/pod/light,
-/area/ship/cargo)
 "rt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/pod/light,
 /area/ship/science/robotics)
 "rw" = (
@@ -1404,17 +1399,12 @@
 /area/ship/crew/canteen)
 "sc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/pod/light,
 /area/ship/science/robotics)
 "sf" = (
@@ -1443,12 +1433,6 @@
 /turf/open/floor/pod/light,
 /area/ship/hallway/fore)
 "sA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/techfloor{
 	dir = 9
 	},
@@ -1458,6 +1442,7 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 6
 	},
+/obj/structure/frame/machine,
 /turf/open/floor/pod/light,
 /area/ship/storage)
 "sK" = (
@@ -1650,23 +1635,21 @@
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "uR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/pod/light,
 /area/ship/hallway/fore)
 "uU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/closet/secure_closet/freezer/kitchen/wall{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/pod/dark,
-/area/ship/cargo)
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/maintenance/starboard)
 "uV" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -1709,18 +1692,14 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
 	},
+/obj/structure/frame/machine,
+/obj/structure/frame/machine,
 /turf/open/floor/pod/light,
 /area/ship/storage)
 "wx" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/canteen)
 "wA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/pod/light,
 /area/ship/science/robotics)
@@ -1754,14 +1733,11 @@
 /turf/open/floor/pod/light,
 /area/ship/crew/dorm)
 "xh" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/pod/dark,
-/area/ship/cargo)
+/turf/open/floor/plating,
+/area/ship/engineering/electrical)
 "xk" = (
 /obj/structure/frame/machine,
 /obj/item/stock_parts/scanning_module,
@@ -1769,14 +1745,17 @@
 /turf/open/floor/carpet/royalblue,
 /area/ship/construction)
 "xl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/pod/light,
 /area/ship/crew/dorm)
@@ -1787,6 +1766,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/techfloor/orange,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/pod/light,
 /area/ship/storage)
 "xN" = (
@@ -1800,6 +1782,12 @@
 "xS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/siding/yellow,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "xU" = (
@@ -1836,9 +1824,6 @@
 /turf/open/floor/pod/light,
 /area/ship/crew/canteen)
 "yc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -1941,12 +1926,8 @@
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "zg" = (
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine/longrange,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/effect/turf_decal/techfloor{
 	dir = 10
 	},
@@ -1992,6 +1973,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/eighties,
 /area/ship/crew/canteen)
 "zz" = (
@@ -2015,21 +1999,12 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
-"zB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/pod/dark,
-/area/ship/cargo)
 "zG" = (
 /obj/machinery/holopad/emergency/command,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/pod/light,
 /area/ship/bridge)
 "zZ" = (
@@ -2091,11 +2066,13 @@
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "AO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/pod/light,
 /area/ship/hallway/starboard)
 "AX" = (
@@ -2110,8 +2087,9 @@
 /turf/open/floor/pod/light,
 /area/ship/bridge)
 "Ba" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/pod/light,
 /area/ship/hallway/starboard)
 "Bb" = (
@@ -2136,6 +2114,7 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/pod/light,
 /area/ship/storage)
 "Bz" = (
@@ -2145,15 +2124,6 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/starboard)
-"BE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/mono/white,
-/area/ship/science)
 "BJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -2166,12 +2136,6 @@
 	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/science)
-"BO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/pod/dark,
-/area/ship/cargo)
 "BQ" = (
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 1
@@ -2237,10 +2201,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/railing{
 	dir = 8
 	},
@@ -2264,9 +2224,6 @@
 /turf/open/floor/pod/light,
 /area/ship/science/robotics)
 "Df" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
@@ -2274,14 +2231,8 @@
 /area/ship/science)
 "Dh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/techfloor{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
 	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
@@ -2294,9 +2245,6 @@
 /obj/item/circuitboard/machine/public_nanite_chamber,
 /obj/item/survey_handheld,
 /obj/item/survey_handheld,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/science)
 "DH" = (
@@ -2364,11 +2312,12 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/science)
@@ -2395,6 +2344,7 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "EI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/pod/light,
 /area/ship/bridge)
 "EK" = (
@@ -2420,9 +2370,6 @@
 "EW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -2472,6 +2419,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/construction)
 "Fm" = (
@@ -2509,6 +2459,9 @@
 	pixel_x = -24
 	},
 /obj/machinery/space_heater,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/pod/light,
 /area/ship/hallway/starboard)
 "FG" = (
@@ -2518,7 +2471,6 @@
 /turf/open/floor/pod/light,
 /area/ship/science/robotics)
 "FP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/box,
 /obj/structure/closet/crate{
 	name = "Resupply Crate"
@@ -2554,11 +2506,14 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/science)
 "Gt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
 /obj/effect/turf_decal/siding/yellow,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "Gv" = (
@@ -2612,9 +2567,6 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "GY" = (
@@ -2659,12 +2611,7 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 9
 	},
-/turf/open/floor/pod/light,
-/area/ship/storage)
-"HR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
+/obj/item/pipe_dispenser,
 /turf/open/floor/pod/light,
 /area/ship/storage)
 "HU" = (
@@ -2698,6 +2645,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/yellow,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
@@ -2773,19 +2724,6 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
-"IH" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/pod/light,
-/area/ship/cargo)
 "IJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/eighties,
@@ -2814,8 +2752,12 @@
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/pod/light,
 /area/ship/hallway/fore)
@@ -2864,16 +2806,6 @@
 "JQ" = (
 /turf/open/floor/pod/light,
 /area/ship/storage)
-"JW" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/eighties,
-/area/ship/crew/canteen)
 "JY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/reinforced,
@@ -2886,6 +2818,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
@@ -2908,9 +2843,6 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -3013,6 +2945,12 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "Ll" = (
@@ -3031,6 +2969,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/pod/light,
 /area/ship/science/robotics)
 "Lp" = (
@@ -3146,6 +3087,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/computer/helm/viewscreen{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "Mr" = (
@@ -3208,21 +3155,6 @@
 	},
 /turf/open/floor/pod/light,
 /area/ship/hallway/fore)
-"Nt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/mono/white,
-/area/ship/science)
 "Nw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -3242,20 +3174,21 @@
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/pod/light,
 /area/ship/hallway/starboard)
 "Nz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/open/floor/pod/light,
 /area/ship/hallway/fore)
@@ -3270,7 +3203,9 @@
 /turf/open/floor/pod/light,
 /area/ship/hallway/central)
 "NG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "NH" = (
@@ -3292,10 +3227,6 @@
 	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/science)
-"NN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/pod/dark,
-/area/ship/cargo)
 "NO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech/techmaint,
@@ -3320,19 +3251,19 @@
 	dir = 8;
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+	icon_state = "1-2"
 	},
 /turf/open/floor/pod/light,
 /area/ship/crew/dorm)
 "Ok" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Or" = (
@@ -3344,12 +3275,15 @@
 /turf/open/floor/eighties,
 /area/ship/crew/canteen)
 "Ox" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/siding/yellow,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
@@ -3396,15 +3330,15 @@
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "OP" = (
 /turf/closed/wall/mineral/plastitanium/overspace,
 /area/ship/engineering/electrical)
 "Ph" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "Pi" = (
@@ -3426,22 +3360,11 @@
 "Pw" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/toilet)
-"Py" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/pod/light,
-/area/ship/science/robotics)
 "PA" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/dorm)
 "PC" = (
 /obj/machinery/power/apc/auto_name/south,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -3449,14 +3372,8 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
-/turf/open/floor/pod/light,
-/area/ship/cargo)
-"PF" = (
-/turf/template_noop,
-/area/template_noop)
-"PR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -3464,6 +3381,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/turf/open/floor/pod/light,
+/area/ship/cargo)
+"PF" = (
+/turf/template_noop,
+/area/template_noop)
+"PR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/pod/light,
 /area/ship/hallway/fore)
 "PU" = (
@@ -3501,15 +3425,12 @@
 /turf/open/floor/pod/light,
 /area/ship/hallway/fore)
 "Ql" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
 /turf/open/floor/pod/light,
 /area/ship/crew/dorm)
@@ -3593,12 +3514,6 @@
 "Ra" = (
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
-"Rd" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/white,
-/area/ship/science)
 "Rh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -3638,15 +3553,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/science)
 "Rq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/railing{
 	dir = 1
 	},
@@ -3692,14 +3598,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/toilet)
@@ -3709,6 +3615,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/eighties,
 /area/ship/crew/canteen)
@@ -3761,6 +3670,7 @@
 	pixel_y = 24
 	},
 /obj/structure/closet/secure_closet/freezer/fridge/open,
+/obj/item/reagent_containers/food/condiment/enzyme,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/maintenance/starboard)
 "Te" = (
@@ -3768,6 +3678,9 @@
 /obj/item/clothing/gloves/color/latex/nitrile,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/science)
 "Tm" = (
@@ -3786,15 +3699,12 @@
 "Tp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "Tq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -3823,9 +3733,6 @@
 "TC" = (
 /obj/structure/closet/crate{
 	name = "Spare Clothing Crate"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/shoes/jackboots,
@@ -3860,17 +3767,14 @@
 /turf/open/floor/pod/light,
 /area/ship/bridge)
 "TI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/pod/light,
 /area/ship/storage)
@@ -3904,9 +3808,7 @@
 /turf/open/floor/pod/light,
 /area/ship/science/robotics)
 "TU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/chair,
 /turf/open/floor/pod/light,
 /area/ship/storage)
 "TW" = (
@@ -3914,7 +3816,7 @@
 /area/ship/cargo)
 "TZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/science)
@@ -3928,9 +3830,11 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/science)
 "Ug" = (
@@ -3964,38 +3868,33 @@
 	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
-"Uo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/pod/dark,
-/area/ship/cargo)
 "Ur" = (
 /obj/machinery/power/apc/auto_name/east,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/science)
 "UC" = (
-/obj/machinery/computer/monitor,
 /obj/item/radio/intercom{
 	pixel_y = 28
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 5
 	},
+/obj/structure/frame/machine,
 /turf/open/floor/pod/light,
 /area/ship/storage)
 "UG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "UI" = (
@@ -4012,7 +3911,7 @@
 	dir = 6
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/open/floor/eighties,
 /area/ship/crew/canteen)
@@ -4052,28 +3951,17 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/computer/helm/viewscreen{
-	pixel_x = 32;
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
-"VE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel/mono/white,
-/area/ship/science)
 "VL" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "VN" = (
@@ -4086,15 +3974,6 @@
 	},
 /turf/open/floor/eighties,
 /area/ship/crew/canteen)
-"VP" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/pod/dark,
-/area/ship/cargo)
 "VS" = (
 /turf/open/floor/pod/light,
 /area/ship/hallway/fore)
@@ -4145,21 +4024,13 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"WB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/pod/light,
-/area/ship/hallway/fore)
 "WH" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "0-4"
+	},
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
 	},
 /turf/open/floor/pod/light,
 /area/ship/science/robotics)
@@ -4176,9 +4047,7 @@
 /area/ship/crew/canteen)
 "WR" = (
 /obj/effect/turf_decal/box,
-/obj/machinery/atmospherics/components/unary/tank/air{
-	piping_layer = 1
-	},
+/obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "WZ" = (
@@ -4206,12 +4075,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "XE" = (
@@ -4270,33 +4133,22 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering/atmospherics)
 "Yy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/science)
 "YB" = (
 /obj/machinery/power/apc/auto_name/west,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/pod/light,
 /area/ship/hallway/starboard)
 "YF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/pod/light,
 /area/ship/science/robotics)
-"YW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/pod/dark,
-/area/ship/cargo)
 "Zf" = (
 /obj/machinery/button/door{
 	id = "externalbridgeshutter";
@@ -4321,12 +4173,6 @@
 	},
 /turf/open/floor/pod/light,
 /area/ship/bridge)
-"Zk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/pod/dark,
-/area/ship/cargo)
 "Zn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4341,14 +4187,17 @@
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Zq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 6
 	},
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/pod/light,
 /area/ship/cargo)
@@ -4378,6 +4227,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/eighties,
 /area/ship/crew/canteen)
 "ZF" = (
@@ -4400,11 +4252,16 @@
 /obj/machinery/status_display/shuttle{
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/stairs{
 	dir = 4
 	},
@@ -4585,7 +4442,7 @@ EI
 zG
 gm
 Ft
-WB
+Kf
 Jg
 wx
 OI
@@ -4597,7 +4454,7 @@ ID
 Wy
 rY
 LM
-nq
+LM
 zv
 wx
 Yh
@@ -4635,7 +4492,7 @@ rI
 jy
 ij
 RR
-JW
+DR
 RQ
 wx
 tA
@@ -4673,7 +4530,7 @@ Jx
 ij
 ij
 RR
-JW
+DR
 nO
 wx
 SO
@@ -4775,8 +4632,8 @@ aB
 no
 QY
 DL
-ky
-rr
+DY
+Ox
 QZ
 VN
 yP
@@ -4816,9 +4673,9 @@ sP
 Dh
 xS
 VN
-Uo
-NN
-Zk
+VN
+VN
+VN
 VN
 mh
 Vo
@@ -4830,7 +4687,7 @@ FC
 RS
 ZF
 bA
-HR
+JQ
 CB
 RS
 BU
@@ -4851,12 +4708,12 @@ zs
 Gh
 Gh
 Ij
-IH
+DY
 Ox
-mB
-uU
+QZ
+VN
 TC
-VP
+VN
 qv
 oh
 Ny
@@ -4892,9 +4749,9 @@ Ri
 Xe
 Gt
 VN
-BO
 VN
-YW
+VN
+VN
 VN
 bo
 XR
@@ -4930,15 +4787,15 @@ DL
 DY
 Is
 nj
-zB
+VN
 qA
-xh
+VN
 FP
 PC
 eN
 eN
 eN
-dT
+mB
 ed
 dT
 RS
@@ -4949,7 +4806,7 @@ sC
 RS
 Mb
 Ra
-Ra
+xh
 AN
 va
 WZ
@@ -4969,7 +4826,7 @@ DY
 OM
 Ui
 UG
-Ui
+lt
 Zq
 nT
 br
@@ -5004,11 +4861,11 @@ DL
 DL
 tF
 DY
-Is
+ky
 pR
 Ph
 pR
-Is
+ky
 GY
 eN
 eN
@@ -5042,19 +4899,19 @@ Sr
 Sr
 ug
 DY
-Is
+ky
 DO
 Ph
 DO
-Is
+ky
 ep
 eN
 eN
 JA
 Te
 NV
-lt
-Rd
+BJ
+NV
 TZ
 NV
 Qm
@@ -5092,7 +4949,7 @@ iR
 KX
 KX
 Ed
-VE
+NV
 Yy
 NK
 Lg
@@ -5129,15 +4986,15 @@ AE
 du
 NV
 NV
-Nt
-BE
+BJ
+NV
 nQ
 Df
 DB
 tf
 tf
 gQ
-tf
+uU
 zZ
 yA
 hp
@@ -5167,7 +5024,7 @@ Ep
 Gs
 LP
 LP
-AL
+nq
 Ud
 Ur
 Es
@@ -5232,7 +5089,7 @@ mX
 qM
 uE
 Lo
-Py
+Rl
 hd
 jc
 rt


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pipes. Wires. Enzyme. Flour. Empty machine frames. A missing air alarm. An RPD. One less sci-drobe, one more robodrobe. That's it. That's all. Also please stop putting devices under things that take up so much of a tile. A vent underneath a SMES? Really? Oh and one of the air tanks was set to the wrong layer. It's not anymore.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
God I hate the piping on this ship, also cooking is good, now you can do more of it on this ship.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The Scrapper-B has had its piping moved around to be more sensible, as well as receiving some extra cooking supplies and some needed miscellaneous equipment such as a rapid piping device.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
