### PR TITLE
Adds voidmelon ruins to the blacklist

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -1,4 +1,4 @@
-// Hey! Listen! Update \config\spaceruinblacklist.txt with your new ruins!
+// Hey! Listen! Update \config\ruins\spaceruinblacklist.txt with your new ruins!
 
 /datum/map_template/ruin/space
 	prefix = "_maps/RandomRuins/SpaceRuins/"
@@ -23,6 +23,38 @@
 	suffix = "excavator_DK.dmm"
 	name = "Excavator DK Class"
 	description = "A heavily damaged DK class excavator"
+
+/datum/map_template/ruin/space/asteroid1
+	id = "asteroid1"
+	suffix = "asteroid1.dmm"
+	name = "Asteroid 1"
+	description = "I-spy with my little eye, something beginning with R."
+
+
+/datum/map_template/ruin/space/asteroid2
+	id = "asteroid2"
+	suffix = "asteroid2.dmm"
+	name = "Asteroid 2"
+	description = "Oh my god, a giant rock!"
+
+/datum/map_template/ruin/space/asteroid3
+	id = "asteroid3"
+	suffix = "asteroid3.dmm"
+	name = "Asteroid 3"
+	description = "This asteroid floating in space has no official designation, because the scientist that discovered it deemed it 'super dull'."
+
+/datum/map_template/ruin/space/asteroid4
+	id = "asteroid4"
+	suffix = "asteroid4.dmm"
+	name = "Asteroid 4"
+	description = "Nanotrasen Escape Pods have a 100%* success rate, and a 99%* customer satisfaction rate. \
+	*Please note that these statistics are taken from pods that have successfully docked with a recovery vessel."
+
+/datum/map_template/ruin/space/asteroid5
+	id = "asteroid5"
+	suffix = "asteroid5.dmm"
+	name = "Asteroid 5"
+	description = "Oh my god, another giant rock!"
 
 /datum/map_template/ruin/space/deep_storage
 	id = "deep-storage"

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -24,38 +24,6 @@
 	name = "Excavator DK Class"
 	description = "A heavily damaged DK class excavator"
 
-/datum/map_template/ruin/space/asteroid1
-	id = "asteroid1"
-	suffix = "asteroid1.dmm"
-	name = "Asteroid 1"
-	description = "I-spy with my little eye, something beginning with R."
-
-
-/datum/map_template/ruin/space/asteroid2
-	id = "asteroid2"
-	suffix = "asteroid2.dmm"
-	name = "Asteroid 2"
-	description = "Oh my god, a giant rock!"
-
-/datum/map_template/ruin/space/asteroid3
-	id = "asteroid3"
-	suffix = "asteroid3.dmm"
-	name = "Asteroid 3"
-	description = "This asteroid floating in space has no official designation, because the scientist that discovered it deemed it 'super dull'."
-
-/datum/map_template/ruin/space/asteroid4
-	id = "asteroid4"
-	suffix = "asteroid4.dmm"
-	name = "Asteroid 4"
-	description = "Nanotrasen Escape Pods have a 100%* success rate, and a 99%* customer satisfaction rate. \
-	*Please note that these statistics are taken from pods that have successfully docked with a recovery vessel."
-
-/datum/map_template/ruin/space/asteroid5
-	id = "asteroid5"
-	suffix = "asteroid5.dmm"
-	name = "Asteroid 5"
-	description = "Oh my god, another giant rock!"
-
 /datum/map_template/ruin/space/deep_storage
 	id = "deep-storage"
 	suffix = "deepstorage.dmm"

--- a/config/ruins/spaceruinblacklist.txt
+++ b/config/ruins/spaceruinblacklist.txt
@@ -5,11 +5,11 @@
 
 #_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
 #_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
-#_maps/RandomRuins/SpaceRuins/asteroid1.dmm
-#_maps/RandomRuins/SpaceRuins/asteroid2.dmm
-#_maps/RandomRuins/SpaceRuins/asteroid3.dmm
-#_maps/RandomRuins/SpaceRuins/asteroid4.dmm
-#_maps/RandomRuins/SpaceRuins/asteroid5.dmm
+_maps/RandomRuins/SpaceRuins/asteroid1.dmm
+_maps/RandomRuins/SpaceRuins/asteroid2.dmm
+_maps/RandomRuins/SpaceRuins/asteroid3.dmm
+_maps/RandomRuins/SpaceRuins/asteroid4.dmm
+_maps/RandomRuins/SpaceRuins/asteroid5.dmm
 #_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
 #_maps/RandomRuins/SpaceRuins/bus.dmm
 #_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -52,4 +52,3 @@
 #_maps/RandomRuins/SpaceRuins/whiteshipdock.dmm
 #_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
 #_maps/RandomRuins/SpaceRuins/forgottenship.dmm
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nobody likes these. Everyone immediately turns around and leaves. If you want mining, you'd land on an asteroid. No I have not tested this. Now on the blacklist instead of removed from the config. As a side benefit, I updated the comment on where the blacklist is, because it was wrong. It isn't wrong anymore.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nobody likes them. This'll "increase" chances for other space ruins.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed the voidmelon asteroids from the spawn chances. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
