### PR TITLE
Slime Rancher Free Vendors and Firing Pins

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_slimerancher.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_slimerancher.dmm
@@ -307,7 +307,11 @@
 /area/ruin/powered/slimerancher)
 "lI" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/vending/hydroseeds,
+/obj/machinery/vending/hydroseeds{
+	default_price = 0;
+	extra_price = 0;
+	fair_market_price = 0
+	},
 /turf/open/floor/plating/grass,
 /area/ruin/powered/slimerancher)
 "lT" = (
@@ -376,7 +380,8 @@
 "oq" = (
 /obj/machinery/vending/dinnerware{
 	default_price = 0;
-	extra_price = 0
+	extra_price = 0;
+	fair_market_price = 0
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -605,7 +610,9 @@
 /turf/closed/wall/r_wall,
 /area/ruin/powered/slimerancher)
 "wa" = (
-/obj/item/gun/energy/temperature,
+/obj/item/gun/energy/temperature{
+	pin = /obj/item/firing_pin
+	},
 /obj/structure/closet/wall/red{
 	name = "Weapons Locker";
 	pixel_y = 32
@@ -1420,7 +1427,8 @@
 "Rs" = (
 /obj/machinery/vending/autodrobe/all_access{
 	default_price = 0;
-	extra_price = 0
+	extra_price = 0;
+	fair_market_price = 0
 	},
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the Hydroseed vendor free and adds a firing pin to the temp gun.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: slime rancher vendor is free and the temp gun has a firing pin.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
