### PR TITLE
adds a square mapping shuttle for mappers who dont want to play the game

### DIFF
--- a/_maps/configs/NEU_strongdmm.JSON
+++ b/_maps/configs/NEU_strongdmm.JSON
@@ -1,0 +1,19 @@
+{
+	"map_name": "Strong-Class Mapping application",
+	"prefix": "NEU",
+	"map_short_name": "Strong-Class",
+	"map_path": "_maps/shuttles/shiptest/voidcrew/strong.dmm",
+	"map_id": "strong_class",
+	"job_slots": {
+		"Maptainer": {
+			"outfit": "/datum/outfit/job/ce",
+			"officer": true,
+			"slots": 2
+		},
+		"Mapper": {
+			"outfit": "/datum/outfit/job/engineer/mapper",
+			"slots": 3
+		}
+	},
+	"cost": 250
+}

--- a/_maps/shuttles/shiptest/voidcrew/strong.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/strong.dmm
@@ -1,0 +1,289 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"c" = (
+/obj/structure/tank_dispenser,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"d" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"f" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"h" = (
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"i" = (
+/obj/item/areaeditor/shuttle,
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"j" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"k" = (
+/obj/machinery/autolathe,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"m" = (
+/obj/item/grown/log,
+/obj/item/grown/log,
+/obj/item/grown/log,
+/obj/item/grown/log,
+/obj/item/grown/log,
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"n" = (
+/obj/structure/fans/tiny,
+/obj/docking_port/mobile{
+	can_move_docking_ports = 1;
+	dir = 2;
+	launch_status = 0;
+	name = "mining ship";
+	port_direction = 8;
+	preferred_direction = 4
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"o" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/utility/full/engi,
+/obj/item/storage/belt/utility/full/engi,
+/obj/item/storage/belt/utility/full/engi,
+/obj/item/construction/rcd/loaded,
+/obj/item/pipe_dispenser,
+/obj/item/construction/rld,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"s" = (
+/obj/machinery/suit_storage_unit/engine,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"t" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"w" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"x" = (
+/obj/machinery/computer/cryopod{
+	pixel_y = -24
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe/silver,
+/obj/item/pickaxe/silver,
+/obj/item/pickaxe/silver,
+/obj/item/t_scanner/adv_mining_scanner,
+/obj/item/t_scanner/adv_mining_scanner,
+/obj/item/t_scanner/adv_mining_scanner,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"z" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"C" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"D" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/mineral/plasma/fifty,
+/obj/item/circuitboard/machine/shuttle/smes,
+/obj/item/circuitboard/machine/shuttle/smes,
+/obj/item/circuitboard/machine/shuttle/smes,
+/obj/item/circuitboard/machine/shuttle/smes,
+/obj/item/circuitboard/machine/shuttle/engine/electric,
+/obj/item/circuitboard/machine/shuttle/engine/electric,
+/obj/item/circuitboard/machine/shuttle/engine/electric,
+/obj/item/circuitboard/machine/shuttle/engine/electric,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"F" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"H" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"J" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"L" = (
+/turf/closed/wall,
+/area/ship/hallway/central)
+"O" = (
+/obj/machinery/suit_storage_unit/ce,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"R" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"V" = (
+/obj/machinery/computer/helm{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"W" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"Y" = (
+/obj/machinery/atmospherics/components/unary/tank/air,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+
+(1,1,1) = {"
+a
+a
+a
+a
+j
+a
+a
+a
+a
+"}
+(2,1,1) = {"
+a
+Y
+W
+J
+C
+h
+h
+h
+a
+"}
+(3,1,1) = {"
+t
+a
+h
+h
+d
+H
+f
+h
+a
+"}
+(4,1,1) = {"
+a
+a
+h
+R
+k
+D
+w
+h
+a
+"}
+(5,1,1) = {"
+a
+h
+m
+x
+L
+z
+F
+h
+n
+"}
+(6,1,1) = {"
+a
+h
+h
+o
+V
+c
+h
+h
+a
+"}
+(7,1,1) = {"
+a
+h
+h
+h
+i
+h
+h
+h
+a
+"}
+(8,1,1) = {"
+a
+O
+h
+s
+s
+s
+h
+O
+a
+"}
+(9,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -177,3 +177,8 @@
 	shoes = /obj/item/clothing/shoes/workboots
 	alt_uniform = null
 	glasses = null
+
+/datum/outfit/job/engineer/mapper
+	name = "Mapper"
+
+	uniform = /obj/item/clothing/under/rank/civilian/janitor/maid


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/89428914/185766319-d11098b6-5d67-467b-a28a-c0b24bdaa0ee.png)
![image](https://user-images.githubusercontent.com/89428914/185766323-4685a5b8-172c-4f6a-856c-421376d850dc.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
adds outfit datum for "mapper" (engineer in maid outfit)
adds the shuttle itself and its accompanying config

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

mapping is more fun than playing the game for some so im tryna bridge the gap

## Changelog
:cl:
add: Added strong class mapping application shuttle and config
add: Added the "mapper" outfit into station_engineer.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
