### PR TITLE
Preferences saving, robot overlay and achievement fixes

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -1911,7 +1911,7 @@
 	dir = 9
 	},
 /obj/structure/rack,
-/obj/item/syndie_crusher,
+/obj/item/kinetic_crusher/syndie,
 /obj/item/card/emag,
 /obj/item/construction/rcd/combat{
 	desc = "A suspicious-looking RCD that rapidly builds and deconstructs. Has extra ammo capacity.";

--- a/_maps/configs/NT-C_Nanopill.json
+++ b/_maps/configs/NT-C_Nanopill.json
@@ -1,6 +1,6 @@
 {
 	"prefix": "NT-C",
-	"map_name": "Nanopill class Trasport Pill",
+	"map_name": "Nanopill-class Transport Pill",
 	"map_short_name": "Nanopill-class",
 	"map_path": "_maps/shuttles/shiptest/voidcrew/Nanopill.dmm",
 	"map_id": "nt_nanopill",

--- a/_maps/shuttles/shiptest/hyena.dmm
+++ b/_maps/shuttles/shiptest/hyena.dmm
@@ -1149,7 +1149,7 @@
 	pixel_y = 24
 	},
 /obj/item/storage/box/emptysandbags,
-/obj/item/syndie_crusher{
+/obj/item/kinetic_crusher/syndie{
 	pixel_x = 5;
 	pixel_y = 6
 	},
@@ -1552,7 +1552,7 @@
 	pixel_y = 28
 	},
 /obj/item/storage/box/emptysandbags,
-/obj/item/syndie_crusher{
+/obj/item/kinetic_crusher/syndie{
 	pixel_x = 5;
 	pixel_y = 6
 	},

--- a/code/datums/achievements/boss_scores.dm
+++ b/code/datums/achievements/boss_scores.dm
@@ -14,9 +14,9 @@
 	database_id = MINER_SCORE
 
 /datum/award/score/demonic_miner_score
-	name = "Blood-Drunk Miners Killed"
+	name = "Demonic-Frost Miners Killed"
 	desc = "You've killed HOW many?"
-	database_id = MINER_SCORE
+	database_id = FROST_MINER_SCORE
 
 /datum/award/score/bubblegum_score
 	name = "Bubblegums Killed"

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -53,17 +53,17 @@
 /obj/item/robot_suit/update_overlays()
 	. = ..()
 	if(l_arm)
-		. += "[l_arm.icon_state]+o"
+		. += "[initial(l_arm.icon_state)]+o"
 	if(r_arm)
-		. += "[r_arm.icon_state]+o"
+		. += "[initial(r_arm.icon_state)]+o"
 	if(chest)
-		. += "[chest.icon_state]+o"
+		. += "[initial(chest.icon_state)]+o"
 	if(l_leg)
-		. += "[l_leg.icon_state]+o"
+		. += "[initial(l_leg.icon_state)]+o"
 	if(r_leg)
-		. += "[r_leg.icon_state]+o"
+		. += "[initial(r_leg.icon_state)]+o"
 	if(head)
-		. += "[head.icon_state]+o"
+		. += "[initial(head.icon_state)]+o"
 
 /obj/item/robot_suit/proc/check_completion()
 	if(src.l_arm && src.r_arm)

--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -364,7 +364,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 			if(prob(35))
 				new /obj/item/storage/belt/military(loc)
 			if(prob(25))
-				new /obj/item/syndie_crusher(loc)
+				new /obj/item/kinetic_crusher/syndie(loc)
 				new /mob/living/simple_animal/hostile/syndicate/ranged/smg(loc)
 			if(prob(25))
 				new /obj/item/card/id/syndicate/anyone(loc)

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -46,11 +46,7 @@ GLOBAL_LIST_INIT(tendrils, list())
 
 
 /obj/structure/spawner/lavaland/Destroy()
-	var/last_tendril = TRUE
-	if(GLOB.tendrils.len>1)
-		last_tendril = FALSE
-
-	if(last_tendril && !(flags_1 & ADMIN_SPAWNED_1))
+	if(!(flags_1 & ADMIN_SPAWNED_1))
 		if(SSachievements.achievements_enabled)
 			for(var/mob/living/L in view(7,src))
 				if(L.stat || !L.client)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -385,8 +385,10 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	READ_FILE(S["feature_mcolor"], features["mcolor"])
 	READ_FILE(S["feature_ethcolor"], features["ethcolor"])
 	READ_FILE(S["feature_lizard_tail"], features["tail_lizard"])
+	READ_FILE(S["feature_human_tail"], features["tail_human"])
 	READ_FILE(S["feature_lizard_snout"], features["snout"])
 	READ_FILE(S["feature_lizard_horns"], features["horns"])
+	READ_FILE(S["feature_human_ears"], features["ears"])
 	READ_FILE(S["feature_lizard_frills"], features["frills"])
 	READ_FILE(S["feature_lizard_spines"], features["spines"])
 	READ_FILE(S["feature_lizard_body_markings"], features["body_markings"])
@@ -424,13 +426,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		equipped_gear = list()
 
 	//WS End
-
-	if(!CONFIG_GET(flag/join_with_mutant_humans))
-		features["tail_human"] = "none"
-		features["ears"] = "none"
-	else
-		READ_FILE(S["feature_human_tail"], features["tail_human"])
-		READ_FILE(S["feature_human_ears"], features["ears"])
 
 	//Custom names
 	for(var/custom_name_id in GLOB.preferences_custom_names)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -653,173 +653,47 @@
 	item_state = "crusherold[wielded]" // still not supported by 2hcomponent
 
 //100% original syndicate oc, plz do not steal. More effective against human targets then the typical crusher, with a bit of block chance.
-/obj/item/syndie_crusher
-	icon = 'icons/obj/mining.dmi'
+/obj/item/kinetic_crusher/syndie
 	icon_state = "crushersyndie"
 	item_state = "crushersyndie0"
-	lefthand_file = 'icons/mob/inhands/weapons/hammers_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/weapons/hammers_righthand.dmi'
 	name = "magnetic cleaver"
 	desc = "Designed by Syndicate Research and Development for their resource-gathering operations on hostile worlds. Syndicate Legal Ops would like to stress that you've never seen anything like this before. Ever."
 	armour_penetration = 69//nice cut
-	force = 0 //You can't hit stuff unless wielded
-	w_class = WEIGHT_CLASS_BULKY
-	slot_flags = ITEM_SLOT_BACK
-	throwforce = 5
-	throw_speed = 4
 	block_chance = 30
 	custom_materials = list(/datum/material/titanium=5000, /datum/material/iron=2075)
 	hitsound = 'sound/weapons/blade1.ogg'
 	attack_verb = list("sliced", "bisected", "diced", "chopped", "filleted")
-	sharpness = IS_SHARP
-	obj_flags = UNIQUE_RENAME
+	actions_types = null
 	light_color = "#fb6767"
-	light_system = MOVABLE_LIGHT
 	light_range = 3
 	light_power = 1
-	light_on = FALSE
 	custom_price = 7500//a rare syndicate prototype.
-	var/list/trophies = list()
-	var/charged = TRUE
-	var/charge_time = 15
-	var/detonation_damage = 10
-	var/backstab_bonus = 30
-	var/wielded = FALSE // track wielded status on item
+	detonation_damage = 10
 
-/obj/item/syndie_crusher/Initialize()
+/obj/item/kinetic_crusher/syndie/Initialize()
 	. = ..()
-	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, .proc/on_wield)
-	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, .proc/on_unwield)
 	set_light_on(wielded)
 	START_PROCESSING(SSobj, src)
 
-/obj/item/syndie_crusher/ComponentInitialize()
-	. = ..()
+/obj/item/kinetic_crusher/syndie/ComponentInitialize()
 	AddComponent(/datum/component/butchering, 60, 150)
 	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=35)
 
-/obj/item/syndie_crusher/Destroy()
-	QDEL_LIST(trophies)
-	STOP_PROCESSING(SSobj, src)
-	return ..()
 
 /// triggered on wield of two handed item
-/obj/item/syndie_crusher/proc/on_wield(obj/item/source, mob/user)
-	wielded = TRUE
+/obj/item/kinetic_crusher/syndie/on_wield(obj/item/source, mob/user)
+	. = ..()
 	icon_state = "crushersyndie1"
 	playsound(user, 'sound/weapons/saberon.ogg', 35, TRUE)
 	set_light_on(wielded)
 
 /// triggered on unwield of two handed item
-/obj/item/syndie_crusher/proc/on_unwield(obj/item/source, mob/user)
-	wielded = FALSE
+/obj/item/kinetic_crusher/syndie/on_unwield(obj/item/source, mob/user)
+	. = ..()
 	icon_state = "crushersyndie"
 	playsound(user, 'sound/weapons/saberoff.ogg', 35, TRUE)
 	set_light_on(wielded)
 
-/obj/item/syndie_crusher/examine(mob/living/user)
-	. = ..()
-	. += "<span class='notice'>Induce magnetism in an enemy by striking them with a magnetospheric wave, then hit them in melee to force a waveform collapse for <b>[force + detonation_damage]</b> damage.</span>"
-	. += "<span class='notice'>Does <b>[force + detonation_damage + backstab_bonus]</b> damage if the target is backstabbed, instead of <b>[force + detonation_damage]</b>.</span>"
-	for(var/t in trophies)
-		var/obj/item/crusher_trophy/T = t
-		. += "<span class='notice'>It has \a [T] attached, which causes [T.effect_desc()].</span>"
-
-/obj/item/syndie_crusher/attackby(obj/item/I, mob/living/user)
-	if(I.tool_behaviour == TOOL_CROWBAR)
-		if(LAZYLEN(trophies))
-			to_chat(user, "<span class='notice'>You remove [src]'s trophies.</span>")
-			I.play_tool_sound(src)
-			for(var/t in trophies)
-				var/obj/item/crusher_trophy/T = t
-				T.remove_from(src, user)
-		else
-			to_chat(user, "<span class='warning'>There are no trophies on [src].</span>")
-	else if(istype(I, /obj/item/crusher_trophy))
-		var/obj/item/crusher_trophy/T = I
-		T.add_to(src, user)
-	else
-		return ..()
-
-/obj/item/syndie_crusher/attack(mob/living/target, mob/living/carbon/user)
-	if(!wielded)
-		to_chat(user, "<span class='warning'>[src] is too heavy to use with one hand! You fumble and drop everything.</span>")
-		user.drop_all_held_items()
-		return
-	var/datum/status_effect/crusher_damage/C = target.has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
-	var/target_health = target.health
-	..()
-	for(var/t in trophies)
-		if(!QDELETED(target))
-			var/obj/item/crusher_trophy/T = t
-			T.on_melee_hit(target, user)
-	if(!QDELETED(C) && !QDELETED(target))
-		C.total_damage += target_health - target.health //we did some damage, but let's not assume how much we did
-
-/obj/item/syndie_crusher/afterattack(atom/target, mob/living/user, proximity_flag, clickparams)
-	. = ..()
-	if(!wielded)
-		return
-	if(!proximity_flag && charged)//Mark a target, or mine a tile.
-		var/turf/proj_turf = user.loc
-		if(!isturf(proj_turf))
-			return
-		var/obj/projectile/destabilizer/D = new /obj/projectile/destabilizer(proj_turf)
-		for(var/t in trophies)
-			var/obj/item/crusher_trophy/T = t
-			T.on_projectile_fire(D, user)
-		D.preparePixelProjectile(target, user, clickparams)
-		D.firer = user
-		D.hammer_synced = src
-		playsound(user, 'sound/weapons/plasma_cutter.ogg', 100, TRUE)
-		D.fire()
-		charged = FALSE
-		update_icon()
-		addtimer(CALLBACK(src, .proc/Recharge), charge_time)
-		return
-	if(proximity_flag && isliving(target))
-		var/mob/living/L = target
-		var/datum/status_effect/crusher_mark/CM = L.has_status_effect(STATUS_EFFECT_CRUSHERMARK)
-		if(!CM || CM.hammer_synced != src || !L.remove_status_effect(STATUS_EFFECT_CRUSHERMARK))
-			return
-		var/datum/status_effect/crusher_damage/C = L.has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
-		var/target_health = L.health
-		for(var/t in trophies)
-			var/obj/item/crusher_trophy/T = t
-			T.on_mark_detonation(target, user)
-		if(!QDELETED(L))
-			if(!QDELETED(C))
-				C.total_damage += target_health - L.health //we did some damage, but let's not assume how much we did
-			new /obj/effect/temp_visual/kinetic_blast(get_turf(L))
-			var/backstab_dir = get_dir(user, L)
-			var/def_check = L.getarmor(type = "bomb")
-			if((user.dir & backstab_dir) && (L.dir & backstab_dir))
-				if(!QDELETED(C))
-					C.total_damage += detonation_damage + backstab_bonus //cheat a little and add the total before killing it, so certain mobs don't have much lower chances of giving an item
-				L.apply_damage(detonation_damage + backstab_bonus, BRUTE, blocked = def_check)
-				playsound(user, 'sound/weapons/kenetic_accel.ogg', 100, TRUE) //Seriously who spelled it wrong
-			else
-				if(!QDELETED(C))
-					C.total_damage += detonation_damage
-				L.apply_damage(detonation_damage, BRUTE, blocked = def_check)
-
-/obj/item/syndie_crusher/proc/Recharge()
-	if(!charged)
-		charged = TRUE
-		update_icon()
-		playsound(src.loc, 'sound/weapons/kenetic_reload.ogg', 60, TRUE)
-
-/obj/item/syndie_crusher/ui_action_click(mob/user, actiontype)
-	set_light_on(!light_on)
-	playsound(user, 'sound/weapons/empty.ogg', 100, TRUE)
-	update_icon()
-
-/obj/item/syndie_crusher/update_icon_state()
+/obj/item/kinetic_crusher/syndie/update_icon_state()
 	item_state = "crushersyndie[wielded]" // this is not icon_state and not supported by 2hcomponent
 
-/obj/item/syndie_crusher/update_overlays()
-	. = ..()
-	if(!charged)
-		. += "[icon_state]_uncharged"
-	if(wielded)
-		. += "[icon_state]_lit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR will fix the tail and ears preferences not saving, prebuilt cyborgs not having overlays, the syndicate crusher is now a subtype of a normal crusher and every tendril will add to the tendril score
This PR also changes the Nanopill ship name.
Please tell me if any changes need to be reverted or modified.

## Why It's Good For The Game
Fixes #98
Players are now able to get achievements when killing megafauna using the syndicate crusher and all tendril destructions will add to the score.
Tail and ears preferences for felinids will no longer have to be redone every server restart.

## Changelog
:cl: Alysiah
fix: Fixed tail and ears preferences not saving.
fix: Prebuilt cyborg bodies now show up correctly.
fix: Megafauna kills with the syndicate crusher will now count for achievements.
fix: Demonic-frost miner achievement score is now separate from blood-drunk.
tweak: Every tendril destruction will add to your tendril score.
spellcheck: The Nanopill ship name is correct now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
