### PR TITLE
Restores Cyanide's vendor placement

### DIFF
--- a/_maps/shuttles/shiptest/voidcrew/cyanide.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/cyanide.dmm
@@ -38,9 +38,6 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/vending/security/marine{
-	all_items_free = 1
-	},
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/security)
 "s" = (
@@ -50,6 +47,10 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/vending/security/marine{
+	all_items_free = 1;
+	pixel_y = 32
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security)


### PR DESCRIPTION
## About The Pull Request
Places the marine vendor on Cyanide in the same place as it was while also restoring its pixel shift.

## Why It's Good For The Game
It was made like this so it would look like it's installed in the wall behind the console while being reachable without having to deconstruct the console.

## Changelog
:cl:
fix: The Cyanide interceptor should now have its vendor actually reachable without having to decon the shuttle console.
/:cl:
