### PR TITLE
Price higher for cyanide

### DIFF
--- a/_maps/configs/SYN-C_cyanide.json
+++ b/_maps/configs/SYN-C_cyanide.json
@@ -16,6 +16,6 @@
         }
 
     },
-    "cost": 200,
+    "cost": 375,
 	"disable_passwords": true
 }


### PR DESCRIPTION
## About The Pull Request

People are using the cyanide in almost all rounds at least two around it only feels right too higher the price for how much the ship is being used

## Why It's Good For The Game

So people pick more syndi ships other then mainly using the cyanide

## Changelog
:cl:
add: Made price of the cyanide to 375 from 200 pre wishes of maker and frequent use of it
/:cl:
