### PR TITLE
Head of Staff hardsuit crates

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -791,7 +791,7 @@
 	desc = "Contains an advanced hardsuit, for all your temperature immunity needs."
 	cost = 100000
 	contains = list(/obj/item/clothing/suit/space/hardsuit/engine/elite)
-	crate_name = "Advanced Hardsuit Crate"
+	crate_name = "advanced hardsuit crate"
 
 /datum/supply_pack/engineering/shieldgen
 	name = "Anti-breach Shield Projector Crate"
@@ -1512,6 +1512,13 @@
 					/obj/item/assembly/timer)
 	crate_name = "plasma assembly crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
+
+/datum/supply_pack/science/rdhardsuit
+	name = "Research Director's Hardsuit Crate"
+	desc = "A spare Research Director's Hardsuit in case the first one wasn't explosion-proof enough"
+	cost = 100000
+	contains = list(/obj/item/clothing/suit/space/hardsuit/rd)
+	crate_name = "research director's hardsuit crate"
 
 /datum/supply_pack/science/robotics
 	name = "Robotics Assembly Crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -298,6 +298,13 @@
 					/obj/item/clothing/head/fedora/det_hat)
 	crate_name = "forensics crate"
 
+/datum/supply_pack/security/headofsecsuit
+	name = "Head of Security's Spare Hardsuit
+	desc = "Contains a spare hardsuit for the head of security. Don't lose this one."
+	cost = 120000
+	contains = list(/obj/item/clothing/suit/space/hardsuit/security/hos)
+	crate_name = "head of security's spare hardsuit"
+
 /datum/supply_pack/security/helmets
 	name = "Helmets Crate"
 	desc = "Contains three standard-issue brain buckets. Requires extended Security access to open."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1522,7 +1522,7 @@
 
 /datum/supply_pack/science/rdhardsuit
 	name = "Research Director's Hardsuit Crate"
-	desc = "A spare Research Director's Hardsuit in case the first one wasn't explosion-proof enough"
+	desc = "A spare Research Director's Hardsuit in case the first one wasn't explosion-proof enough."
 	cost = 100000
 	contains = list(/obj/item/clothing/suit/space/hardsuit/rd)
 	crate_name = "research director's hardsuit crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -299,7 +299,7 @@
 	crate_name = "forensics crate"
 
 /datum/supply_pack/security/headofsecsuit
-	name = "Head of Security's Spare Hardsuit
+	name = "Head of Security's Spare Hardsuit"
 	desc = "Contains a spare hardsuit for the head of security. Don't lose this one."
 	cost = 120000
 	contains = list(/obj/item/clothing/suit/space/hardsuit/security/hos)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -786,6 +786,13 @@
 	group = "Engineering"
 	crate_type = /obj/structure/closet/crate/engineering
 
+/datum/supply_pack/engineering/cehardsuit
+	name = "Advanced Hardsuit Crate"
+	desc = "Contains an advanced hardsuit, for all your temperature immunity needs."
+	cost = 100000
+	contains = list(/obj/item/clothing/suit/space/hardsuit/engine/elite)
+	crate_name = "Advanced Hardsuit Crate"
+
 /datum/supply_pack/engineering/shieldgen
 	name = "Anti-breach Shield Projector Crate"
 	desc = "Hull breaches again? Say no more with the Nanotrasen Anti-Breach Shield Projector! Uses forcefield technology to keep the air in, and the space out. Contains two shield projectors."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cargo crates for the CE, RD, and HoS hardsuits. CMO was ignored because the only difference over the medical hardsuit in this code is the flash protection in the helmet, and eh.

CE and RD hardsuits cost 100K, HoS hardsuit costs 120K, prices negotiable. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Head of staff hardsuits are solid equipment generally intended to be fielded against relevant threats in-game, which you generally are unable to do on voidcrew due to lack of the hardsuits. This gives you those options back, if you're willing to pay for it. I don't think the HoS hardsuit will change combat balance due to combat balance being around the even-higher-tier hardsuits such as the syndie and ERT hardsuits.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now buy the Chief Engineer's Hardsuit, the Research Director's Hardsuit, and the Head of Security's hardsuit from cargo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
