### PR TITLE
Properly adds an agelimit wire to vendors

### DIFF
--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -5,7 +5,7 @@
 /datum/wires/vending/New(atom/holder)
 	wires = list(
 		WIRE_THROW, WIRE_SHOCK, WIRE_SPEAKER,
-		WIRE_CONTRABAND, WIRE_IDSCAN
+		WIRE_CONTRABAND, WIRE_IDSCAN, WIRE_AGELIMIT
 	)
 	add_duds(1)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This will allow hacking a vendor to disable the age limit. It already had a pulse action, I'm not sure why the wire itself didn't exist.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: You can now hack vendors to disable the age wire, finally allowing you to buy cigarettes while underage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
