### PR TITLE
Sends a chat notification to ghosts when ghost roles become available

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -18,6 +18,9 @@
 	Estimated time of last contact: Deployment, 5000 millennia ago."
 	assignedrole = "Lifebringer"
 
+/obj/effect/mob_spawn/human/seed_vault/Initialize(mapload)
+	notify_ghosts("A preserved Terrarium is available", flashwindow = FALSE, notify_suiciders = FALSE)
+
 /obj/effect/mob_spawn/human/seed_vault/special(mob/living/new_spawn)
 	var/plant_name = pick("Tomato", "Potato", "Broccoli", "Carrot", "Ambrosia", "Pumpkin", "Ivy", "Kudzu", "Banana", "Moss", "Flower", "Bloom", "Root", "Bark", "Glowshroom", "Petal", "Leaf", \
 	"Venus", "Sprout","Cocoa", "Strawberry", "Citrus", "Oak", "Cactus", "Pepper", "Juniper")
@@ -183,6 +186,7 @@
 	golems, so that no golem may ever be forced to serve again."
 
 /obj/effect/mob_spawn/human/golem/Initialize(mapload, datum/species/golem/species = null, mob/creator = null)
+	notify_ghosts("A fre golem shell is now available", flashwindow = FALSE, notify_suiciders = FALSE)
 	if(species) //spawners list uses object name to register so this goes before ..()
 		name += " ([initial(species.prefix)])"
 		mob_species = species
@@ -276,6 +280,7 @@
 	assignedrole = "Hermit"
 
 /obj/effect/mob_spawn/human/hermit/Initialize(mapload)
+	notify_ghosts("A malfunctioning cryostasis sleeper is available", flashwindow = FALSE, notify_suiciders = FALSE)
 	. = ..()
 	var/arrpee = rand(1,4)
 	switch(arrpee)
@@ -693,6 +698,10 @@
 	backpack_contents = list(/obj/item/gun/ballistic/automatic/pistol/deagle)
 	assignedrole = "Ancient Crew"
 
+/obj/effect/mob_spawn/human/oldcap/Initialize(mapload)
+	notify_ghosts("An old cryogenics pod has been created", flashwindow = FALSE, notify_suiciders = FALSE)
+	. = ..()
+
 /obj/effect/mob_spawn/human/oldcap/Destroy()
 	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
 	return ..()
@@ -775,6 +784,7 @@
 	assignedrole = "Cybersun Captain"
 
 /obj/effect/mob_spawn/human/syndicatespace/syndicaptain/Initialize(mapload)
+	notify_ghosts("A stranded syndicate ship has spawned", flashwindow = FALSE, notify_suiciders = FALSE)
 	. = ..()
 	var/policy = get_policy(ROLE_SYNDICATE_CYBERSUN_CAPTAIN)
 	if(policy)

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -19,6 +19,7 @@
 	assignedrole = "Lifebringer"
 
 /obj/effect/mob_spawn/human/seed_vault/Initialize(mapload)
+	. = ..()
 	notify_ghosts("A preserved Terrarium is available", flashwindow = FALSE, notify_suiciders = FALSE)
 
 /obj/effect/mob_spawn/human/seed_vault/special(mob/living/new_spawn)

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -186,7 +186,7 @@
 	golems, so that no golem may ever be forced to serve again."
 
 /obj/effect/mob_spawn/human/golem/Initialize(mapload, datum/species/golem/species = null, mob/creator = null)
-	notify_ghosts("A fre golem shell is now available", flashwindow = FALSE, notify_suiciders = FALSE)
+	notify_ghosts("A free golem shell is now available", flashwindow = FALSE, notify_suiciders = FALSE)
 	if(species) //spawners list uses object name to register so this goes before ..()
 		name += " ([initial(species.prefix)])"
 		mob_species = species

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -115,7 +115,6 @@
 	"<span class='warning'><u>If you do not have the regular drone laws, follow your laws to the best of your ability.</u></span>"
 
 /mob/living/simple_animal/drone/Initialize()
-	notify_ghosts("A drone shell has been created", flashwindow = FALSE, ignore_key = POLL_IGNORE_DRONE, notify_suiciders = FALSE)
 	. = ..()
 	GLOB.drones_list += src
 	access_card = new /obj/item/card/id(src)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -115,6 +115,7 @@
 	"<span class='warning'><u>If you do not have the regular drone laws, follow your laws to the best of your ability.</u></span>"
 
 /mob/living/simple_animal/drone/Initialize()
+	notify_ghosts("A drone shell has been created", flashwindow = FALSE, ignore_key = POLL_IGNORE_DRONE, notify_suiciders = FALSE)
 	. = ..()
 	GLOB.drones_list += src
 	access_card = new /obj/item/card/id(src)
@@ -324,4 +325,3 @@
 
 /mob/living/simple_animal/drone/get_bank_account(hand_first)
 	return SSeconomy.get_dep_account(ACCOUNT_CIV)
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ghost roles often go unused on voidcrew simply because ghosts can't know when a new ghost role has been made available. There's no notification, they have to just constantly check the spawner menu. This adds a notification to the initialization of most ghost spawns that occur on voidcrew, ignoring the ones that are packaged with others, such as with delta/charlie/beta station, or whatever that is. I also tried to make the drone send out its notification when the metis spawns, no luck. I cry.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More ghost engagement

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Ghosts will now be notified upon the creation of ghost role spawners
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
