### PR TITLE
Adds a missing cable to the Carina

### DIFF
--- a/_maps/shuttles/shiptest/carina.dmm
+++ b/_maps/shuttles/shiptest/carina.dmm
@@ -1347,6 +1347,9 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/industrial/outline,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "wF" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Carina was missing a cable to the storage room APC, the room with the autolathe and ORM. Almost probably my fault, maybe not, here's a fix.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Power
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Added a missing cable to the carina, the storage room will now be powered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
