### PR TITLE
Gives the Box hospital basic mining, swaps decals

### DIFF
--- a/_maps/shuttles/shiptest/box.dmm
+++ b/_maps/shuttles/shiptest/box.dmm
@@ -102,13 +102,6 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering)
 "au" = (
-/obj/effect/turf_decal/corner/neutral,
-/obj/effect/turf_decal/corner/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/neutral{
-	dir = 8
-	},
 /obj/structure/closet/secure_closet/medical3{
 	anchored = 1
 	},
@@ -120,6 +113,7 @@
 	dir = 8;
 	pixel_x = -26
 	},
+/obj/effect/turf_decal/corner/neutral/three_quarters,
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "aw" = (
@@ -182,13 +176,6 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/cargo)
 "aH" = (
-/obj/effect/turf_decal/corner/neutral,
-/obj/effect/turf_decal/corner/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/neutral{
-	dir = 8
-	},
 /obj/structure/closet/secure_closet{
 	icon_state = "med";
 	name = "medicine locker"
@@ -198,6 +185,7 @@
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/corner/neutral/three_quarters,
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "aI" = (
@@ -629,14 +617,8 @@
 /obj/machinery/computer/crew{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
+/obj/effect/turf_decal/corner/blue/three_quarters{
 	dir = 4
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
@@ -857,11 +839,7 @@
 	dir = 4
 	},
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/corner/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/neutral,
-/obj/effect/turf_decal/corner/neutral{
+/obj/effect/turf_decal/corner/neutral/three_quarters{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -905,15 +883,11 @@
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "co" = (
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
 /obj/machinery/computer/helm{
 	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue/three_quarters{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
@@ -1247,12 +1221,8 @@
 /turf/open/floor/wood,
 /area/ship/crew)
 "cW" = (
-/obj/effect/turf_decal/corner/neutral{
+/obj/effect/turf_decal/corner/neutral/three_quarters{
 	dir = 1
-	},
-/obj/effect/turf_decal/corner/neutral,
-/obj/effect/turf_decal/corner/neutral{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
@@ -1301,14 +1271,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue/diagonal{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/crew)
@@ -1437,10 +1404,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
+/obj/effect/turf_decal/corner/blue/diagonal{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -1649,19 +1613,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "nC" = (
-/obj/effect/turf_decal/corner/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/neutral{
-	dir = 8
-	},
 /obj/machinery/iv_drip,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/effect/turf_decal/corner/neutral/three_quarters{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
@@ -1946,16 +1904,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
-"Ht" = (
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/blue,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
 "Jf" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
@@ -1967,13 +1915,7 @@
 /turf/open/floor/plasteel/white,
 /area/ship/cargo)
 "Jq" = (
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/corner/blue/three_quarters,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "Lt" = (
@@ -1981,14 +1923,8 @@
 	dir = 4
 	},
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/corner/neutral{
+/obj/effect/turf_decal/corner/neutral/three_quarters{
 	dir = 4
-	},
-/obj/effect/turf_decal/corner/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/neutral{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
@@ -2109,6 +2045,13 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/light/small,
+/obj/item/pickaxe,
+/obj/item/storage/bag/ore,
+/obj/item/mining_scanner,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/structure/closet/crate,
+/obj/item/circuitboard/machine/ore_redemption,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "UN" = (
@@ -2149,21 +2092,14 @@
 /turf/open/floor/plating,
 /area/ship/bridge)
 "Ye" = (
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
+/obj/effect/turf_decal/corner/blue/three_quarters{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "Yj" = (
 /obj/machinery/door/window/eastleft,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
+/obj/effect/turf_decal/corner/blue/diagonal{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -2534,7 +2470,7 @@ Jf
 OA
 bX
 cQ
-Ht
+Ye
 qX
 bT
 xP


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
They start with no materials, no mining tools. This might not be an issue on any other server where folks might cooperate, but here? Nah. Also I saw that there were fulltile decals so I realized there's probably others like that, so I swapped out a few diagonal/three individual quarters decals for the special decals, since other servers sometimes make a big deal about decal count and it hurts nothing.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
mining

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The Box class ship now has basic mining gear and starting materials.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
