### PR TITLE
Fixes the syndicate courage class ship

### DIFF
--- a/_maps/shuttles/shiptest/voidcrew/courage.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/courage.dmm
@@ -15,6 +15,9 @@
 	dir = 4
 	},
 /obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/pod/dark,
 /area/ship/crew)
 "bo" = (
@@ -166,15 +169,13 @@
 /turf/open/floor/pod/dark,
 /area/ship/crew)
 "sn" = (
-/obj/machinery/power/apc/syndicate{
-	dir = 8;
-	name = "Syndicate Drop Ship APC";
-	pixel_y = 25
+/obj/structure/table/reinforced,
+/obj/machinery/airalarm/syndicate{
+	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/obj/structure/table/reinforced,
 /turf/open/floor/pod/dark,
 /area/ship/crew)
 "ss" = (
@@ -262,11 +263,16 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "EO" = (
-/obj/machinery/airalarm/syndicate{
-	pixel_y = 24
-	},
 /obj/structure/table/reinforced,
 /obj/item/disk/design_disk/ammo_c9mm,
+/obj/machinery/power/apc/syndicate{
+	dir = 8;
+	name = "Syndicate Drop Ship APC";
+	pixel_y = 25
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/pod/dark,
 /area/ship/crew)
 "Fa" = (
@@ -473,9 +479,6 @@
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 20
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plating,
 /area/ship/crew)
 "PJ" = (
@@ -618,21 +621,6 @@
 	dir = 8;
 	name = "fuel pump"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/crew)
-"ZK" = (
-/obj/effect/turf_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "ZZ" = (
@@ -679,7 +667,7 @@ Tn
 (4,1,1) = {"
 Tn
 sn
-ZK
+ss
 ZJ
 BQ
 ka


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So here's what happened. Round ID 379, the courage class ship spawns in, the APC is behind the SMES, instead of on the tile it's meant to be on. Floor tile under where the APC is meant to be is crowbarred up, terminal is found facing the SMES. Somehow, the terminal thought that it belonged to the SMES, so it pointed itself towards the SMES. The APC, seeing this, put itself on the tile the SMES was on. I don't know what REALLY caused this besides the way maps load, but I can fix it by moving these things apart, so I have. Enjoy. Keep in mind though, the APC WAS receiving power. It was just massively scuffed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is a nightmare and should not happen

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The courage class ship will no longer do strange things with power terminals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
