### PR TITLE
Touches up the listening station

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -11,6 +11,12 @@
 "ag" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
+"ah" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/listeningstation)
 "aL" = (
 /obj/item/bombcore/badmin{
 	anchored = 1;
@@ -24,7 +30,7 @@
 	req_access_txt = "150"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/turf/open/space/basic,
+/turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "aQ" = (
 /obj/machinery/computer/message_monitor,
@@ -215,15 +221,6 @@
 	},
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav/listeningstation)
-"dw" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
 "dz" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	piping_layer = 2
@@ -285,10 +282,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
@@ -450,13 +444,16 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
+"ne" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
 "nf" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+/obj/structure/sink{
+	pixel_y = 27
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/listeningstation)
@@ -491,21 +488,15 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/corner/red{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "pN" = (
-/obj/structure/sign/departments/medbay/alt{
-	pixel_y = -32
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -584,6 +575,12 @@
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav/listeningstation)
 "sy" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/listeningstation)
 "sS" = (
@@ -623,10 +620,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
@@ -671,15 +665,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
-"xe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/listeningstation)
 "xn" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
@@ -869,10 +854,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/corner/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
@@ -898,9 +880,11 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "Iq" = (
-/obj/machinery/iv_drip,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/listeningstation)
@@ -963,8 +947,11 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "LD" = (
-/turf/closed/wall,
-/area/ruin/unpowered/no_grav)
+/obj/structure/sign/departments/medbay/alt{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
 "LG" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 8;
@@ -976,9 +963,8 @@
 /area/ruin/space/has_grav/listeningstation)
 "Mb" = (
 /obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/corner/red,
 /obj/effect/turf_decal/corner/red{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
@@ -1051,14 +1037,8 @@
 /obj/machinery/vending/cola/random{
 	extended_inventory = 1
 	},
-/obj/effect/turf_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/red{
+/obj/effect/turf_decal/corner/red/three_quarters{
 	dir = 4
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
@@ -1105,15 +1085,11 @@
 /obj/machinery/washing_machine{
 	pixel_x = 4
 	},
-/obj/effect/turf_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/red,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/effect/turf_decal/corner/red/three_quarters{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
@@ -1134,6 +1110,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
+"Ti" = (
+/obj/machinery/airalarm/syndicate{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/listeningstation)
 "Tw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -1141,16 +1126,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
-"TB" = (
+"TV" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
 	req_access_txt = "150"
-	},
-/obj/machinery/airalarm/syndicate{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/listeningstation)
@@ -1172,10 +1151,7 @@
 	extended_inventory = 1
 	},
 /obj/effect/turf_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/red{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
@@ -1201,6 +1177,10 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Wq" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/listeningstation)
 "Wv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -1248,9 +1228,11 @@
 /area/ruin/space/has_grav/listeningstation)
 "ZJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay"
 	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/listeningstation)
 
@@ -1624,7 +1606,7 @@ ac
 ac
 ac
 ac
-ac
+ag
 ag
 gy
 ag
@@ -1954,7 +1936,7 @@ Xw
 Xw
 Pc
 ej
-dw
+ol
 ZJ
 Iq
 OY
@@ -1995,7 +1977,7 @@ ac
 ac
 pN
 LD
-xe
+ac
 sy
 oC
 ac
@@ -2034,8 +2016,8 @@ bj
 ac
 bv
 Nd
+qi
 ac
-TB
 nf
 Ci
 ac
@@ -2074,10 +2056,10 @@ bk
 bp
 ac
 bw
+qi
 ac
-ac
-ac
-ac
+Ti
+Wq
 ac
 ab
 ab
@@ -2114,11 +2096,11 @@ bl
 ig
 bz
 bD
+ne
 ac
-ab
-ab
-ab
-ab
+ah
+TV
+ac
 ab
 ab
 ab
@@ -2154,11 +2136,11 @@ mD
 Kr
 ac
 qi
+qi
 ac
-ab
-ab
-ab
-ab
+ac
+ac
+ac
 ab
 ab
 ab
@@ -2195,7 +2177,7 @@ ac
 ac
 aO
 ac
-ab
+ac
 ab
 ab
 ab


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Yesterday I noticed one of the bolted doors on the listening station had space under it. So I fixed it. Then I fixed the decals. Then I decided to touch up the rest of it a little. By which I mean I made the hall in front of the radio room slightly wider, making medical squished but overall larger. Over time I want to just generally improve this place, as I'm not really happy with it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Space tiles under doors is bad. Space is good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The syndicate listneing post now has slightly more room available to begin with.
fix: The syndicate listening post no longer has space lying in wait underneath one of its doors.
/:cl:
The new look of this area.
![image](https://user-images.githubusercontent.com/29469766/185248981-b38f91bc-b6e1-4b17-bdec-7e50c29fc8fc.png)

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
