### PR TITLE
removes transfer vote

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -74,18 +74,18 @@ SUBSYSTEM_DEF(vote)
 
 			//WS Begin - Autotransfer
 			else if(mode == "transfer")
-				var/factor = 1
+				var/factor = 0
 				switch(world.time / (1 MINUTES ))
 					if(0 to 60)
-						factor = 0.5
+						factor = 0
 					if(61 to 120)
-						factor = 0.8
+						factor = 0
 					if(121 to 240)
-						factor = 1
+						factor = 0
 					if(241 to 300)
-						factor = 1.2
+						factor = 0
 					else
-						factor = 1.4
+						factor = 0
 				choices["Initiate Crew Transfer"] += round(non_voters.len * factor)
 			//WS End
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It changes 'factor' variable to 0 on start and on every timer check

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

As planets (Z-levels to be exact) reset every time they're empty, and there is no other reason for keeping redundant part of static gameplay (known from bee and /tg) called "Crew Transfer". I did easiest possible way to remove it, but if there's better option than changing 'factor' to 0 then tell me and I will remake PR

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced crew transfer timer
server: this actually disables crew transfer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
