### PR TITLE
Cleans up decals on carina, cricket, and delta

### DIFF
--- a/_maps/shuttles/shiptest/carina.dmm
+++ b/_maps/shuttles/shiptest/carina.dmm
@@ -555,13 +555,7 @@
 /obj/machinery/navbeacon/wayfinding/med{
 	name = "navigation beacon"
 	},
-/obj/effect/turf_decal/corner/green{
-	dir = 6
-	},
-/obj/effect/turf_decal/corner/green,
-/obj/effect/turf_decal/corner/green{
-	dir = 8
-	},
+/obj/effect/turf_decal/corner/green/three_quarters,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "kJ" = (

--- a/_maps/shuttles/shiptest/cricket.dmm
+++ b/_maps/shuttles/shiptest/cricket.dmm
@@ -246,10 +246,7 @@
 /area/ship/hallway/aft)
 "cB" = (
 /obj/effect/decal/cleanable/food/egg_smudge,
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "cQ" = (
@@ -497,14 +494,10 @@
 /turf/template_noop,
 /area/ship/external)
 "fG" = (
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/bar/diagonal{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "fI" = (
 /obj/structure/cable{
@@ -589,10 +582,7 @@
 "gN" = (
 /obj/structure/fluff/paper,
 /obj/effect/spawner/lootdrop/crate_spawner,
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "gO" = (
@@ -625,14 +615,10 @@
 "gX" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/bar/diagonal{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "hb" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1256,14 +1242,10 @@
 /obj/item/reagent_containers/glass/rag,
 /obj/item/reagent_containers/food/condiment/enzyme,
 /obj/item/kitchen/knife,
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/bar/diagonal{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "oy" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -1416,14 +1398,10 @@
 "qG" = (
 /obj/structure/table,
 /obj/machinery/microwave,
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/bar/diagonal{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "qL" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -1945,14 +1923,10 @@
 	dir = 1;
 	network = list("cricket")
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/bar/diagonal{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "xU" = (
 /obj/structure/curtain/bounty,
@@ -2030,10 +2004,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "yX" = (
@@ -2231,10 +2202,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "AB" = (
@@ -2375,14 +2343,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/bar/diagonal{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "BJ" = (
 /turf/open/floor/engine/air,
@@ -2542,14 +2506,10 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/bar/diagonal{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "Da" = (
 /obj/machinery/airalarm/server{
@@ -2640,10 +2600,7 @@
 "DQ" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "DR" = (
@@ -2666,10 +2623,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "Ej" = (
@@ -2878,10 +2832,7 @@
 /obj/item/cigbutt/cigarbutt,
 /obj/item/toy/plush/snakeplushie,
 /obj/effect/spawner/lootdrop/maintenance/two,
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "GK" = (
@@ -2943,19 +2894,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "Hu" = (
 /obj/machinery/iv_drip,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "Hy" = (
@@ -2991,14 +2936,10 @@
 /area/ship/hallway/starboard)
 "HB" = (
 /obj/machinery/vending/boozeomat/all_access,
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/bar/diagonal{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "HE" = (
 /obj/structure/cable{
@@ -3233,10 +3174,7 @@
 /obj/structure/closet/crate/engineering,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "KL" = (
@@ -3312,14 +3250,10 @@
 	pixel_y = 24
 	},
 /obj/machinery/gibber,
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/bar/diagonal{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "LR" = (
 /obj/machinery/power/apc/auto_name/east,
@@ -3330,14 +3264,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/bar/diagonal{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "LV" = (
 /obj/structure/sign/departments/cargo{
@@ -3375,14 +3305,10 @@
 "Mq" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/bar/diagonal{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "Mu" = (
 /obj/structure/cable{
@@ -3726,10 +3652,7 @@
 /obj/item/clothing/suit/space/eva,
 /obj/item/clothing/head/helmet/space/eva,
 /obj/item/tank/internals/generic,
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "QU" = (
@@ -3744,10 +3667,7 @@
 /obj/item/circuitboard/machine/protolathe,
 /obj/item/circuitboard/machine/rad_collector,
 /obj/item/circuitboard/machine/hydroponics,
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "QZ" = (
@@ -3806,14 +3726,10 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/rice,
 /obj/item/reagent_containers/food/condiment/rice,
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/bar/diagonal{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "RZ" = (
 /obj/structure/cable{
@@ -3859,10 +3775,7 @@
 /obj/item/clothing/neck/cloak/qm,
 /obj/effect/spawner/lootdrop/maintenance/eight,
 /obj/item/storage/bag/trash,
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "SJ" = (
@@ -3881,10 +3794,7 @@
 /obj/item/reagent_containers/food/snacks/meat/slab,
 /obj/item/storage/box/ingredients/vegetarian,
 /obj/item/storage/cans/sixsoda,
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "Tg" = (
@@ -3895,10 +3805,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "Ti" = (
@@ -3951,14 +3858,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/bar/diagonal{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "TW" = (
 /obj/machinery/power/apc/auto_name/west,
@@ -4088,14 +3991,10 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/bar/diagonal{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "VJ" = (
 /obj/structure/rack,
@@ -4209,10 +4108,7 @@
 /obj/item/reagent_containers/blood/random,
 /obj/item/reagent_containers/blood/random,
 /obj/item/roller,
-/obj/effect/turf_decal/corner/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/black,
+/obj/effect/turf_decal/corner/black/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "WY" = (
@@ -4441,14 +4337,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/bar/diagonal{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "ZP" = (
 /obj/structure/cable{

--- a/_maps/shuttles/shiptest/delta.dmm
+++ b/_maps/shuttles/shiptest/delta.dmm
@@ -137,10 +137,7 @@
 "aq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "ar" = (
@@ -154,21 +151,15 @@
 	pixel_x = 7;
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "as" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "at" = (
@@ -202,10 +193,7 @@
 	pixel_y = 24
 	},
 /obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "aw" = (
@@ -325,11 +313,8 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
 /obj/machinery/power/apc/auto_name/west,
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "aI" = (
@@ -338,10 +323,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "aJ" = (
@@ -365,10 +347,7 @@
 	desc = "They look like human remains, and have clearly been gnawed at."
 	},
 /obj/effect/decal/cleanable/blood/gibs/old,
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "aL" = (
@@ -618,30 +597,24 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "bc" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "bd" = (
@@ -658,13 +631,10 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "bg" = (
@@ -757,16 +727,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew)
@@ -791,13 +760,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/recharger,
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
 /obj/item/gun/energy/e_gun/mini,
 /obj/machinery/light/small/built{
 	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
@@ -816,22 +784,18 @@
 	desc = "A badge on the arm indicates that it's meant to be worn by CentCom recovery teams. This one seems dusty and clearly hasn't been cleaned in some time.";
 	name = "\improper dusty old CentCom jumpsuit"
 	},
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew)
 "bu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair,
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "bv" = (
@@ -863,10 +827,7 @@
 /area/ship/crew)
 "bx" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "by" = (
@@ -911,14 +872,8 @@
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
+/obj/effect/turf_decal/corner/blue/three_quarters{
 	dir = 4
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
@@ -978,20 +933,14 @@
 	dir = 8
 	},
 /obj/structure/chair,
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "bJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
 /obj/machinery/microwave,
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "bK" = (
@@ -1008,20 +957,14 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "bL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "bN" = (
@@ -1105,12 +1048,11 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
 /obj/item/areaeditor/shuttle,
 /obj/machinery/light/small/built,
+/obj/effect/turf_decal/corner/blue{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "bV" = (
@@ -1164,15 +1106,12 @@
 /obj/item/pen{
 	pixel_x = -4
 	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
 /obj/item/radio/intercom/wideband{
 	pixel_x = -16;
 	pixel_y = 28
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
@@ -1222,18 +1161,15 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /obj/item/circuitboard/machine/rdserver,
 /obj/item/camera,
+/obj/effect/turf_decal/corner/blue{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "cg" = (
@@ -1343,10 +1279,7 @@
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
@@ -1470,10 +1403,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/beer,
 /obj/item/reagent_containers/food/snacks/sandwich,
-/obj/effect/turf_decal/corner/bar,
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "cx" = (
@@ -1670,15 +1600,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
@@ -1925,14 +1852,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white{
+/obj/effect/turf_decal/corner/white/three_quarters{
 	dir = 4
-	},
-/obj/effect/turf_decal/corner/white{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
@@ -1948,10 +1869,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
@@ -1969,10 +1887,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
@@ -2041,12 +1956,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
-/obj/effect/turf_decal/corner/white{
-	dir = 4
+/obj/effect/turf_decal/corner/white/three_quarters{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
@@ -2136,31 +2047,7 @@
 /area/ship/cargo)
 "dw" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/neutral,
-/obj/effect/turf_decal/corner/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ship/cargo)
-"dx" = (
-/obj/effect/turf_decal/corner/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/neutral,
-/obj/effect/turf_decal/corner/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ship/cargo)
 "dy" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -2225,9 +2112,8 @@
 	req_access = null
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/white{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
@@ -2261,23 +2147,17 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
 "dI" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
 /obj/machinery/computer/helm{
 	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
@@ -2336,15 +2216,11 @@
 /area/ship/engineering)
 "dO" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
 /obj/machinery/computer/autopilot{
 	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue/three_quarters{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
@@ -2417,17 +2293,7 @@
 	dir = 4
 	},
 /obj/item/shard,
-/obj/effect/turf_decal/corner/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/neutral,
-/obj/effect/turf_decal/corner/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white,
 /area/ship/cargo)
 "dW" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2485,10 +2351,7 @@
 /obj/item/defibrillator,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
@@ -2815,9 +2678,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/white{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
@@ -2975,9 +2837,8 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/white,
 /obj/effect/turf_decal/corner/white{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
@@ -3499,7 +3360,7 @@ aa
 GM
 dK
 dK
-dx
+dw
 fM
 ea
 Mc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If it was three individual decals of one color on a tile? three-quarters decal. Four of a decal? Swapped for a full tile. Two individual halves? Also swapped. Decal count lower, changes nothing other than file size/mapping convenience.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Does "not bad" count?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Carina, Cricket, and Delta model ships have had some of their decals swapped for combined versions, to no functional difference.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
