### PR TITLE
Makes the "oldstation" dinnerware vendor free

### DIFF
--- a/voidcrew/_maps/RandomRuins/IceRuins/icemoon_underground_oldstation.dmm
+++ b/voidcrew/_maps/RandomRuins/IceRuins/icemoon_underground_oldstation.dmm
@@ -567,8 +567,7 @@
 "bH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor/border_only/closed{
-	dir = 8;
-	icon_state = "door_closed"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -1302,8 +1301,7 @@
 	},
 /obj/machinery/door/firedoor/border_only/closed,
 /obj/machinery/door/firedoor/border_only/closed{
-	dir = 1;
-	icon_state = "door_closed"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/rnd)
@@ -2604,9 +2602,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "gt" = (
@@ -2652,9 +2648,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "gw" = (
@@ -3037,13 +3031,13 @@
 /area/ruin/space/has_grav/ancientstation)
 "hr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/dinnerware,
+/obj/machinery/vending/dinnerware{
+	all_items_free = 1
+	},
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "hs" = (
@@ -3052,9 +3046,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "ht" = (
@@ -3062,9 +3054,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "hu" = (
@@ -3075,9 +3065,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "hv" = (
@@ -3109,9 +3097,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "hy" = (
@@ -3124,9 +3110,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "hz" = (
@@ -3242,8 +3226,7 @@
 "hJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor/border_only/closed{
-	dir = 8;
-	icon_state = "door_closed"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -3352,9 +3335,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "hU" = (
@@ -3368,9 +3349,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "hV" = (
@@ -3380,9 +3359,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "hW" = (
@@ -3561,9 +3538,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "ij" = (
@@ -3907,9 +3882,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "iI" = (
@@ -3926,9 +3899,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "iJ" = (
@@ -3939,9 +3910,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "iK" = (
@@ -3952,9 +3921,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "iL" = (
@@ -3964,9 +3931,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "iM" = (
@@ -3977,9 +3942,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "iN" = (
@@ -3993,9 +3956,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "iO" = (
@@ -4761,8 +4722,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor/border_only/closed,
 /obj/machinery/door/firedoor/border_only/closed{
-	dir = 1;
-	icon_state = "door_closed"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/rnd)
@@ -5240,18 +5200,14 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "ly" = (
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "lz" = (
@@ -6567,8 +6523,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor/border_only/closed{
-	dir = 1;
-	icon_state = "door_closed"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only/closed,
 /turf/open/floor/plasteel,
@@ -6579,8 +6534,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/firedoor/border_only/closed{
-	dir = 1;
-	icon_state = "door_closed"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only/closed,
 /turf/open/floor/plasteel,
@@ -7113,9 +7067,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "qf" = (
@@ -7199,9 +7151,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "qJ" = (
@@ -7287,9 +7237,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "tz" = (
@@ -7416,9 +7364,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "vv" = (
@@ -7788,9 +7734,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "Cs" = (
@@ -7905,9 +7849,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "EV" = (
@@ -8183,8 +8125,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only/closed{
-	dir = 8;
-	icon_state = "door_closed"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only/closed{
 	dir = 4
@@ -8264,9 +8205,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "MI" = (
@@ -8651,9 +8590,7 @@
 /obj/effect/turf_decal/corner/white{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 2
-	},
+/obj/effect/turf_decal/corner/white,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "SI" = (
@@ -8800,8 +8737,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor/border_only/closed{
-	dir = 8;
-	icon_state = "door_closed"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only/closed{
 	dir = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I'm fairly certain ghost spawns don't get accounts, and I just watched them unsuccessfully try to purchase stuff, so... free vendor.

Oh and strongdmm cleaning default vars. That too.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Why does it exist if not to be used?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The oldstation dinnerware vendor is now free.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
