### PR TITLE
Removes the second deep fryer in the Phalanx kitchen

### DIFF
--- a/_maps/shuttles/shiptest/voidcrew/phalanx.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/phalanx.dmm
@@ -497,10 +497,10 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering/electrical)
 "fo" = (
-/obj/machinery/deepfryer,
 /obj/machinery/camera{
 	dir = 5
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/mono/white,
 /area/ship/crew/canteen/kitchen)
 "fs" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I have never used a deep fryer. I do not need two deep fryers. Counter space? I can use that. A second deep fryer? What for?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cooking is fun. Counter space is deluxe.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The Phalanx' second deep fryer has been replaced with a table.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
