### PR TITLE
Removes Squid Inking

### DIFF
--- a/voidcrew/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
+++ b/voidcrew/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
@@ -40,7 +40,7 @@
 	var/datum/action/innate/change_color/change_color = new
 	//var/datum/action/cooldown/spit_ink/spit_ink = new
 	change_color.Grant(human)
-	spit_ink.Grant(human)
+	//spit_ink.Grant(human)
 
 /datum/species/squid/on_species_loss(mob/living/carbon/human/human)
 	. = ..()

--- a/voidcrew/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
+++ b/voidcrew/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
@@ -38,7 +38,7 @@
 /datum/species/squid/on_species_gain(mob/living/carbon/human/human, datum/species/old_species)
 	. = ..()
 	var/datum/action/innate/change_color/change_color = new
-	var/datum/action/cooldown/spit_ink/spit_ink = new
+	//var/datum/action/cooldown/spit_ink/spit_ink = new
 	change_color.Grant(human)
 	spit_ink.Grant(human)
 
@@ -72,7 +72,7 @@
 	if(active)
 		return FALSE
 	return ..()
-
+/* 	// Giving a roundstart species slip immunity, and the ability to create slips whenever is dumb
 /datum/action/cooldown/spit_ink
 	name = "Spit Ink"
 	check_flags = AB_CHECK_CONSCIOUS | AB_CHECK_IMMOBILE
@@ -100,7 +100,7 @@
 	else
 		to_chat(carbon_owner, "<span class='warning'>You don't have enough neutrients to create ink, you need to eat!</span>")
 		return
-
+*/
 #define SQUID_SPEEDMOD_GRAV 0.55
 #define SQUID_SPEEDMOD_NO_GRAV 0
 // Zero gravity movement


### PR DESCRIPTION
## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Removes the ink ability from squids pending whenever someone decides to rework it.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I have never seen a squid not ink their entire ship, just to laugh at those that slip on them.

Giving a round start race this ability is stupid.
Has been requested multiple times.
Did I mention they already have 100% slip immunity?