### PR TITLE
Replaces the stairs in the imperial church with floor stairs

### DIFF
--- a/_maps/RandomRuins/IceRuins/imperialchurch.dmm
+++ b/_maps/RandomRuins/IceRuins/imperialchurch.dmm
@@ -449,12 +449,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/icemoon)
-"AJ" = (
-/obj/structure/stairs,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/icemoon)
 "AX" = (
 /obj/structure/mineral_door/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -651,8 +645,9 @@
 /turf/open/floor/carpet/red,
 /area/icemoon)
 "NK" = (
-/obj/structure/stairs,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/stairs{
+	dir = 1
+	},
 /area/icemoon)
 "Oi" = (
 /obj/structure/chair/pew{
@@ -769,10 +764,10 @@
 /turf/open/floor/plating/snowed,
 /area/icemoon)
 "Wi" = (
-/obj/structure/stairs,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/snow,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/stairs{
+	dir = 1
+	},
 /area/icemoon)
 "Wl" = (
 /mob/living/simple_animal/hostile/guardian/gravitokinetic,
@@ -1257,7 +1252,7 @@ KD
 AI
 Vv
 NK
-AJ
+NK
 cE
 Nz
 sj


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
obj/structure/stairs versus turf/open/floor/plasteel/stairs. The game wants to make you change Z-levels with "normal" stairs. Obviously that ain't happening, so you can't cross the stairs in these spots. So this just... replaces them. Yep. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The stairs in the imperial church ruin have been replaced with stairs that will not block your passage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
