### PR TITLE
Fixes portals in wizardmaze.dmm

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/wizardmaze.dmm
+++ b/_maps/RandomRuins/SpaceRuins/wizardmaze.dmm
@@ -143,6 +143,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/wizard_station)
+"oZ" = (
+/obj/effect/portal/permanent/one_way{
+	id = "portalnumero2o"
+	},
+/turf/open/floor/carpet/red,
+/area/wizard_station)
 "qu" = (
 /obj/effect/portal/permanent/one_way{
 	id = "portalnumero5"
@@ -294,6 +300,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/wizard_station)
+"BD" = (
+/obj/effect/portal/permanent/one_way{
+	id = "portalnumero3o"
+	},
+/turf/open/floor/carpet/red,
+/area/wizard_station)
 "Ck" = (
 /obj/effect/landmark/portal_exit{
 	id = "portalnumero19"
@@ -397,9 +409,24 @@
 	},
 /turf/open/floor/carpet/red,
 /area/wizard_station)
+"KE" = (
+/obj/effect/portal/permanent/one_way{
+	id = "portalnumero1o"
+	},
+/turf/open/floor/carpet/red,
+/area/wizard_station)
 "KI" = (
 /obj/effect/portal/permanent/one_way{
 	id = "portalnumero13"
+	},
+/turf/open/floor/carpet/red,
+/area/wizard_station)
+"LK" = (
+/obj/effect/landmark/portal_exit{
+	id = "portalnumero2o"
+	},
+/obj/machinery/light/floor{
+	alpha = 0
 	},
 /turf/open/floor/carpet/red,
 /area/wizard_station)
@@ -457,6 +484,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/wizard_station)
+"Qj" = (
+/obj/effect/landmark/portal_exit{
+	id = "portalnumero1o"
+	},
+/obj/machinery/light/floor{
+	alpha = 0
+	},
+/turf/open/floor/carpet/red,
+/area/wizard_station)
 "ST" = (
 /obj/effect/portal/permanent/one_way{
 	id = "portalnumero6"
@@ -486,7 +522,7 @@
 /area/wizard_station)
 "XJ" = (
 /obj/effect/landmark/portal_exit{
-	id = "portalnumero3"
+	id = "portalnumero3o"
 	},
 /turf/open/floor/carpet/blue,
 /area/wizard_station)
@@ -1920,7 +1956,7 @@ wO
 wO
 wO
 jA
-Yx
+LK
 jA
 wO
 jA
@@ -1928,7 +1964,7 @@ gr
 jA
 wO
 jA
-Id
+Qj
 jA
 wO
 jA
@@ -2119,13 +2155,13 @@ tK
 wO
 ix
 jA
-vk
+oZ
 wO
 bb
 jA
 Mu
 wO
-Ga
+KE
 jA
 Gy
 wO
@@ -2249,17 +2285,17 @@ tK
 jA
 tK
 wO
-vk
+oZ
 jA
-vk
+oZ
 wO
 bb
 jA
 bb
 wO
-Ga
+KE
 jA
-Ga
+KE
 wO
 oy
 jA
@@ -2640,7 +2676,7 @@ wO
 wO
 iH
 jA
-HF
+BD
 wO
 Mr
 jA
@@ -3309,7 +3345,7 @@ ix
 jA
 ix
 wO
-vk
+oZ
 jA
 Mu
 wO
@@ -3319,7 +3355,7 @@ bb
 wO
 vY
 jA
-Ga
+KE
 wO
 wO
 ZQ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the missing 0s in wizard maze ruin portals caused by an issue with map conversion, and the maze should now be able to be completed properly.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because stuff working properly is good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed portals ID'd "portalnumero10", "portalnumero20", and "portalnumero30", replacing the 0s with Os to avoid any further issues.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
