### PR TITLE
Really small fix to an  apc in icemoon engi

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
@@ -601,6 +601,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
 /turf/open/floor/plasteel/icemoon,
 /area/icemoon/surface/outdoors)
 "by" = (


### PR DESCRIPTION
The apc did not have a connecter to the grid

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix APC connecter so  there's  no unnecessary time wasted for a player fixing it

## Why It's Good For The Game

Why would it not be I don't want to rebuild a whole APC because someone forgot the connecter.

## Changelog
:cl:
add: Added **_Brand new connector for all your power needs!_**
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
