### PR TITLE
Cleans up decals on Twinkleshine, Courage, Midway

### DIFF
--- a/_maps/shuttles/shiptest/twinkleshine.dmm
+++ b/_maps/shuttles/shiptest/twinkleshine.dmm
@@ -1,9 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
+/obj/effect/turf_decal/corner/white/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "ah" = (
@@ -1788,10 +1785,7 @@
 /turf/open/floor/plating/airless,
 /area/ship/external)
 "qD" = (
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/bar,
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "qE" = (
@@ -1851,14 +1845,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ri" = (
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/bar,
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "rj" = (
@@ -2023,10 +2014,7 @@
 /area/ship/engineering)
 "sj" = (
 /obj/machinery/deepfryer,
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
+/obj/effect/turf_decal/corner/white/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "st" = (
@@ -2242,10 +2230,7 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/sugar,
 /obj/item/reagent_containers/food/condiment/rice,
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
+/obj/effect/turf_decal/corner/white/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "uh" = (
@@ -2433,10 +2418,7 @@
 "vQ" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
+/obj/effect/turf_decal/corner/white/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "vX" = (
@@ -2934,15 +2916,12 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical/surgery)
 "Aq" = (
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
 /obj/machinery/button/door{
 	id = "syndikitchen";
 	pixel_x = -23;
 	pixel_y = 23
 	},
+/obj/effect/turf_decal/corner/white/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "As" = (
@@ -3102,11 +3081,8 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/dorm)
 "BR" = (
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/bar,
 /obj/machinery/vending/cigarette/syndicate,
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "BX" = (
@@ -3463,15 +3439,12 @@
 /turf/open/floor/engine/plasma,
 /area/ship/engineering/atmospherics)
 "FN" = (
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/bar,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 26
 	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "FW" = (
@@ -3489,10 +3462,7 @@
 "FY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
+/obj/effect/turf_decal/corner/white/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Ge" = (
@@ -3729,10 +3699,6 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering/engine)
 "Ie" = (
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/bar,
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -3740,6 +3706,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "If" = (
@@ -3852,12 +3819,9 @@
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Jg" = (
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/bar,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Jh" = (
@@ -4156,10 +4120,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/enzyme,
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
+/obj/effect/turf_decal/corner/white/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Me" = (
@@ -4369,10 +4330,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
+/obj/effect/turf_decal/corner/white/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "NZ" = (
@@ -4735,16 +4693,13 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew/dorm)
 "QM" = (
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/bar,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "QN" = (
@@ -4771,16 +4726,13 @@
 /turf/open/floor/engine,
 /area/ship/engineering)
 "QR" = (
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/bar,
 /obj/structure/sign/departments/restroom{
 	pixel_y = 32
 	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Rp" = (
@@ -5087,14 +5039,11 @@
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/crew/dorm)
 "Tr" = (
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/bar,
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Tx" = (
@@ -5127,10 +5076,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
+/obj/effect/turf_decal/corner/white/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "TT" = (
@@ -5329,12 +5275,9 @@
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/bridge)
 "Wd" = (
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/bar,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "We" = (
@@ -5566,16 +5509,13 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/dorm)
 "XD" = (
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/bar,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "XK" = (
@@ -5613,13 +5553,10 @@
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "Yj" = (
-/obj/effect/turf_decal/corner/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/bar,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/turf_decal/corner/bar/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Yp" = (
@@ -5712,10 +5649,7 @@
 	dir = 8;
 	req_one_access_txt = "150"
 	},
-/obj/effect/turf_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/white,
+/obj/effect/turf_decal/corner/white/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "YZ" = (

--- a/_maps/shuttles/shiptest/voidcrew/courage.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/courage.dmm
@@ -86,30 +86,17 @@
 /turf/open/floor/plating,
 /area/ship/crew)
 "hN" = (
-/obj/effect/turf_decal/corner/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/red,
-/obj/effect/turf_decal/corner/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 1
+/obj/effect/turf_decal/corner/red/three_quarters{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "je" = (
-/obj/effect/turf_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 8
-	},
 /obj/machinery/computer/autopilot{
 	dir = 8
+	},
+/obj/effect/turf_decal/corner/red/three_quarters{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
@@ -148,13 +135,7 @@
 /turf/open/floor/pod/dark,
 /area/ship/crew)
 "rD" = (
-/obj/effect/turf_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/red{
+/obj/effect/turf_decal/corner/red/three_quarters{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -180,10 +161,7 @@
 /area/ship/crew)
 "ss" = (
 /obj/effect/turf_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
@@ -220,17 +198,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "Bp" = (
-/obj/effect/turf_decal/corner/red,
-/obj/effect/turf_decal/corner/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/effect/turf_decal/corner/red{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "BQ" = (
-/obj/effect/turf_decal/corner/red,
 /obj/effect/turf_decal/corner/red{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
@@ -304,12 +280,8 @@
 "FM" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/flash/handheld,
-/obj/effect/turf_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/red,
-/obj/effect/turf_decal/corner/red{
-	dir = 4
+/obj/effect/turf_decal/corner/red/three_quarters{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
@@ -337,14 +309,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "HB" = (
-/obj/effect/turf_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 8
-	},
 /obj/machinery/computer/helm{
 	dir = 8
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
@@ -365,13 +334,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/red,
-/obj/effect/turf_decal/corner/red{
-	dir = 8
-	},
 /obj/machinery/microwave,
 /obj/effect/spawner/lootdrop/donkpockets,
 /obj/effect/spawner/lootdrop/donkpockets,
@@ -379,13 +341,7 @@
 /obj/effect/spawner/lootdrop/donkpockets,
 /obj/effect/spawner/lootdrop/donkpockets,
 /obj/effect/spawner/lootdrop/donkpockets,
-/turf/open/floor/plasteel/dark,
-/area/ship/crew)
-"Ij" = (
-/obj/effect/turf_decal/corner/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/red{
+/obj/effect/turf_decal/corner/red/three_quarters{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -439,14 +395,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew)
 "Pg" = (
-/obj/effect/turf_decal/corner/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/red,
-/obj/effect/turf_decal/corner/red,
-/obj/effect/turf_decal/corner/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/corner/red/three_quarters,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "Pt" = (
@@ -506,15 +455,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "RB" = (
-/obj/effect/turf_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/red,
-/obj/effect/turf_decal/corner/red{
-	dir = 8
-	},
 /obj/machinery/photocopier/faxmachine/longrange,
 /obj/structure/table/reinforced,
+/obj/effect/turf_decal/corner/red/three_quarters{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "Sl" = (
@@ -544,35 +489,23 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 8
-	},
 /obj/item/ammo_box/a357,
 /obj/item/ammo_box/a357,
 /obj/item/ammo_box/a357,
 /obj/item/card/emag,
 /obj/item/areaeditor/shuttle,
+/obj/effect/turf_decal/corner/red/three_quarters{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "Wr" = (
-/obj/effect/turf_decal/corner/red,
-/obj/effect/turf_decal/corner/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 8
-	},
 /obj/machinery/suit_storage_unit/syndicate{
 	name = "captain's suit storage unit";
 	storage_type = /obj/item/clothing/shoes/magboots/syndie;
 	suit_type = /obj/item/clothing/suit/space/hardsuit/syndi/elite
 	},
+/obj/effect/turf_decal/corner/red/three_quarters,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "YU" = (
@@ -624,15 +557,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "ZZ" = (
-/obj/effect/turf_decal/corner/red{
+/obj/effect/turf_decal/corner/red/three_quarters{
 	dir = 1
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/red,
-/obj/effect/turf_decal/corner/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
@@ -748,7 +674,7 @@ Tn
 (13,1,1) = {"
 rU
 ns
-Ij
+ss
 Dx
 BQ
 vw
@@ -757,7 +683,7 @@ rU
 (14,1,1) = {"
 rU
 ns
-Ij
+ss
 Dx
 BQ
 PJ

--- a/_maps/shuttles/shiptest/voidcrew/midway.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/midway.dmm
@@ -35,11 +35,10 @@
 /turf/open/floor/engine/vacuum,
 /area/ship/engineering/atmospherics)
 "aR" = (
-/obj/effect/turf_decal/corner/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/brown,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/corner/brown{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "bb" = (
@@ -74,14 +73,11 @@
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "bF" = (
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
@@ -120,28 +116,18 @@
 /turf/open/floor/engine/vacuum,
 /area/ship/engineering/atmospherics)
 "cW" = (
-/obj/effect/turf_decal/corner/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/brown{
+/obj/machinery/suit_storage_unit/mining/eva,
+/obj/effect/turf_decal/corner/brown/three_quarters{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "do" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/corner/green,
-/obj/effect/turf_decal/corner/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/green{
+/obj/machinery/light,
+/obj/effect/turf_decal/corner/green/three_quarters{
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/ship/crew)
 "dK" = (
@@ -180,14 +166,10 @@
 /area/ship/engineering)
 "eY" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/brown,
 /obj/machinery/suit_storage_unit/mining/eva,
+/obj/effect/turf_decal/corner/brown/three_quarters{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "fs" = (
@@ -411,18 +393,14 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/cargo)
 "lc" = (
-/obj/effect/turf_decal/corner/brown,
-/obj/effect/turf_decal/corner/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/brown{
-	dir = 1
-	},
 /obj/machinery/autolathe,
 /obj/item/stack/sheet/glass{
 	amount = 10
 	},
 /obj/item/stack/sheet/metal/twenty,
+/obj/effect/turf_decal/corner/brown/three_quarters{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "ls" = (
@@ -516,10 +494,7 @@
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/ship/bridge)
@@ -536,14 +511,8 @@
 "oB" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
-/obj/effect/turf_decal/corner/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/green,
-/obj/effect/turf_decal/corner/green{
-	dir = 8
-	},
 /obj/machinery/light,
+/obj/effect/turf_decal/corner/green/three_quarters,
 /turf/open/floor/plasteel,
 /area/ship/crew)
 "oC" = (
@@ -576,19 +545,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/turf_decal/corner/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/brown{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "pv" = (
 /obj/effect/turf_decal/corner/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/brown{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
@@ -690,22 +653,18 @@
 /turf/open/floor/plasteel,
 /area/ship/bridge)
 "rC" = (
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
 /obj/structure/closet/secure_closet/captains,
+/obj/effect/turf_decal/corner/blue{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/ship/bridge)
 "sa" = (
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
@@ -900,20 +859,13 @@
 /area/ship/hallway/central)
 "xX" = (
 /obj/effect/turf_decal/corner/brown{
-	dir = 8
+	dir = 10
 	},
-/obj/effect/turf_decal/corner/brown,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "ya" = (
 /obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/corner/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/brown,
-/obj/effect/turf_decal/corner/brown{
-	dir = 8
-	},
+/obj/effect/turf_decal/corner/brown/three_quarters,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "ym" = (
@@ -1026,9 +978,8 @@
 /area/ship/hallway/central)
 "Bo" = (
 /obj/effect/turf_decal/corner/blue{
-	dir = 8
+	dir = 10
 	},
-/obj/effect/turf_decal/corner/blue,
 /turf/open/floor/plasteel,
 /area/ship/bridge)
 "Bx" = (
@@ -1041,21 +992,14 @@
 /obj/machinery/computer/monitor{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
+/obj/effect/turf_decal/corner/blue/three_quarters{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ship/bridge)
 "BV" = (
 /obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/ship/bridge)
@@ -1135,13 +1079,10 @@
 /area/ship/engineering/atmospherics)
 "DR" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/brown{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/corner/brown{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "DS" = (
@@ -1339,24 +1280,12 @@
 /obj/structure/table,
 /obj/item/healthanalyzer,
 /obj/item/storage/firstaid/o2,
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/corner/blue/full,
 /turf/open/floor/plasteel,
 /area/ship/medical)
 "IU" = (
 /obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
@@ -1372,17 +1301,14 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/ship/bridge)
@@ -1497,16 +1423,10 @@
 /turf/open/floor/plasteel,
 /area/ship/crew)
 "Ns" = (
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
 /obj/machinery/computer/helm{
 	dir = 8
 	},
+/obj/effect/turf_decal/corner/blue/three_quarters,
 /turf/open/floor/plasteel,
 /area/ship/bridge)
 "Nz" = (
@@ -1532,16 +1452,7 @@
 /obj/structure/table,
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/brute,
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
+/obj/effect/turf_decal/corner/blue/full,
 /turf/open/floor/plasteel,
 /area/ship/medical)
 "On" = (
@@ -1632,13 +1543,10 @@
 "Pr" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/green{
-	dir = 1
-	},
 /obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/corner/green{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew)
 "PF" = (
@@ -1773,13 +1681,12 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/corner/brown,
-/obj/effect/turf_decal/corner/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
@@ -1801,10 +1708,7 @@
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/ship/bridge)
@@ -1812,14 +1716,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/corner/blue{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
 "Sz" = (
@@ -1939,13 +1840,7 @@
 "Un" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/green{
+/obj/effect/turf_decal/corner/green/three_quarters{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -1973,9 +1868,8 @@
 /turf/open/floor/engine/vacuum,
 /area/ship/engineering/atmospherics)
 "Vh" = (
-/obj/effect/turf_decal/corner/blue,
 /obj/effect/turf_decal/corner/blue{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
@@ -2030,13 +1924,10 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "WJ" = (
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
 /obj/item/circuitboard/computer/operating,
+/obj/effect/turf_decal/corner/blue{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/ship/medical)
 "WU" = (
@@ -2061,16 +1952,13 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/corner/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/corner/green{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew)
 "XQ" = (
@@ -2081,10 +1969,7 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/corner/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/green{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew)
@@ -2103,16 +1988,10 @@
 /area/ship/crew)
 "Yl" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
 /obj/machinery/computer/autopilot{
 	dir = 1
 	},
+/obj/effect/turf_decal/corner/blue/three_quarters,
 /turf/open/floor/plasteel,
 /area/ship/bridge)
 "Yw" = (
@@ -2130,25 +2009,15 @@
 "YG" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
-/obj/effect/turf_decal/corner/green{
-	dir = 1
+/obj/effect/turf_decal/corner/green/three_quarters{
+	dir = 8
 	},
-/obj/effect/turf_decal/corner/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/green,
 /turf/open/floor/plasteel,
 /area/ship/crew)
 "YK" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
+/obj/effect/turf_decal/corner/blue/three_quarters{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2171,12 +2040,8 @@
 "Zx" = (
 /obj/machinery/computer/crew,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
+/obj/effect/turf_decal/corner/blue/three_quarters{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ship/bridge)
@@ -2205,13 +2070,9 @@
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/regular,
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
+/obj/effect/turf_decal/corner/blue/three_quarters{
+	dir = 8
 	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/blue,
 /turf/open/floor/plasteel,
 /area/ship/medical)
 "ZR" = (
@@ -2224,13 +2085,12 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "ZU" = (
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/ship/medical)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces decals, keeps it identical.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Twinkleshine, Courage, and Midway model ships have had some of their decals swapped for combined versions, to no functional difference.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
