### PR TITLE
Ports the sugarcube

### DIFF
--- a/_maps/configs/NEU_sugarcube.json
+++ b/_maps/configs/NEU_sugarcube.json
@@ -1,0 +1,11 @@
+{
+	"map_name": "Sugarcube-Class Prison Bus Ship",
+	"map_short_name": "Sugarcube-class",
+	"map_path": "_maps/shuttles/shiptest/sugarcube.dmm",
+	"map_id": "sugarcube",
+	"limit": 2,
+	"job_slots": {
+		"Prisoner": 4
+	},
+	"cost": 100
+}

--- a/_maps/configs/NEU_sugarcube.json
+++ b/_maps/configs/NEU_sugarcube.json
@@ -1,6 +1,7 @@
 {
 	"map_name": "Sugarcube-Class Prison Bus Ship",
 	"map_short_name": "Sugarcube-class",
+	"prefix": "NEU",
 	"map_path": "_maps/shuttles/shiptest/sugarcube.dmm",
 	"map_id": "sugarcube",
 	"limit": 2,

--- a/_maps/shuttles/shiptest/sugarcube.dmm
+++ b/_maps/shuttles/shiptest/sugarcube.dmm
@@ -237,6 +237,7 @@
 /obj/effect/spawner/lootdrop/glowstick,
 /obj/item/tank/internals/oxygen,
 /obj/item/tank/internals/oxygen,
+/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plating,
 /area/ship/storage)
 "E" = (

--- a/_maps/shuttles/shiptest/sugarcube.dmm
+++ b/_maps/shuttles/shiptest/sugarcube.dmm
@@ -1,0 +1,373 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall/rust,
+/area/ship/storage)
+"b" = (
+/turf/closed/wall,
+/area/ship/storage)
+"c" = (
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/turf/open/floor/plating,
+/area/ship/storage)
+"d" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/docking_port/mobile{
+	can_move_docking_ports = 1;
+	dir = 2;
+	launch_status = 0;
+	port_direction = 8;
+	preferred_direction = 4
+	},
+/turf/open/floor/plating,
+/area/ship/storage)
+"e" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/storage)
+"f" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/apc/auto_name/north{
+	charging = 20000
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/storage)
+"g" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/smes/shuttle/precharged,
+/turf/open/floor/plating,
+/area/ship/storage)
+"h" = (
+/obj/item/reagent_containers/food/snacks/rationpack,
+/obj/item/reagent_containers/food/snacks/rationpack,
+/obj/item/trash/cheesie,
+/obj/item/trash/cheesie,
+/obj/item/trash/candy,
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/food/drinks/beer,
+/obj/item/reagent_containers/food/drinks/beer,
+/turf/open/floor/plating,
+/area/ship/storage)
+"i" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/ship/storage)
+"j" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plating,
+/area/ship/storage)
+"k" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ship/storage)
+"l" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/storage)
+"m" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/item/radio/intercom/wideband{
+	pixel_y = 26
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/mob_spawn/human/corpse{
+	outfit = /datum/outfit/job/security
+	},
+/turf/open/floor/plating,
+/area/ship/storage)
+"n" = (
+/obj/machinery/computer/helm{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/storage)
+"o" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ship/storage)
+"p" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/port_gen/pacman,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/stack/sheet/mineral/plasma/five,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ship/storage)
+"q" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/trash/chips,
+/turf/open/floor/plating,
+/area/ship/storage)
+"r" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plating,
+/area/ship/storage)
+"s" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/holopad/emergency/command,
+/obj/effect/mob_spawn/human/corpse/assistant,
+/turf/open/floor/plating,
+/area/ship/storage)
+"t" = (
+/obj/item/areaeditor/shuttle,
+/obj/structure/table/reinforced,
+/turf/open/floor/plating,
+/area/ship/storage)
+"u" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_x = -1;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/open/floor/plating,
+/area/ship/storage)
+"v" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/cockroach/glockroach,
+/turf/open/floor/plating,
+/area/ship/storage)
+"w" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/turf/open/floor/plating,
+/area/ship/storage)
+"x" = (
+/mob/living/simple_animal/deer{
+	desc = "A strange looking pony? It likes sugarcubes that is for sure!";
+	name = "Applejack"
+	},
+/turf/open/floor/plating,
+/area/ship/storage)
+"y" = (
+/turf/open/floor/plating,
+/area/ship/storage)
+"z" = (
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/open/floor/plating,
+/area/ship/storage)
+"A" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/obj/item/shard,
+/obj/item/kitchen/knife/shiv,
+/obj/effect/mob_spawn/human/corpse/charredskeleton,
+/turf/open/floor/plating,
+/area/ship/storage)
+"B" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/telecomms/relay,
+/turf/open/floor/plating,
+/area/ship/storage)
+"C" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/safe/floor,
+/obj/item/toy/plush/among,
+/obj/item/clothing/suit/space/hardsuit/carp/old,
+/obj/item/clothing/suit/space/hardsuit/carp/old,
+/turf/open/floor/plating,
+/area/ship/storage)
+"D" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical/old,
+/obj/item/circuitboard/machine/autolathe,
+/obj/item/pickaxe/improvised,
+/obj/item/pickaxe/improvised,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/ship/storage)
+"E" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/storage)
+"F" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/west,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/storage)
+"G" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/ship/storage)
+"H" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/fluff/oldturret,
+/turf/open/floor/plating,
+/area/ship/storage)
+"J" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plating,
+/area/ship/storage)
+"K" = (
+/obj/structure/sign/poster/official/moth/meth,
+/turf/closed/wall/rust,
+/area/ship/storage)
+
+(1,1,1) = {"
+a
+e
+b
+a
+e
+b
+"}
+(2,1,1) = {"
+a
+f
+o
+u
+C
+b
+"}
+(3,1,1) = {"
+a
+g
+p
+v
+D
+b
+"}
+(4,1,1) = {"
+b
+b
+K
+w
+b
+a
+"}
+(5,1,1) = {"
+c
+h
+q
+l
+E
+c
+"}
+(6,1,1) = {"
+a
+i
+l
+x
+j
+b
+"}
+(7,1,1) = {"
+c
+j
+j
+y
+F
+c
+"}
+(8,1,1) = {"
+b
+k
+r
+l
+G
+b
+"}
+(9,1,1) = {"
+d
+l
+l
+z
+l
+J
+"}
+(10,1,1) = {"
+a
+m
+s
+A
+H
+a
+"}
+(11,1,1) = {"
+c
+n
+t
+B
+l
+c
+"}
+(12,1,1) = {"
+c
+c
+c
+c
+c
+c
+"}

--- a/_maps/shuttles/shiptest/sugarcube.dmm
+++ b/_maps/shuttles/shiptest/sugarcube.dmm
@@ -235,6 +235,8 @@
 /obj/item/pickaxe/improvised,
 /obj/effect/spawner/lootdrop/glowstick,
 /obj/effect/spawner/lootdrop/glowstick,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plating,
 /area/ship/storage)
 "E" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sugarcube, as seen on shiptest. Only difference is the addition of two oxygen tanks that weren't present on the shiptest version. 

Original PR: https://github.com/shiptest-ss13/Shiptest/pull/826
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More ships don't hurt, this is a bigger pill, everyone loves their pills.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
![image](https://user-images.githubusercontent.com/29469766/184718726-ac0a02a7-4245-45b0-8ed8-c5f4b78a5dd3.png)
Turret is broken, the carp suits are in a safe. Better get cracking.
## Changelog
:cl:
add: Added the sugarcube from shiptest
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
