### PR TITLE
Adds armour values to all jumpsuits, rebalances armored vests and RIGs.

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -562,7 +562,7 @@
 	glasses = /obj/item/clothing/glasses/night
 	belt = /obj/item/storage/belt/military
 	back = /obj/item/storage/backpack/duffelbag/syndie
-	suit = /obj/item/clothing/suit/armor/vest
+	suit = /obj/item/clothing/suit/armor/vest/syndie
 	suit_store = /obj/item/gun/ballistic/automatic/pistol
 	backpack_contents = list(/obj/item/storage/box/survival/syndie=1, /obj/item/gun_voucher/syndicate=1)
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -589,7 +589,7 @@
 	icon_state = "hardsuit0-sec"
 	item_state = "sec_helm"
 	hardsuit_type = "sec"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 30,"energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
+	armor = list("melee" = 40, "bullet" = 20, "laser" = 30,"energy" = 40, "bomb" = 25, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
 
 
 /obj/item/clothing/suit/space/hardsuit/security
@@ -597,7 +597,7 @@
 	name = "security hardsuit"
 	desc = "A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor."
 	item_state = "sec_hardsuit"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 30, "energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
+	armor = list("melee" = 40, "bullet" = 20, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/security
 	supports_variations = DIGITIGRADE_VARIATION
 
@@ -611,14 +611,14 @@
 	desc = "A special bulky helmet designed for work in a hazardous, low pressure environment. Has an additional layer of armor."
 	icon_state = "hardsuit0-hos"
 	hardsuit_type = "hos"
-	armor = list("melee" = 45, "bullet" = 25, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 100, "rad" = 50, "fire" = 95, "acid" = 95)
+	armor = list("melee" = 50, "bullet" = 30, "laser" = 35, "energy" = 40, "bomb" = 30, "bio" = 100, "rad" = 50, "fire" = 95, "acid" = 95)
 
 
 /obj/item/clothing/suit/space/hardsuit/security/hos
 	icon_state = "hardsuit-hos"
 	name = "head of security's hardsuit"
 	desc = "A special bulky suit that protects against hazardous, low pressure environments. Has an additional layer of armor."
-	armor = list("melee" = 45, "bullet" = 25, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 100, "rad" = 50, "fire" = 95, "acid" = 95)
+	armor = list("melee" = 50, "bullet" = 30, "laser" = 35, "energy" = 40, "bomb" = 30, "bio" = 100, "rad" = 50, "fire" = 95, "acid" = 95)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/security/hos
 	jetpack = /obj/item/tank/jetpack/suit
 	supports_variations = DIGITIGRADE_VARIATION
@@ -629,7 +629,7 @@
 	icon_state = "swat2helm"
 	item_state = "swat2helm"
 	desc = "A tactical SWAT helmet MK.II."
-	armor = list("melee" = 40, "bullet" = 50, "laser" = 50, "energy" = 60, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 55, "bullet" = 50, "laser" = 50, "energy" = 60, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 100, "acid" = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR //we want to see the mask //this makes the hardsuit not fireproof you genius
 	heat_protection = HEAD
@@ -643,7 +643,7 @@
 	desc = "A MK.II SWAT suit with streamlined joints and armor made out of superior materials, insulated against intense heat if worn with the complementary gas mask. The most advanced tactical armor available."
 	icon_state = "swat2"
 	item_state = "swat2"
-	armor = list("melee" = 40, "bullet" = 50, "laser" = 50, "energy" = 60, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 55, "bullet" = 50, "laser" = 50, "energy" = 60, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 100, "acid" = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT //this needed to be added a long fucking time ago

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -40,10 +40,13 @@
 
 /obj/item/clothing/suit/armor/vest/blueshirt
 	name = "large armor vest"
-	desc = "A large, yet comfortable piece of armor, protecting you from some threats."
+	desc = "A large, bulky kevlar vest that has integrated polymer plates to protect the wearer's entire body from attacks. Unfortunately, the older plates make it difficult to move around in."
 	icon_state = "blueshift"
 	item_state = "blueshift"
-	custom_premium_price = 750
+	custom_premium_price = 400
+	armor = list("melee" = 45, "bullet" = 35, "laser" = 35, "energy" = 40, "bomb" = 25, "bio" = 10, "rad" = 10, "fire" = 75, "acid" = 75)
+	body_parts_covered = CHEST|GROIN|ARMS|LEGS
+	slowdown = 0.4
 
 /obj/item/clothing/suit/armor/hos
 	name = "armored greatcoat"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -40,11 +40,11 @@
 
 /obj/item/clothing/suit/armor/vest/blueshirt
 	name = "large armor vest"
-	desc = "A large, bulky kevlar vest that has integrated polymer plates to protect the wearer's entire body from attacks. Unfortunately, the older plates make it difficult to move around in."
+	desc = "A large kevlar vest with polymer plating attacked at key points to protect the wearer's entire body. While the additional polymer plating is lightweight, the added bulk makes it difficult to move around in."
 	icon_state = "blueshift"
 	item_state = "blueshift"
 	custom_premium_price = 400
-	armor = list("melee" = 45, "bullet" = 35, "laser" = 35, "energy" = 40, "bomb" = 25, "bio" = 10, "rad" = 10, "fire" = 75, "acid" = 75)
+	armor = list("melee" = 45, "bullet" = 40, "laser" = 40, "energy" = 50, "bomb" = 25, "bio" = 10, "rad" = 10, "fire" = 75, "acid" = 75)
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	slowdown = 0.4
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -124,7 +124,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	armor = list("melee" = 70, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 15, "bio" = 15, "rad" = 15, "fire" = 80, "acid" = 80)
+	armor = list("melee" = 70, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 15, "bio" = 15, "rad" = 10, "fire" = 75, "acid" = 75)
 	clothing_flags = BLOCKS_SHOVE_KNOCKDOWN
 	strip_delay = 80
 	equip_delay_other = 60
@@ -144,7 +144,7 @@
 	icon_state = "bulletproof"
 	item_state = "armor"
 	blood_overlay_type = "armor"
-	armor = list("melee" = 15, "bullet" = 70, "laser" = 10, "energy" = 10, "bomb" = 15, "bio" = 15, "rad" = 15, "fire" = 50, "acid" = 50)
+	armor = list("melee" = 15, "bullet" = 70, "laser" = 10, "energy" = 10, "bomb" = 15, "bio" = 15, "rad" = 10, "fire" = 50, "acid" = 50)
 	strip_delay = 70
 	equip_delay_other = 50
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -51,7 +51,7 @@
 	icon_state = "hos"
 	item_state = "greatcoat"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 70, "acid" = 90)
+	armor = list("melee" = 45, "bullet" = 35, "laser" = 35, "energy" = 50, "bomb" = 25, "bio" = 10, "rad" = 10, "fire" = 75, "acid" = 75)
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS
 	strip_delay = 80
@@ -98,7 +98,7 @@
 	icon_state = "capcarapace"
 	item_state = "armor"
 	body_parts_covered = CHEST|GROIN
-	armor = list("melee" = 50, "bullet" = 40, "laser" = 50, "energy" = 50, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 90)
+	armor = list("melee" = 55, "bullet" = 50, "laser" = 55, "energy" = 50, "bomb" = 30, "bio" = 10, "rad" = 10, "fire" = 100, "acid" = 100)
 	dog_fashion = null
 	resistance_flags = FIRE_PROOF
 
@@ -121,7 +121,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	armor = list("melee" = 50, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
+	armor = list("melee" = 70, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 15, "bio" = 15, "rad" = 15, "fire" = 80, "acid" = 80)
 	clothing_flags = BLOCKS_SHOVE_KNOCKDOWN
 	strip_delay = 80
 	equip_delay_other = 60
@@ -141,7 +141,7 @@
 	icon_state = "bulletproof"
 	item_state = "armor"
 	blood_overlay_type = "armor"
-	armor = list("melee" = 15, "bullet" = 60, "laser" = 10, "energy" = 10, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	armor = list("melee" = 15, "bullet" = 70, "laser" = 10, "energy" = 10, "bomb" = 15, "bio" = 15, "rad" = 15, "fire" = 50, "acid" = 50)
 	strip_delay = 70
 	equip_delay_other = 50
 
@@ -154,8 +154,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS
 	heat_protection = CHEST|GROIN|ARMS
-	armor = list("melee" = 10, "bullet" = 10, "laser" = 60, "energy" = 60, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	armor = list("melee" = 10, "bullet" = 10, "laser" = 70, "energy" = 70, "bomb" = 5, "bio" = 10, "rad" = 5, "fire" = 50, "acid" = 50)
 	var/hit_reflect_chance = 50
 
 /obj/item/clothing/suit/armor/laserproof/IsReflect(def_zone)
@@ -273,7 +272,7 @@
 	equip_delay_other = 40
 	max_integrity = 200
 	resistance_flags = FLAMMABLE
-	armor = list("melee" = 20, "bullet" = 10, "laser" = 30, "energy" = 40, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 50)
+	armor = list("melee" = 40, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 15, "bio" = 10, "rad" = 10, "fire" = 50, "acid" = 50)
 
 /obj/item/clothing/suit/armor/vest/russian
 	name = "russian vest"

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -57,7 +57,7 @@
 	icon_state = "goliath_cloak"
 	desc = "A staunch, practical cape made out of numerous monster materials, it is coveted amongst exiles & hermits."
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/pickaxe, /obj/item/spear, /obj/item/organ/regenerative_core/legion, /obj/item/kitchen/knife/combat/bone, /obj/item/kitchen/knife/combat/survival)
-	armor = list("melee" = 35, "bullet" = 10, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60) //a fair alternative to bone armor, requiring alternative materials and gaining a suit slot
+	armor = list("melee" = 35, "bullet" = 20, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60) //a fair alternative to bone armor, requiring alternative materials and gaining a suit slot
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/goliath
 	body_parts_covered = CHEST|GROIN|ARMS
 
@@ -65,7 +65,7 @@
 	name = "goliath cloak hood"
 	icon_state = "golhood"
 	desc = "A protective & concealing hood."
-	armor = list("melee" = 35, "bullet" = 10, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
+	armor = list("melee" = 35, "bullet" = 20, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
 	clothing_flags = SNUG_FIT
 	flags_inv = HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR
 	transparent_protection = HIDEMASK
@@ -75,7 +75,7 @@
 	icon_state = "dragon"
 	desc = "A suit of armour fashioned from the remains of an ash drake."
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe, /obj/item/spear)
-	armor = list("melee" = 50, "bullet" = 10, "laser" = 40, "energy" = 50, "bomb" = 50, "bio" = 60, "rad" = 50, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 75, "bullet" = 40, "laser" = 30, "energy" = 50, "bomb" = 50, "bio" = 60, "rad" = 50, "fire" = 100, "acid" = 100)
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/drake
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -87,7 +87,7 @@
 	name = "drake helm"
 	icon_state = "dragon"
 	desc = "The skull of a dragon."
-	armor = list("melee" = 50, "bullet" = 10, "laser" = 40, "energy" = 50, "bomb" = 50, "bio" = 60, "rad" = 50, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 75, "bullet" = 40, "laser" = 30, "energy" = 50, "bomb" = 50, "bio" = 60, "rad" = 50, "fire" = 100, "acid" = 100)
 	clothing_flags = SNUG_FIT
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -57,7 +57,7 @@
 	icon_state = "goliath_cloak"
 	desc = "A staunch, practical cape made out of numerous monster materials, it is coveted amongst exiles & hermits."
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/pickaxe, /obj/item/spear, /obj/item/organ/regenerative_core/legion, /obj/item/kitchen/knife/combat/bone, /obj/item/kitchen/knife/combat/survival)
-	armor = list("melee" = 35, "bullet" = 20, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60) //a fair alternative to bone armor, requiring alternative materials and gaining a suit slot
+	armor = list("melee" = 35, "bullet" = 20, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 15, "rad" = 5, "fire" = 60, "acid" = 60) //a fair alternative to bone armor, requiring alternative materials and gaining a suit slot
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/goliath
 	body_parts_covered = CHEST|GROIN|ARMS
 
@@ -65,7 +65,7 @@
 	name = "goliath cloak hood"
 	icon_state = "golhood"
 	desc = "A protective & concealing hood."
-	armor = list("melee" = 35, "bullet" = 20, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
+	armor = list("melee" = 35, "bullet" = 20, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 15, "rad" = 5, "fire" = 60, "acid" = 60)
 	clothing_flags = SNUG_FIT
 	flags_inv = HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR
 	transparent_protection = HIDEMASK
@@ -75,7 +75,7 @@
 	icon_state = "dragon"
 	desc = "A suit of armour fashioned from the remains of an ash drake."
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe, /obj/item/spear)
-	armor = list("melee" = 75, "bullet" = 40, "laser" = 30, "energy" = 50, "bomb" = 50, "bio" = 60, "rad" = 50, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 75, "bullet" = 35, "laser" = 30, "energy" = 50, "bomb" = 50, "bio" = 60, "rad" = 50, "fire" = 100, "acid" = 100)
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/drake
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -87,7 +87,7 @@
 	name = "drake helm"
 	icon_state = "dragon"
 	desc = "The skull of a dragon."
-	armor = list("melee" = 75, "bullet" = 40, "laser" = 30, "energy" = 50, "bomb" = 50, "bio" = 60, "rad" = 50, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 75, "bullet" = 35, "laser" = 30, "energy" = 50, "bomb" = 50, "bio" = 60, "rad" = 50, "fire" = 100, "acid" = 100)
 	clothing_flags = SNUG_FIT
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -562,7 +562,7 @@
 	name = "captain's winter coat"
 	icon_state = "coatcaptain"
 	item_state = "coatcaptain"
-	armor = list("melee" = 25, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 50)
+	armor = list("melee" = 30, "bullet" = 30, "laser" = 35, "energy" = 40, "bomb" = 25, "bio" = 25, "rad" = 10, "fire" = 15, "acid" = 50)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/captain
 
 /obj/item/clothing/suit/hooded/wintercoat/captain/Initialize()
@@ -571,13 +571,13 @@
 
 /obj/item/clothing/head/hooded/winterhood/captain
 	icon_state = "winterhood_captain"
-	armor = list("melee" = 25, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 50)
+	armor = list("melee" = 30, "bullet" = 30, "laser" = 35, "energy" = 40, "bomb" = 25, "bio" = 25, "rad" = 10, "fire" = 15, "acid" = 50)
 
 /obj/item/clothing/suit/hooded/wintercoat/security
 	name = "security winter coat"
 	icon_state = "coatsecurity"
 	item_state = "coatsecurity"
-	armor = list("melee" = 25, "bullet" = 15, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 45)
+	armor = list("melee" = 25, "bullet" = 20, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 45)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/security
 
 /obj/item/clothing/suit/hooded/wintercoat/security/Initialize()
@@ -586,7 +586,7 @@
 
 /obj/item/clothing/head/hooded/winterhood/security
 	icon_state = "winterhood_security"
-	armor = list("melee" = 25, "bullet" = 15, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 45)
+	armor = list("melee" = 25, "bullet" = 20, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 45)
 
 /obj/item/clothing/suit/hooded/wintercoat/medical
 	name = "medical winter coat"
@@ -698,7 +698,7 @@
 	icon_state = "ablativecoat"
 	item_state = "ablativecoat"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list("melee" = 10, "bullet" = 10, "laser" = 60, "energy" = 60, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 10, "bullet" = 10, "laser" = 70, "energy" = 70, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	hoodtype = /obj/item/clothing/head/hooded/ablative
 	strip_delay = 30
 	equip_delay_other = 40

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -5,7 +5,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	permeability_coefficient = 0.9
 	slot_flags = ITEM_SLOT_ICLOTHING
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 15, "rad" = 10, "fire" = 30, "acid" = 30)
 	equip_sound = 'sound/items/equip/jumpsuit_equip.ogg'
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound =  'sound/items/handling/cloth_pickup.ogg'

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -5,7 +5,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	permeability_coefficient = 0.9
 	slot_flags = ITEM_SLOT_ICLOTHING
-	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 15, "rad" = 10, "fire" = 30, "acid" = 30)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 5, "rad" = 5, "fire" = 30, "acid" = 30)
 	equip_sound = 'sound/items/equip/jumpsuit_equip.ogg'
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound =  'sound/items/handling/cloth_pickup.ogg'

--- a/code/modules/clothing/under/jobs/cargo.dm
+++ b/code/modules/clothing/under/jobs/cargo.dm
@@ -42,7 +42,7 @@
 	name = "shaft miner's jumpsuit"
 	icon_state = "miner"
 	item_state = "miner"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 0)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 5, "bio" = 5, "rad" = 0, "fire" = 75, "acid" = 25)
 	resistance_flags = NONE
 
 /obj/item/clothing/under/rank/cargo/miner/lavaland
@@ -65,5 +65,5 @@
 	desc = "A standardized NT jumpsuit line, designed to protect the fragile and profitable bodies of the shaft-charting explorers Nanotransen Resource Operations favoured in the closing years of their golden age. Slightly encumbering, due to heavy protective padding."
 	name = "prototype shaft miner's jumpsuit"
 	slowdown = 0.1
-	armor = list("melee" = 15, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 80, "acid" = 0)
+	armor = list("melee" = 15, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 80, "acid" = 25)
 	can_adjust = FALSE

--- a/code/modules/clothing/under/jobs/centcom.dm
+++ b/code/modules/clothing/under/jobs/centcom.dm
@@ -1,7 +1,7 @@
 /obj/item/clothing/under/rank/centcom
 	icon = 'icons/obj/clothing/under/centcom.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/centcom.dmi'
-	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 10, "bio" = 15, "rad" = 15, "fire" = 50, "acid" = 0)
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 50, "acid" = 50)
 
 /*WS Edit - Better Command Uniforms
 

--- a/code/modules/clothing/under/jobs/centcom.dm
+++ b/code/modules/clothing/under/jobs/centcom.dm
@@ -1,7 +1,7 @@
 /obj/item/clothing/under/rank/centcom
 	icon = 'icons/obj/clothing/under/centcom.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/centcom.dmi'
-	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 10, "bio" = 15, "rad" = 15, "fire" = 50, "acid" = 50)
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 10, "bio" = 15, "rad" = 15, "fire" = 50, "acid" = 0)
 
 /*WS Edit - Better Command Uniforms
 

--- a/code/modules/clothing/under/jobs/centcom.dm
+++ b/code/modules/clothing/under/jobs/centcom.dm
@@ -1,6 +1,7 @@
 /obj/item/clothing/under/rank/centcom
 	icon = 'icons/obj/clothing/under/centcom.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/centcom.dmi'
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 10, "bio" = 15, "rad" = 15, "fire" = 50, "acid" = 50)
 
 /*WS Edit - Better Command Uniforms
 

--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -3,13 +3,14 @@
 /obj/item/clothing/under/rank/engineering
 	icon = 'icons/obj/clothing/under/engineering.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/engineering.dmi'
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 5, "bio" = 5, "rad" = 10, "fire" = 50, "acid" = 50)
 
 /obj/item/clothing/under/rank/engineering/chief_engineer
 	desc = "It's a high visibility jumpsuit given to those engineers insane enough to achieve the rank of \"Chief Engineer\". It has minor radiation shielding."
 	name = "chief engineer's jumpsuit"
 	icon_state = "chiefengineer"
 	item_state = "gy_suit"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 10, "fire" = 80, "acid" = 40)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 5, "bio" = 5, "rad" = 15, "fire" = 75, "acid" = 75)
 	resistance_flags = NONE
 
 /obj/item/clothing/under/rank/engineering/chief_engineer/skirt
@@ -42,7 +43,6 @@
 	name = "engineer's jumpsuit"
 	icon_state = "engine"
 	item_state = "engi_suit"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 10, "fire" = 60, "acid" = 20)
 	resistance_flags = NONE
 
 /obj/item/clothing/under/rank/engineering/engineer/hazard

--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -3,14 +3,14 @@
 /obj/item/clothing/under/rank/engineering
 	icon = 'icons/obj/clothing/under/engineering.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/engineering.dmi'
-	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 5, "bio" = 5, "rad" = 10, "fire" = 50, "acid" = 50)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 5, "bomb" = 5, "bio" = 5, "rad" = 10, "fire" = 50, "acid" = 50)
 
 /obj/item/clothing/under/rank/engineering/chief_engineer
 	desc = "It's a high visibility jumpsuit given to those engineers insane enough to achieve the rank of \"Chief Engineer\". It has minor radiation shielding."
 	name = "chief engineer's jumpsuit"
 	icon_state = "chiefengineer"
 	item_state = "gy_suit"
-	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 5, "bio" = 5, "rad" = 15, "fire" = 75, "acid" = 75)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 5, "bomb" = 10, "bio" = 5, "rad" = 15, "fire" = 75, "acid" = 75)
 	resistance_flags = NONE
 
 /obj/item/clothing/under/rank/engineering/chief_engineer/skirt

--- a/code/modules/clothing/under/jobs/medical.dm
+++ b/code/modules/clothing/under/jobs/medical.dm
@@ -1,14 +1,16 @@
 /obj/item/clothing/under/rank/medical
 	icon = 'icons/obj/clothing/under/medical.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/medical.dmi'
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 25, "rad" = 5, "fire" = 30, "acid" = 30)
+
 
 /obj/item/clothing/under/rank/medical/chief_medical_officer
 	desc = "It's a jumpsuit worn by those with the experience to be \"Chief Medical Officer\". It provides minor biological protection."
 	name = "chief medical officer's jumpsuit"
 	icon_state = "cmo"
 	item_state = "w_suit"
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 30, "rad" = 5, "fire" = 40, "acid" = 40)
 	permeability_coefficient = 0.5
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/under/rank/medical/chief_medical_officer/skirt
 	name = "chief medical officer's jumpskirt"
@@ -28,7 +30,6 @@
 	icon_state = "genetics"
 	item_state = "w_suit"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/under/rank/medical/geneticist/skirt
 	name = "geneticist's jumpskirt"
@@ -46,7 +47,6 @@
 	icon_state = "virology"
 	item_state = "w_suit"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/under/rank/medical/virologist/skirt
 	name = "virologist's jumpskirt"
@@ -64,7 +64,6 @@
 	icon_state = "nursesuit"
 	item_state = "w_suit"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
 	body_parts_covered = CHEST|GROIN|ARMS
 	fitted = NO_FEMALE_UNIFORM
 	can_adjust = FALSE
@@ -76,7 +75,6 @@
 	icon_state = "medical"
 	item_state = "w_suit"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/under/rank/medical/doctor/blue
 	name = "medical scrubs"
@@ -112,7 +110,7 @@
 	icon_state = "chemistry"
 	item_state = "w_suit"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 50, "acid" = 65)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 60, "acid" = 60)
 
 /obj/item/clothing/under/rank/medical/chemist/skirt
 	name = "chemist's jumpskirt"
@@ -130,7 +128,6 @@
 	icon_state = "paramedic"
 	item_state = "w_suit"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/under/rank/medical/paramedic/skirt
 	name = "paramedic jumpskirt"

--- a/code/modules/clothing/under/jobs/medical.dm
+++ b/code/modules/clothing/under/jobs/medical.dm
@@ -3,7 +3,6 @@
 	mob_overlay_icon = 'icons/mob/clothing/under/medical.dmi'
 	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 20, "rad" = 5, "fire" = 40, "acid" = 40)
 
-
 /obj/item/clothing/under/rank/medical/chief_medical_officer
 	desc = "It's a jumpsuit worn by those with the experience to be \"Chief Medical Officer\". It provides minor biological protection."
 	name = "chief medical officer's jumpsuit"

--- a/code/modules/clothing/under/jobs/medical.dm
+++ b/code/modules/clothing/under/jobs/medical.dm
@@ -1,7 +1,7 @@
 /obj/item/clothing/under/rank/medical
 	icon = 'icons/obj/clothing/under/medical.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/medical.dmi'
-	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 25, "rad" = 5, "fire" = 30, "acid" = 30)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 20, "rad" = 5, "fire" = 40, "acid" = 40)
 
 
 /obj/item/clothing/under/rank/medical/chief_medical_officer
@@ -9,7 +9,7 @@
 	name = "chief medical officer's jumpsuit"
 	icon_state = "cmo"
 	item_state = "w_suit"
-	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 30, "rad" = 5, "fire" = 40, "acid" = 40)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 5, "bio" = 25, "rad" = 5, "fire" = 40, "acid" = 40)
 	permeability_coefficient = 0.5
 
 /obj/item/clothing/under/rank/medical/chief_medical_officer/skirt
@@ -110,7 +110,7 @@
 	icon_state = "chemistry"
 	item_state = "w_suit"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 60, "acid" = 60)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 20, "rad" = 0, "fire" = 50, "acid" = 75)
 
 /obj/item/clothing/under/rank/medical/chemist/skirt
 	name = "chemist's jumpskirt"

--- a/code/modules/clothing/under/jobs/rnd.dm
+++ b/code/modules/clothing/under/jobs/rnd.dm
@@ -9,7 +9,7 @@
 	name = "research director's vest suit"
 	icon_state = "director"
 	item_state = "lb_suit"
-	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 15, "bio" = 15, "rad" = 5, "fire" = 50, "acid" = 50)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 15, "bio" = 10, "rad" = 5, "fire" = 50, "acid" = 50)
 	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/rnd/research_director/skirt

--- a/code/modules/clothing/under/jobs/rnd.dm
+++ b/code/modules/clothing/under/jobs/rnd.dm
@@ -3,7 +3,6 @@
 	mob_overlay_icon = 'icons/mob/clothing/under/rnd.dmi'
 	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 10, "bio" = 10, "rad" = 5, "fire" = 40, "acid" = 40)
 
-
 /obj/item/clothing/under/rank/rnd/research_director
 	desc = "It's a suit worn by those with the know-how to achieve the position of \"Research Director\". Its fabric provides minor protection from biological contaminants."
 	name = "research director's vest suit"

--- a/code/modules/clothing/under/jobs/rnd.dm
+++ b/code/modules/clothing/under/jobs/rnd.dm
@@ -1,13 +1,15 @@
 /obj/item/clothing/under/rank/rnd
 	icon = 'icons/obj/clothing/under/rnd.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/rnd.dmi'
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 10, "bio" = 10, "rad" = 5, "fire" = 40, "acid" = 40)
+
 
 /obj/item/clothing/under/rank/rnd/research_director
 	desc = "It's a suit worn by those with the know-how to achieve the position of \"Research Director\". Its fabric provides minor protection from biological contaminants."
 	name = "research director's vest suit"
 	icon_state = "director"
 	item_state = "lb_suit"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 10, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 35)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 15, "bio" = 15, "rad" = 5, "fire" = 50, "acid" = 50)
 	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/rnd/research_director/skirt
@@ -25,7 +27,6 @@
 	name = "research director's tan suit"
 	icon_state = "rdwhimsy"
 	item_state = "rdwhimsy"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 10, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
 	can_adjust = TRUE
 	alt_covers_chest = TRUE
 
@@ -44,7 +45,6 @@
 	name = "research director's turtleneck"
 	icon_state = "rdturtle"
 	item_state = "p_suit"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 10, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
 	can_adjust = TRUE
 	alt_covers_chest = TRUE
 
@@ -64,7 +64,6 @@
 	icon_state = "toxins"
 	item_state = "w_suit"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/under/rank/rnd/scientist/skirt
 	name = "scientist's jumpskirt"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -145,7 +145,7 @@
 	icon_state = "durathread"
 	item_state = "durathread"
 	can_adjust = FALSE
-	armor = list("melee" = 15, "bullet" = 5, "laser" = 10, "energy" = 5, "fire" = 40, "acid" = 40, "bomb" = 5)
+	armor = list("melee" = 15, "bullet" = 5, "laser" = 10,"energy" = 5, "bomb" = 10, "bio" = 10, "rad" = 5, "fire" = 50, "acid" = 50)
 	cuttable = FALSE
 
 /obj/item/clothing/under/misc/bouncer

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -145,7 +145,7 @@
 	icon_state = "durathread"
 	item_state = "durathread"
 	can_adjust = FALSE
-	armor = list("melee" = 10, "laser" = 10, "fire" = 40, "acid" = 10, "bomb" = 5)
+	armor = list("melee" = 15, "bullet" = 5, "laser" = 10, "energy" = 5, "fire" = 40, "acid" = 40, "bomb" = 5)
 	cuttable = FALSE
 
 /obj/item/clothing/under/misc/bouncer

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -4,7 +4,7 @@
 	icon_state = "syndicate"
 	item_state = "bl_suit"
 	has_sensor = NO_SENSORS
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 10, "bio" = 15, "rad" = 15, "fire" = 50, "acid" = 50)
 	alt_covers_chest = TRUE
 	icon = 'icons/obj/clothing/under/syndicate.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/syndicate.dmi'
@@ -15,7 +15,6 @@
 	icon_state = "syndicate_skirt"
 	item_state = "bl_suit"
 	has_sensor = NO_SENSORS
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
 	alt_covers_chest = TRUE
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
@@ -73,7 +72,6 @@
 	desc = "Badly translated labels tell you to clean this in Vodka. Great for squatting in."
 	icon_state = "trackpants"
 	can_adjust = FALSE
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	resistance_flags = NONE
 
 /obj/item/clothing/under/syndicate/combat
@@ -87,5 +85,4 @@
 	desc = "Military grade tracksuits for frontline squatting."
 	icon_state = "rus_under"
 	can_adjust = FALSE
-	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	resistance_flags = NONE

--- a/code/modules/clothing/under/trek.dm
+++ b/code/modules/clothing/under/trek.dm
@@ -5,6 +5,8 @@
 	can_adjust = FALSE
 	icon = 'icons/obj/clothing/under/trek.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/trek.dmi'
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 15, "rad" = 15, "fire" = 40, "acid" = 40) // It's star trek, it deserves to be a bit better then your average jumpsuit
+	strip_delay = 50
 
 
 //TOS
@@ -13,14 +15,14 @@
 	desc = "The uniform worn by command officers."
 	icon_state = "trek_command"
 	item_state = "y_suit"
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 10, "bio" = 15, "rad" = 15, "fire" = 75, "acid" = 50)
+
 
 /obj/item/clothing/under/trek/engsec
 	name = "engsec uniform"
 	desc = "The uniform worn by engineering/security officers."
 	icon_state = "trek_engsec"
 	item_state = "r_suit"
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0) //more sec than eng, but w/e.
-	strip_delay = 50
 
 /obj/item/clothing/under/trek/medsci
 	name = "medsci uniform"

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -64,7 +64,7 @@
 	name = "Atmospheric Technician (Chadmos)"  //WS Edit - Give Chadmos Sr. Uniform
 
 	belt = null
-	uniform = /obj/item/clothing/under/suit/senior_atmos
+	uniform = /obj/item/clothing/under/rank/engineering/suit/senior_atmos
 	alt_uniform = null
 	suit = /obj/item/clothing/suit/toggle/lawyer/atmos
 	alt_suit = /obj/item/clothing/suit/hazardvest

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -74,7 +74,7 @@
 /datum/outfit/job/doctor/seniordoctor
 	name = "Medical Doctor (Senior Doctor)"
 
-	uniform = /obj/item/clothing/under/suit/senior_doctor
+	uniform = /obj/item/clothing/under/rank/medical/suit/senior_doctor
 	alt_uniform = null
 	shoes = /obj/item/clothing/shoes/laceup
 	suit = /obj/item/clothing/suit/toggle/lawyer/medical

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -76,7 +76,7 @@
 /datum/outfit/job/roboticist/seniorroboticist
 	name = "Roboticist (Senior Roboticist)"
 
-	uniform = /obj/item/clothing/under/suit/senior_roboticist
+	uniform = /obj/item/clothing/under/suit/rank/rnd/senior_roboticist
 	alt_uniform = null
 	shoes = /obj/item/clothing/shoes/laceup
 	suit = null

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -80,7 +80,7 @@
 /datum/outfit/job/scientist/seniorscientist
 	name = "Scientist (Senior Scientist)"
 
-	uniform = /obj/item/clothing/under/suit/senior_scientist
+	uniform = /obj/item/clothing/under/suit/rank/rnd/senior_scientist
 	alt_uniform = null
 	shoes = /obj/item/clothing/shoes/laceup
 	suit = /obj/item/clothing/suit/toggle/lawyer/science

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -92,7 +92,7 @@
 	name = "Station Engineer (Senior Engineer)"
 
 	belt = null
-	uniform = /obj/item/clothing/under/suit/senior_engineer
+	uniform = /obj/item/clothing/under/rank/engineering/suit/senior_engineer
 	alt_uniform = null
 	suit = /obj/item/clothing/suit/toggle/lawyer/orange
 	alt_suit = /obj/item/clothing/suit/hazardvest

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -43,7 +43,7 @@
 /datum/outfit/job/virologist/pathologist
 	name = "Virologist (Pathologist)"
 
-	uniform = /obj/item/clothing/under/suit/pathologist
+	uniform = /obj/item/clothing/under/rank/medical/suit/pathologist
 	alt_uniform = null
 	shoes = /obj/item/clothing/shoes/laceup
 	neck = /obj/item/clothing/neck/tie/green

--- a/whitesands/code/modules/clothing/suits/coats.dm
+++ b/whitesands/code/modules/clothing/suits/coats.dm
@@ -39,7 +39,7 @@
 	icon_state = "blueshield_coat"
 	item_state = "blueshield_coat"
 	allowed = list(/obj/item/gun/energy, /obj/item/reagent_containers/spray/pepper, /obj/item/ammo_box, /obj/item/ammo_casing,/obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/flashlight/seclite, /obj/item/melee/classic_baton)
-	armor = list("melee" = 35, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	armor = list("melee" = 40, "bullet" = 30, "laser" = 35, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	body_parts_covered = CHEST|GROIN|ARMS|HANDS
 
 /obj/item/clothing/suit/aclf
@@ -49,4 +49,4 @@
 	icon_state = "aclfjacket"
 	item_state = "aclfjacket"
 	blood_overlay_type = "coat"
-	armor = list("melee" = 35, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	armor = list("melee" = 40, "bullet" = 30, "laser" = 35, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)

--- a/whitesands/code/modules/clothing/under/accessories.dm
+++ b/whitesands/code/modules/clothing/under/accessories.dm
@@ -4,6 +4,7 @@
 	icon_state = "holster"
 	item_state = "holster"
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/holster
+	armor = list("melee" = 5, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 20, "bio" = 20, "rad" = 5, "fire" = 25, "acid" = 25)
 
 /obj/item/clothing/accessory/holster/detective
 	name = "detective's shoulder holster"

--- a/whitesands/code/modules/clothing/under/jobs/cargo.dm
+++ b/whitesands/code/modules/clothing/under/jobs/cargo.dm
@@ -21,7 +21,7 @@
 
 /obj/item/clothing/under/suit/cargo_tech
 	name = "deliveries officer suit"
-	desc = "A suit with cargo colors, with a pair of shorts..."
+	desc = "A suit with cargo colors, with a pair of shorts."
 	icon_state = "deliveries_officer"
 	fitted = NO_FEMALE_UNIFORM
 	icon = 'icons/obj/clothing/under/cargo.dmi'
@@ -29,7 +29,7 @@
 
 /obj/item/clothing/under/suit/cargo_tech/skirt
 	name = "deliveries officer skirtsuit"
-	desc = "A suit with cargo colors, with a skirt..."
+	desc = "A suit with cargo colors, with a skirt."
 	icon_state = "deliveries_officer_skirt"
 
 	body_parts_covered = CHEST|GROIN|ARMS

--- a/whitesands/code/modules/clothing/under/jobs/centcom.dm
+++ b/whitesands/code/modules/clothing/under/jobs/centcom.dm
@@ -6,6 +6,7 @@
 	icon_state = "officer"
 	item_state = "g_suit"
 	alt_covers_chest = TRUE
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 10, "bio" = 10, "rad" = 5, "fire" = 75, "acid" = 50)
 
 /obj/item/clothing/under/rank/centcom/commander
 	name = "\improper CentCom officer's jumpsuit"

--- a/whitesands/code/modules/clothing/under/jobs/command.dm
+++ b/whitesands/code/modules/clothing/under/jobs/command.dm
@@ -1,3 +1,7 @@
+/obj/item/clothing/under/rank/command/captain/suit
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 10, "bio" = 10, "rad" = 5, "fire" = 75, "acid" = 50)
+
+
 /obj/item/clothing/under/rank/command
 	desc = "A standard command jumpsuit."
 	name = "command jumpsuit"
@@ -67,6 +71,8 @@
 	name = "head of personnel's jumpsuit"
 	icon_state = "hop"
 	can_adjust = FALSE
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 5, "bio" = 10, "rad" = 5, "fire" = 40, "acid" = 40)
+
 
 /obj/item/clothing/under/rank/command/head_of_personnel/skirt
 	name = "head of personnel's jumpskirt"

--- a/whitesands/code/modules/clothing/under/jobs/command.dm
+++ b/whitesands/code/modules/clothing/under/jobs/command.dm
@@ -5,6 +5,7 @@
 	mob_overlay_icon = 'icons/mob/clothing/under/command.dmi'
 	icon_state = "cmd"
 	item_state = "w_suit"
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 10, "bio" = 15, "rad" = 15, "fire" = 75, "acid" = 50)
 
 /obj/item/clothing/under/rank/command/skirt
 	desc = "A standard command jumpskirt."

--- a/whitesands/code/modules/clothing/under/jobs/command.dm
+++ b/whitesands/code/modules/clothing/under/jobs/command.dm
@@ -5,7 +5,7 @@
 	mob_overlay_icon = 'icons/mob/clothing/under/command.dmi'
 	icon_state = "cmd"
 	item_state = "w_suit"
-	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 10, "bio" = 15, "rad" = 15, "fire" = 75, "acid" = 50)
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 10, "bio" = 10, "rad" = 5, "fire" = 75, "acid" = 50)
 
 /obj/item/clothing/under/rank/command/skirt
 	desc = "A standard command jumpskirt."

--- a/whitesands/code/modules/clothing/under/jobs/engineering.dm
+++ b/whitesands/code/modules/clothing/under/jobs/engineering.dm
@@ -1,5 +1,8 @@
 //Alt job clothing
 
+/obj/item/clothing/under/rank/engineering/suit
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 5, "bio" = 5, "rad" = 10, "fire" = 50, "acid" = 50)
+
 /obj/item/clothing/under/rank/engineering/engineer/junior
 	name = "junior engineer jumpsuit"
 	desc = "A jumpsuit worn by junior engineers. It has minor radiation shielding."
@@ -52,41 +55,40 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 
-/obj/item/clothing/under/suit/ce
+/obj/item/clothing/under/rank/engineering/suit/ce
 	name = "engineering coordinator suit"
 	desc = "A suit with engineering colors, worn by those who lead and have survived the engineering department."
 	icon_state = "senior_medical"
 	icon = 'icons/obj/clothing/under/engineering.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/engineering.dmi'
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 10, "fire" = 80, "acid" = 40)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 5, "bio" = 5, "rad" = 15, "fire" = 75, "acid" = 50)
 	resistance_flags = NONE
 	fitted = NO_FEMALE_UNIFORM
 
-/obj/item/clothing/under/suit/ce/skirt
+/obj/item/clothing/under/rank/engineering/suit/ce/skirt
 	name = "engineering coordinator skirtsuit"
 	desc = "A skirtsuit with engineering colors, worn by those who lead and have survived the engineering department."
 	icon_state = "engineering_coordinator_skirt"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 
-/obj/item/clothing/under/suit/senior_engineer
+/obj/item/clothing/under/rank/engineering/suit/senior_engineer
 	name = "senior engineer suit"
 	desc = "A suit with engineering colors, meant to be worn by senior staff."
 	icon_state = "senior_engineer"
 	icon = 'icons/obj/clothing/under/engineering.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/engineering.dmi'
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 10, "fire" = 60, "acid" = 20)
 	resistance_flags = NONE
 	fitted = NO_FEMALE_UNIFORM
 
-/obj/item/clothing/under/suit/senior_engineer/skirt
+/obj/item/clothing/under/rank/engineering/suit/senior_engineer/skirt
 	name = "senior engineer skirtsuit"
 	desc = "A skirtsuit with engineering colors, meant to be worn by senior staff."
 	icon_state = "senior_engineer_skirt"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 
-/obj/item/clothing/under/suit/senior_atmos
+/obj/item/clothing/under/rank/engineering/suit/senior_atmos
 	name = "senior atmospheric technician suit"
 	desc = "A suit with atmospheric colors, meant to be worn by senior staff."
 	icon = 'icons/obj/clothing/under/engineering.dmi'
@@ -94,7 +96,7 @@
 	icon_state = "senior_atmos"
 	fitted = NO_FEMALE_UNIFORM
 
-/obj/item/clothing/under/suit/senior_atmos/skirt
+/obj/item/clothing/under/rank/engineering/suit/senior_atmos/skirt
 	name = "senior atmospheric technician skirtsuit"
 	desc = "A skirtsuit with atmospheric colors, meant to be worn by senior staff."
 	icon_state = "senior_atmos_skirt"
@@ -121,7 +123,7 @@
 	name = "firefighter's jumpsuit"
 	desc = "It's a jumpsuit worn by firefigthers to help aid in dealing science caused fires. It is made of fire resistant materials."
 	icon_state = "firefighter"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 0) //Same fire number as standard engineer uniform
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 5, "bio" = 5, "rad" = 5, "fire" = 75, "acid" = 25) //Same fire number as standard engineer uniform
 	fitted = NO_FEMALE_UNIFORM
 
 /obj/item/clothing/under/rank/engineering/atmospheric_technician/firefighter/skirt

--- a/whitesands/code/modules/clothing/under/jobs/engineering.dm
+++ b/whitesands/code/modules/clothing/under/jobs/engineering.dm
@@ -1,7 +1,7 @@
 //Alt job clothing
 
 /obj/item/clothing/under/rank/engineering/suit
-	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 5, "bio" = 5, "rad" = 10, "fire" = 50, "acid" = 50)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 5, "bomb" = 5, "bio" = 5, "rad" = 10, "fire" = 50, "acid" = 50)
 
 /obj/item/clothing/under/rank/engineering/engineer/junior
 	name = "junior engineer jumpsuit"
@@ -61,7 +61,7 @@
 	icon_state = "senior_medical"
 	icon = 'icons/obj/clothing/under/engineering.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/engineering.dmi'
-	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 5, "bio" = 5, "rad" = 15, "fire" = 75, "acid" = 50)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 5, "bomb" = 10, "bio" = 5, "rad" = 15, "fire" = 75, "acid" = 75)
 	resistance_flags = NONE
 	fitted = NO_FEMALE_UNIFORM
 
@@ -123,7 +123,7 @@
 	name = "firefighter's jumpsuit"
 	desc = "It's a jumpsuit worn by firefigthers to help aid in dealing science caused fires. It is made of fire resistant materials."
 	icon_state = "firefighter"
-	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 5, "bio" = 5, "rad" = 5, "fire" = 75, "acid" = 25) //Same fire number as standard engineer uniform
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 5, "bomb" = 5, "bio" = 5, "rad" = 5, "fire" = 75, "acid" = 50) //Same fire number as standard engineer uniform
 	fitted = NO_FEMALE_UNIFORM
 
 /obj/item/clothing/under/rank/engineering/atmospheric_technician/firefighter/skirt

--- a/whitesands/code/modules/clothing/under/jobs/medical.dm
+++ b/whitesands/code/modules/clothing/under/jobs/medical.dm
@@ -1,7 +1,7 @@
 //Alt job uniforms
 
 /obj/item/clothing/under/suit/medical
-	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 5, "fire" = 30, "acid" = 30)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 20, "rad" = 5, "fire" = 40, "acid" = 40)
 
 /obj/item/clothing/under/rank/medical/chemist/pharmacist
 	name = "pharmacist's jumpsuit"
@@ -77,7 +77,7 @@
 	desc = "A suit with medical colors, meant to be worn by those who lead the medical department."
 	icon_state = "medical_director"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 5, "bio" = 15, "rad" = 5, "fire" = 40, "acid" = 40)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 5, "bio" = 25, "rad" = 5, "fire" = 40, "acid" = 40)
 	fitted = NO_FEMALE_UNIFORM
 	icon = 'icons/obj/clothing/under/medical.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/medical.dmi'
@@ -118,7 +118,7 @@
 	desc = "A suit with chemistry colors, meant to be worn by senior staff."
 	icon_state = "senior_chemistry"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 5, "fire" = 50, "acid" = 75)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 20, "rad" = 5, "fire" = 50, "acid" = 75)
 	fitted = NO_FEMALE_UNIFORM
 	icon = 'icons/obj/clothing/under/medical.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/medical.dmi'

--- a/whitesands/code/modules/clothing/under/jobs/medical.dm
+++ b/whitesands/code/modules/clothing/under/jobs/medical.dm
@@ -1,5 +1,8 @@
 //Alt job uniforms
 
+/obj/item/clothing/under/suit/medical
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 5, "fire" = 30, "acid" = 30)
+
 /obj/item/clothing/under/rank/medical/chemist/pharmacist
 	name = "pharmacist's jumpsuit"
 	desc = "It's made of a special fiber that gives special protection against biohazards. For those pharmacists that want to improve or worsen the station's health."
@@ -14,7 +17,7 @@
 
 /obj/item/clothing/under/rank/medical/chemist/pharmacologist
 	name = "pharmacologist's jumpsuit"
-	desc = "It's made of a special fiber that gives special protection against biohazards. For those pharmacologist one step behind to being evil."
+	desc = "It's made of a special fiber that gives special protection against biohazards."
 	icon_state = "pharmacologist"
 	fitted = NO_FEMALE_UNIFORM
 
@@ -45,7 +48,6 @@
 	can_adjust = FALSE
 
 	permeability_coefficient = 0.5
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
 	fitted = NO_FEMALE_UNIFORM
 
 /obj/item/clothing/under/rank/medical/psychiatrist/green
@@ -70,12 +72,12 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 
-/obj/item/clothing/under/suit/cmo
+/obj/item/clothing/under/rank/medical/suit/cmo
 	name = "medical director suit"
 	desc = "A suit with medical colors, meant to be worn by those who lead the medical department."
 	icon_state = "medical_director"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 5, "bio" = 15, "rad" = 5, "fire" = 40, "acid" = 40)
 	fitted = NO_FEMALE_UNIFORM
 	icon = 'icons/obj/clothing/under/medical.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/medical.dmi'
@@ -94,17 +96,16 @@
 	icon_state = "surgeon_general"
 	can_adjust = FALSE
 
-/obj/item/clothing/under/suit/senior_doctor
+/obj/item/clothing/under/rank/medical/suit/senior_doctor
 	name = "senior doctor suit"
 	desc = "A suit with medical colors, meant to be worn by senior staff."
 	icon_state = "senior_medical"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
 	fitted = NO_FEMALE_UNIFORM
 	icon = 'icons/obj/clothing/under/medical.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/medical.dmi'
 
-/obj/item/clothing/under/suit/senior_doctor/skirt
+/obj/item/clothing/under/rank/medical/suit/senior_doctor/skirt
 	name = "senior doctor skirtsuit"
 	desc = "A skirtsuit with medical colors, meant to be worn by senior staff."
 	icon_state = "senior_medical_skirt"
@@ -117,7 +118,7 @@
 	desc = "A suit with chemistry colors, meant to be worn by senior staff."
 	icon_state = "senior_chemistry"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 50, "acid" = 65)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 5, "fire" = 50, "acid" = 75)
 	fitted = NO_FEMALE_UNIFORM
 	icon = 'icons/obj/clothing/under/medical.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/medical.dmi'
@@ -129,17 +130,16 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 
-/obj/item/clothing/under/suit/pathologist
+/obj/item/clothing/under/rank/medical/suit/pathologist
 	name = "pathologist suit"
 	desc = "A suit with special fibers that provide minor protection against biohazards. A suit with green pants, provided to pathologists."
 	icon_state = "pathologist"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
 	fitted = NO_FEMALE_UNIFORM
 	icon = 'icons/obj/clothing/under/medical.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/medical.dmi'
 
-/obj/item/clothing/under/suit/pathologist/skirt
+/obj/item/clothing/under/rank/medical/suit/medical/pathologist/skirt
 	name = "pathologist suit"
 	desc = "A suit with special fibers that provide minor protection against biohazards. A skirtsuit with green pants, provided to pathologists."
 	icon_state = "pathologist_skirt"

--- a/whitesands/code/modules/clothing/under/jobs/rnd.dm
+++ b/whitesands/code/modules/clothing/under/jobs/rnd.dm
@@ -1,4 +1,6 @@
 //Alt job uniforms
+/obj/item/clothing/under/suit/rank/rnd/
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 10, "bio" = 10, "rad" = 5, "fire" = 40, "acid" = 40)
 
 /obj/item/clothing/under/rank/rnd/scientist/junior
 	name = "junior scientist jumpsuit"
@@ -65,7 +67,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 
-/obj/item/clothing/under/suit/senior_scientist
+/obj/item/clothing/under/suit/rank/rnd/senior_scientist
 	name = "senior scientist suit"
 	desc = "A suit with science colors, meant to be worn by senior staff."
 	icon_state = "senior_science"
@@ -74,7 +76,7 @@
 	icon = 'icons/obj/clothing/under/rnd.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/rnd.dmi'
 
-/obj/item/clothing/under/suit/senior_scientist/skirt
+/obj/item/clothing/under/suit/rank/rnd/senior_scientist/skirt
 	name = "senior scientist skirtsuit"
 	desc = "A skirtsuit with science colors, meant to be worn by senior staff."
 	icon_state = "senior_science_skirt"
@@ -82,7 +84,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 
-/obj/item/clothing/under/suit/senior_roboticist
+/obj/item/clothing/under/suit/rank/rnd/senior_roboticist
 	name = "senior roboticist suit"
 	desc = "A suit with robotics colors, meant to be worn by senior staff."
 	icon_state = "senior_roboticist"
@@ -91,7 +93,7 @@
 	icon = 'icons/obj/clothing/under/rnd.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/rnd.dmi'
 
-/obj/item/clothing/under/suit/senior_roboticist/skirt
+/obj/item/clothing/under/suit/rank/rnd/senior_roboticist/skirt
 	name = "senior roboticist skirtsuit"
 	desc = "A skirtsuit with robotics colors, meant to be worn by senior staff."
 	icon_state = "senior_roboticist_skirt"

--- a/whitesands/code/modules/clothing/under/jobs/rnd.dm
+++ b/whitesands/code/modules/clothing/under/jobs/rnd.dm
@@ -18,7 +18,6 @@
 	desc = "It's made of a special fiber that provides minor protection against biohzards. Worn by xenobiologist who have no qualms in creating abominations against nature."
 	icon_state = "xenobiologist"
 
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
 	fitted = NO_FEMALE_UNIFORM
 
 /obj/item/clothing/under/rank/rnd/scientist/xenobiologist/skirt
@@ -32,7 +31,6 @@
 	name = "nanite researcher jumpsuit"
 	desc = "Worn researchers that study and applies the usage of nanites, now more microscopic things to worry about."
 	icon_state = "nanite"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	resistance_flags = NONE
 	fitted = NO_FEMALE_UNIFORM
 
@@ -72,7 +70,6 @@
 	desc = "A suit with science colors, meant to be worn by senior staff."
 	icon_state = "senior_science"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	fitted = NO_FEMALE_UNIFORM
 	icon = 'icons/obj/clothing/under/rnd.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/rnd.dmi'

--- a/whitesands/code/modules/clothing/under/jobs/security.dm
+++ b/whitesands/code/modules/clothing/under/jobs/security.dm
@@ -16,7 +16,7 @@
 /obj/item/clothing/under/rank/security
 	icon = 'icons/obj/clothing/under/security.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/security.dmi'
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 30, "acid" = 30)
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 10, "bio" = 10, "rad" = 5, "fire" = 30, "acid" = 30)
 
 // Security Officer //
 /obj/item/clothing/under/rank/security/officer

--- a/whitesands/code/modules/clothing/under/jobs/security.dm
+++ b/whitesands/code/modules/clothing/under/jobs/security.dm
@@ -16,6 +16,7 @@
 /obj/item/clothing/under/rank/security
 	icon = 'icons/obj/clothing/under/security.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/security.dmi'
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 30, "acid" = 30)
 
 // Security Officer //
 /obj/item/clothing/under/rank/security/officer
@@ -23,7 +24,6 @@
 	desc = "A tactical security jumpsuit for officers complete with Nanotrasen belt buckle."
 	icon_state = "security"
 	item_state = "gy_suit"
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
 	strip_delay = 50
 	alt_covers_chest = TRUE
 	sensor_mode = SENSOR_COORDS
@@ -34,7 +34,7 @@
 	desc = "A \"tactical\" security jumpsuit with the legs replaced by a skirt."
 	icon_state = "security_skirt"
 	body_parts_covered = CHEST|GROIN|ARMS
-	can_adjust = FALSE //you know now that i think of it if you adjust the skirt and the sprite disappears isn't that just like flashing everyone
+	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
 
@@ -44,7 +44,6 @@
 	desc = "Someone who wears this means business."
 	icon_state = "detective"
 	item_state = "det"
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
 	strip_delay = 50
 	alt_covers_chest = TRUE
 	sensor_mode = 3
@@ -109,7 +108,6 @@
 	name = "security suit"
 	desc = "A formal security suit for officers complete with Nanotrasen belt buckle."
 	icon_state = "warden"
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
 	strip_delay = 50
 	alt_covers_chest = TRUE
 	sensor_mode = 3
@@ -129,7 +127,7 @@
 	name = "head of security's jumpsuit"
 	desc = "A security jumpsuit decorated for those few with the dedication to achieve the position of Head of Security."
 	icon_state = "hos"
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 10, "bio" = 15, "rad" = 15, "fire" = 50, "acid" = 50)
 	strip_delay = 60
 	alt_covers_chest = TRUE
 	sensor_mode = 3

--- a/whitesands/code/modules/clothing/under/jobs/security.dm
+++ b/whitesands/code/modules/clothing/under/jobs/security.dm
@@ -127,7 +127,7 @@
 	name = "head of security's jumpsuit"
 	desc = "A security jumpsuit decorated for those few with the dedication to achieve the position of Head of Security."
 	icon_state = "hos"
-	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 10, "bio" = 15, "rad" = 15, "fire" = 50, "acid" = 50)
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 50, "acid" = 50)
 	strip_delay = 60
 	alt_covers_chest = TRUE
 	sensor_mode = 3

--- a/whitesands/code/modules/clothing/under/jobs/service.dm
+++ b/whitesands/code/modules/clothing/under/jobs/service.dm
@@ -2,7 +2,7 @@
 	name = "janitor's jumpsuit"
 	desc = "It's the official uniform of the station's janitor. It has minor protection from biohazards."
 	icon_state = "janitor"
-	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 5, "fire" = 30, "acid" = 30)
 	fitted = NO_FEMALE_UNIFORM
 
 /obj/item/clothing/under/rank/civilian/janitor/skirt

--- a/whitesands/code/modules/clothing/under/jobs/service.dm
+++ b/whitesands/code/modules/clothing/under/jobs/service.dm
@@ -2,7 +2,7 @@
 	name = "janitor's jumpsuit"
 	desc = "It's the official uniform of the station's janitor. It has minor protection from biohazards."
 	icon_state = "janitor"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
 	fitted = NO_FEMALE_UNIFORM
 
 /obj/item/clothing/under/rank/civilian/janitor/skirt

--- a/whitesands/code/modules/clothing/under/misc.dm
+++ b/whitesands/code/modules/clothing/under/misc.dm
@@ -5,10 +5,10 @@
 	desc = "A somewhat uncomfortable suit designed to be as cheap as possible to manufacture."
 	icon_state = "utility"
 	item_state = "utility"
-	fitted = FEMALE_UNIFORM_TOP //i dont know anymore
+	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = TRUE
 
-/obj/item/clothing/under/utility/skirt //trolled.
+/obj/item/clothing/under/utility/skirt
 	name = "utility jumpskirt"
 	desc = "A somewhat uncomfortable suit designed to be as cheap as possible to manufacture. This one has a skirt."
 	body_parts_covered = CHEST|GROIN|ARMS

--- a/whitesands/code/modules/clothing/under/syndicate.dm
+++ b/whitesands/code/modules/clothing/under/syndicate.dm
@@ -2,35 +2,31 @@
 	name = "red polo and khaki pants"
 	desc = "A non-descript and slightly suspicious looking polo paired with a respectable yet also suspicious pair of khaki pants."
 	icon_state = "jake"
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
 	alt_covers_chest = TRUE
 
 /obj/item/clothing/under/syndicate/aclf
 	name = "2nd Battlegroup uniform"
 	desc = "A black uniform worn by the officers of the Gorlex Marauders 2nd Battlegroup."
 	icon_state = "aclf"
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
 	alt_covers_chest = TRUE
 
 /obj/item/clothing/under/syndicate/aclfgrunt
 	name = "ACLF uniform"
 	desc = "A button-up in a tasteful shade of gray with red pants, used as the uniform of the Anti-Corporate Liberation front on the rim."
 	icon_state = "aclfgrunt"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
 	alt_covers_chest = TRUE
 
 /obj/item/clothing/under/syndicate/gorlex
 	name = "Gorlex Marauder uniform"
 	desc = "Originally worn by the miners of the Gorlex VII colony, it is now donned by veteran Gorlex Marauders."
 	icon_state = "gorlex"
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
 	alt_covers_chest = TRUE
 
 /obj/item/clothing/under/syndicate/cybersun
 	name = "Cybersun coveralls"
 	desc = "Nomex coveralls worn by workers and research personnel employed by Cybersun industries."
 	icon_state = "cybersun"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 100)
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 5, "bio" = 10, "rad" = 10, "fire" = 75, "acid" = 100)
 	alt_covers_chest = TRUE
 
 /obj/item/clothing/under/syndicate/medic
@@ -38,7 +34,7 @@
 	desc = "Sterile coveralls worn by Cybersun Industries field medics for protection against biological hazards."
 	icon_state = "cybersun_med"
 	permeability_coefficient = 0.5
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 5, "bio" = 25, "rad" = 10, "fire" = 35, "acid" = 35)
 
 /obj/item/clothing/under/syndicate/medic/skirt
 	name = "Cybersun medical jumpskirt"


### PR DESCRIPTION
## About The Pull Request

A lot of jumpsuits seem to have chaotic armor values or none at all (e.g. various syndie suits, command suits, etc) so I went and gave undersuits a general buff to hopefully make more sense. (Key - Command, Syndicate and star trek suits have 10/5/5, Sec is mostly unchanged)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- Buffs the set of command jumpsuits to have actual armor so you won't be at a disadvantage for wearing your cap's uniform.
- Buffs the Syndie jumpsuits to all have roughly the same armor values with minor differences in enviro. protection. Previously a lot of syndie uniforms lacked any armor values without explaining why.
- Buffs specialized armors (riot/ablative/bulletproof) so they're not awful at their jobs compared to hardsuits.
- Captain/HoS's armor receives a few buffs to make it slightly more relevant
- Ash drake armour is roughly equivalent to a fully upgraded mining RIG now as there's a considerable effort you have to put in.

## Changelog
:cl:
balance: Buffs the Cap's/HoS/Security's clothing including their hardsuits and armored vests to be more relevant. (Sec's RIG originally had a mere 15% bullet resist, half that of a plain armor vest.) Rebalances specialized armor so it isn't flat-out worse then a ERT/Elite RIG, ash drake armor isn't useless anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
