### PR TITLE
The Overmap is vulnerable to thunderdome explosions. This fixes it.

### DIFF
--- a/voidcrew/code/modules/overmap/events.dm
+++ b/voidcrew/code/modules/overmap/events.dm
@@ -6,6 +6,8 @@
 /obj/structure/overmap/event
 	name = "generic overmap event"
 	integrity = 0
+	///A quick fix to prevent them from being flung around by Thunderdome explosions.
+	anchored = 1
 	///Should the affect_ship() proc be called more than once?
 	var/affect_multiple_times = FALSE
 	///If prob(this), call affect_ship when processed
@@ -16,8 +18,6 @@
 	var/chain_rate = 0
 	///The event to run when the station gets hit by an event
 	var/datum/round_event_control/station_event
-	///A quick fix to prevent them from being flung around by Thunderdome explosions.
-	anchored = 1
 
 /obj/structure/overmap/event/Initialize(mapload)
 	. = ..()

--- a/voidcrew/code/modules/overmap/events.dm
+++ b/voidcrew/code/modules/overmap/events.dm
@@ -16,6 +16,8 @@
 	var/chain_rate = 0
 	///The event to run when the station gets hit by an event
 	var/datum/round_event_control/station_event
+	///A quick fix to prevent them from being flung around by Thunderdome explosions.
+	anchored = 1
 
 /obj/structure/overmap/event/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
ah shite

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
anchors the fuckin overmap events so only ships get flung when the thunderdome explodes

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
random flings bad

## Changelog
:cl:
fix: Thunderdome explosions no longer make the Overmap chaos, and will only fling ships. (Because why would we anchor them)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
