### PR TITLE
Syndie tooldisk PR 2 because nobody reopened the first one

### DIFF
--- a/shiptest.dme
+++ b/shiptest.dme
@@ -3384,6 +3384,7 @@ g// DM Environment file for shiptest.dme.
 #include "voidcrew\code\modules\research\designs\nanite_designs.dm"
 #include "voidcrew\code\modules\research\designs\pistol.dm"
 #include "voidcrew\code\modules\research\designs\power_designs.dm"
+#include "voidcrew\code\modules\research\designs\syndie_tool_disk.dm"
 #include "voidcrew\code\modules\research\designs\weapon_designs.dm"
 #include "voidcrew\code\modules\research\nanites\nanite_chamber.dm"
 #include "voidcrew\code\modules\research\nanites\nanite_chamber_computer.dm"

--- a/voidcrew/code/modules/research/designs/pistol.dm
+++ b/voidcrew/code/modules/research/designs/pistol.dm
@@ -32,12 +32,12 @@
 	build_path = /obj/item/gun/ballistic/automatic/pistol/disposable/pizza
 	category = list("Imported")
 
-/obj/item/disk/design_disk/disposable_gun
+/obj/item/disk/design_disk/adv/disposable_gun
 	name = "Design Disk - Disposable Gun"
 	desc = "A design disk containing designs for a cheap and disposable gun."
 	illustration = "gun"
 
-/obj/item/disk/design_disk/disposable_gun/Initialize()
+/obj/item/disk/design_disk/adv/disposable_gun/Initialize()
 	. = ..()
 	var/datum/design/disposable_gun/G = new
 	var/datum/design/pizza_disposable_gun/P = new

--- a/voidcrew/code/modules/research/designs/syndie_tool_disk.dm
+++ b/voidcrew/code/modules/research/designs/syndie_tool_disk.dm
@@ -30,7 +30,7 @@
 	build_path = /obj/item/multitool/syndie
 	category = list("Imported")
 
-/obj/item/disk/design_disk/adv/Syndietools
+/obj/item/disk/design_disk/adv/syndietools
 	name = "Design Disk - Syndicate tools"
 	desc = "A design disk containing the pattern for Syndicate tools."
 	illustration = "generic"

--- a/voidcrew/code/modules/research/designs/syndie_tool_disk.dm
+++ b/voidcrew/code/modules/research/designs/syndie_tool_disk.dm
@@ -1,0 +1,43 @@
+/datum/design/SyndieWrench
+	name = "Suspicious-looking wrench"
+	id = "Syndiwrench"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 150)
+	build_path = /obj/item/wrench/syndie
+	category = list("Imported")
+
+/datum/design/SyndieCrowbar
+	name = "Suspicious-looking crowbar"
+	id = "SyndiCrowbar"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 50)
+	build_path = /obj/item/crowbar/syndie
+	category = list("Imported")
+
+/datum/design/SyndieWirecutters
+	name = "Suspicious-looking wirecutters"
+	id = "SyndiWirecutters"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 80)
+	build_path = /obj/item/wirecutters/syndie
+	category = list("Imported")
+
+/datum/design/SyndieMultitool
+	name = "Suspicious-looking multitool"
+	id = "SyndiMultitool"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 50, /datum/material/glass = 20)
+	build_path = /obj/item/multitool/syndie
+	category = list("Imported")
+
+/obj/item/disk/design_disk/adv/Syndietools
+	name = "Design Disk - Syndicate tools"
+	desc = "A design disk containing the pattern for Syndicate tools."
+	illustration = "generic"
+
+/obj/item/disk/design_disk/adv/Syndietools/Initialize()
+	. = ..()
+	blueprints[1] = new /datum/design/SyndieWrench()
+	blueprints[2] = new /datum/design/SyndieCrowbar()
+	blueprints[3] = new /datum/design/SyndieWirecutters()
+	blueprints[4] = new /datum/design/SyndieMultitool()

--- a/voidcrew/code/modules/research/designs/syndie_tool_disk.dm
+++ b/voidcrew/code/modules/research/designs/syndie_tool_disk.dm
@@ -30,6 +30,14 @@
 	build_path = /obj/item/multitool/syndie
 	category = list("Imported")
 
+/datum/design/SyndieScrewdriver
+	name = "Screwdriver"
+	id = "SyndiScrewdriver"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 75)
+	build_path = /obj/item/screwdriver/nuke
+	category = list("Imported")
+
 /obj/item/disk/design_disk/adv/syndietools
 	name = "Design Disk - Syndicate tools"
 	desc = "A design disk containing the pattern for Syndicate tools."
@@ -41,3 +49,4 @@
 	blueprints[2] = new /datum/design/SyndieCrowbar()
 	blueprints[3] = new /datum/design/SyndieWirecutters()
 	blueprints[4] = new /datum/design/SyndieMultitool()
+	blueprints[5] = new /datum/design/SyndieScrewdriver()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a design disk for basic syndicate tools, and fixes the disk for the disposable gun, as the non-basic design disk couldn't hold the two designs it wanted. I haven't placed the syndicate tool disk anywhere yet, that's for later, since that's largely a mapping thing, apart from where it would be a coding thing, in which case you'd get too many.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I like red tools, so do others.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a design disk for syndicate tools, allowing them to built in an autolathe.
fix: Fixes the disposable gun disk to finally allow you print the disposable pizza gun.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
