### PR TITLE
Drone Dispenser Experiment

### DIFF
--- a/_maps/shuttles/shiptest/boyardee_b.dmm
+++ b/_maps/shuttles/shiptest/boyardee_b.dmm
@@ -1247,7 +1247,7 @@
 /obj/machinery/droneDispenser{
 	cooldownTime = 6000;
 	desc = "A hefty machine that, when supplied with power, will periodically create a wildcard ingredients box. Does not need to be manually operated.";
-	dispense_type = obj/item/storage/box/ingredients/wildcard;
+	dispense_type = /obj/item/storage/box/ingredients/wildcard;
 	end_create_message = "dispenses a box of ingredients.";
 	glass_cost = 0;
 	maximum_idle = 2;

--- a/_maps/shuttles/shiptest/boyardee_b.dmm
+++ b/_maps/shuttles/shiptest/boyardee_b.dmm
@@ -1238,18 +1238,23 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "yx" = (
-/obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = 5;
-	pixel_y = -2
+/obj/machinery/droneDispenser{
+	cooldownTime = 6000;
+	desc = "A hefty machine that, when supplied with power, will periodically create a wildcard ingredients box. Does not need to be manually operated.";
+	dispense_type = obj/item/storage/box/ingredients/wildcard;
+	end_create_message = "dispenses a box of ingredients.";
+	glass_cost = 0;
+	maximum_idle = 2;
+	metal_cost = 0;
+	name = "Ingredients dispenser";
+	power_used = 10000
 	},
-/obj/item/table_bell,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "yJ" = (
@@ -2173,6 +2178,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/table_bell,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Rm" = (

--- a/_maps/shuttles/shiptest/boyardee_b.dmm
+++ b/_maps/shuttles/shiptest/boyardee_b.dmm
@@ -1246,7 +1246,7 @@
 	},
 /obj/machinery/droneDispenser{
 	cooldownTime = 6000;
-	desc = "A hefty machine that, when supplied with power, will periodically create a wildcard ingredients box. Does not need to be manually operated.";
+	desc = "A hefty machine that, when supplied with power and a tiny amount of metal and glass, will periodically create a wildcard ingredients box. Does not need to be manually operated.";
 	dispense_type = /obj/item/storage/box/ingredients/wildcard;
 	end_create_message = "dispenses a box of ingredients.";
 	glass_cost = 0;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives the boyardee a varedited drone dispenser to dispense wildcard ingredient boxes once every ten minutes. This is an experiment to see if the drone dispenser is as flexible as I think it is, and if it works, I'll be able to play around with it in more ways on more ships.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because if this works as I think it will, I can make a maintenance loot dispenser on the assistant-only ships, as well as other gimmicky things on other ships.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The boyardee-b now has a renamed drone dispenser, serving to create ingredient boxes for the ship, and to test the viability of the machine for this purpose.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
