### PR TITLE
Makes thunderdome and CTF arena noteleport

### DIFF
--- a/code/game/area/areas/centcom.dm
+++ b/code/game/area/areas/centcom.dm
@@ -67,6 +67,7 @@
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
 	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
+	area_flags = NOTELEPORT
 	flags_1 = NONE
 
 /area/tdome/arena
@@ -143,6 +144,7 @@
 	icon_state = "yellow"
 	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
+	area_flags = NOTELEPORT
 	flags_1 = NONE
 
 /area/ctf/control_room


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. CTF has an OP sword that can one-hit-kill pretty much anything. You should not be in the thunderdome. Full stop. You should not be teleporting OUT of the thunderdome. Enough said.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Wiz teleport is broken, this doesn't fix it, it just nerfs it. A lot.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Thunderdome and CTF arena are now noteleport
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
