### PR TITLE
Makes welding fuel tanks not blow up on everything

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -103,10 +103,13 @@
 			user.visible_message("<span class='notice'>[user] refills [user.p_their()] [W.name].</span>", "<span class='notice'>You refill [W].</span>")
 			playsound(src, 'sound/effects/refill.ogg', 50, TRUE)
 			W.update_icon()
-		else
+			return
+		if(istype(W) && W.welding)
 			user.visible_message("<span class='danger'>[user] catastrophically fails at refilling [user.p_their()] [I.name]!</span>", "<span class='userdanger'>That was stupid of you.</span>")
 			log_bomber(user, "detonated a", src, "via welding tool")
 			boom()
+		else
+			user.show_message("<span class='notice'>You cannot refill this [W.name].</span>")
 		return
 	return ..()
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -109,7 +109,7 @@
 			log_bomber(user, "detonated a", src, "via welding tool")
 			boom()
 		else
-			user.show_message("<span class='notice'>You cannot refill this [W.name].</span>")
+			user.show_message("<span class='notice'>You cannot refill this [W.name].</span>")//Plasmacutters would set fueltanks off before I changed this. Now they cannot, and neither can varedited tools
 		return
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Welding fuel tanks worked, yes, but the way the code was ordered, it would blow up if you used a plasma cutter or the debug omnitool set to welding type, since they both had tool_welding behaviour, which, while funny, is an issue, since the admin logging for that specifically states "via welding tool", which obviously is bad and misleading.

Of note, this is caused by if(istype(W) && !W.welding) being two checks at once, behind a check for welding behaviour, IE, it checks for welding tool behaviour, and then checks if it's a welding tool, and if it isn't a welding tool, it explodes.

The alternative to this, if we don't want to remove the sillyness that is blowing up a welding tank with a plasmacutter, or something something code freeze, is at minimum a change to the logging to not say "via welding tool". Quite simply that alone is an issue that necessitates changing.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Plasmacutters will no longer blow up welding fuel tanks when trying to refuel them, instead telling you that they cannot be refueled. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
