### PR TITLE
Adds Infiltrator Wreckage as a new SpaceRuin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/infiltratorwreckage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infiltratorwreckage.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ah" = (
 /obj/effect/decal/cleanable/ash/large,
-/turf/open/floor/plating/asteroid/lowpressure,
+/turf/open/floor/plating/asteroid/airless,
 /area/awaymission/moonoutpost19/main)
 "aq" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16,6 +16,9 @@
 /obj/item/mmi/syndie,
 /obj/item/mmi/syndie,
 /turf/open/floor/plasteel/dark,
+/area/awaymission/moonoutpost19/main)
+"aH" = (
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "aU" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -75,7 +78,7 @@
 /area/awaymission/moonoutpost19/main)
 "cx" = (
 /mob/living/simple_animal/hostile/carp,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "dd" = (
 /obj/effect/turf_decal/industrial/warning,
@@ -83,7 +86,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "dh" = (
 /obj/structure/girder/reinforced,
@@ -105,7 +108,7 @@
 /turf/open/space/basic,
 /area/awaymission/moonoutpost19/main)
 "dX" = (
-/turf/open/floor/plating/asteroid/lowpressure,
+/turf/open/floor/plating/asteroid/airless,
 /area/awaymission/moonoutpost19/main)
 "eB" = (
 /obj/structure/grille,
@@ -143,7 +146,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "iw" = (
 /obj/item/toy/figure/syndie{
@@ -152,14 +155,14 @@
 	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "jz" = (
 /obj/item/storage/box/handcuffs{
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "kj" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -207,7 +210,7 @@
 "nF" = (
 /obj/effect/acid/alien,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "nP" = (
 /obj/machinery/door/airlock/external{
@@ -222,7 +225,9 @@
 	name = "Infiltrator Containment Unit"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/circuit/red/off,
+/turf/open/floor/circuit/red/airless{
+	icon_state = "rcircuitoff"
+	},
 /area/awaymission/moonoutpost19/main)
 "of" = (
 /obj/structure/shuttle/engine/heater,
@@ -237,11 +242,11 @@
 /obj/machinery/light/broken{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "qu" = (
 /obj/effect/decal/cleanable/robot_debris/limb,
-/turf/open/floor/plating/asteroid/lowpressure,
+/turf/open/floor/plating/asteroid/airless,
 /area/awaymission/moonoutpost19/main)
 "qI" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -250,7 +255,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/suit_storage_unit/open,
 /obj/machinery/light/small/broken,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/airless,
 /area/awaymission/moonoutpost19/main)
 "qJ" = (
 /obj/structure/chair/comfy/shuttle{
@@ -277,7 +282,7 @@
 /area/awaymission/moonoutpost19/main)
 "si" = (
 /obj/item/stack/sheet/metal,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "sF" = (
 /obj/structure/fluff/broken_flooring{
@@ -296,21 +301,21 @@
 "sS" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/remains/human,
-/turf/open/floor/plating/asteroid/lowpressure,
+/turf/open/floor/plating/asteroid/airless,
 /area/awaymission/moonoutpost19/main)
 "sZ" = (
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/metal,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "tr" = (
 /obj/effect/decal/cleanable/ash,
-/turf/open/floor/plating/asteroid/lowpressure,
+/turf/open/floor/plating/asteroid/airless,
 /area/awaymission/moonoutpost19/main)
 "tX" = (
 /obj/effect/decal/cleanable/shreds,
-/turf/open/floor/plating/asteroid/lowpressure,
+/turf/open/floor/plating/asteroid/airless,
 /area/awaymission/moonoutpost19/main)
 "ub" = (
 /obj/structure/shuttle/engine/propulsion,
@@ -324,7 +329,7 @@
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil/white,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "uY" = (
 /obj/structure/girder/reinforced,
@@ -357,7 +362,9 @@
 "yJ" = (
 /obj/item/restraints/handcuffs,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/circuit/red/off,
+/turf/open/floor/circuit/red/airless{
+	icon_state = "rcircuitoff"
+	},
 /area/awaymission/moonoutpost19/main)
 "yY" = (
 /obj/structure/lattice,
@@ -374,7 +381,9 @@
 /turf/open/floor/plasteel/dark,
 /area/awaymission/moonoutpost19/main)
 "zn" = (
-/turf/open/floor/circuit/red/off,
+/turf/open/floor/circuit/red/airless{
+	icon_state = "rcircuitoff"
+	},
 /area/awaymission/moonoutpost19/main)
 "zN" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -393,7 +402,7 @@
 /area/awaymission/moonoutpost19/main)
 "Dp" = (
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plating/asteroid/lowpressure,
+/turf/open/floor/plating/asteroid/airless,
 /area/awaymission/moonoutpost19/main)
 "DI" = (
 /obj/structure/chair/comfy/shuttle{
@@ -401,14 +410,14 @@
 	name = "tactical chair"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "DP" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1;
 	name = "tactical chair"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "Eh" = (
 /turf/open/floor/plating/airless{
@@ -423,7 +432,7 @@
 /area/awaymission/moonoutpost19/main)
 "EL" = (
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating/asteroid/lowpressure,
+/turf/open/floor/plating/asteroid/airless,
 /area/awaymission/moonoutpost19/main)
 "Fk" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -477,7 +486,7 @@
 	dir = 8;
 	name = "tactical chair"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "Gm" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -506,18 +515,23 @@
 /area/awaymission/moonoutpost19/main)
 "Iv" = (
 /mob/living/simple_animal/hostile/carp,
-/turf/open/floor/plating/asteroid/lowpressure,
+/turf/open/floor/plating/asteroid/airless,
 /area/awaymission/moonoutpost19/main)
 "IF" = (
 /obj/item/gun/ballistic/automatic/pistol/suppressed,
-/turf/open/floor/plating/asteroid/lowpressure,
+/turf/open/floor/plating/asteroid/airless,
+/area/awaymission/moonoutpost19/main)
+"IO" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "IS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/broken{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "IV" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -558,12 +572,12 @@
 /area/awaymission/moonoutpost19/main)
 "KD" = (
 /obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "KL" = (
 /obj/item/stack/cable_coil/red,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "Mz" = (
 /obj/item/cautery,
@@ -583,7 +597,7 @@
 "NH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/metal,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "OQ" = (
 /obj/structure/fluff/broken_flooring{
@@ -595,7 +609,7 @@
 /area/awaymission/moonoutpost19/main)
 "Pa" = (
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "Pl" = (
 /obj/structure/table/reinforced,
@@ -612,37 +626,41 @@
 /area/awaymission/moonoutpost19/main)
 "Pw" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/circuit/red/off,
+/turf/open/floor/circuit/red/airless{
+	icon_state = "rcircuitoff"
+	},
 /area/awaymission/moonoutpost19/main)
 "PO" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/circuit/red/off,
+/turf/open/floor/circuit/red/airless{
+	icon_state = "rcircuitoff"
+	},
 /area/awaymission/moonoutpost19/main)
 "Qa" = (
 /obj/effect/decal/remains/robot,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "Qt" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "Qu" = (
 /obj/machinery/door/airlock/external{
 	name = "E.V.A. Gear Storage";
 	req_access_txt = "150"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "Qx" = (
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "QC" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -663,7 +681,7 @@
 "Ry" = (
 /obj/structure/table_frame,
 /obj/item/stack/sheet/plasteel,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "RL" = (
 /obj/structure/lattice,
@@ -685,24 +703,28 @@
 "SS" = (
 /obj/effect/decal/cleanable/molten_object/large,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "Tb" = (
 /obj/structure/door_assembly/door_assembly_hatch{
 	anchored = 1;
 	broken = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "Tp" = (
 /obj/structure/shuttle/engine/propulsion/left,
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plating/airless,
 /area/awaymission/moonoutpost19/main)
+"TL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/awaymission/moonoutpost19/main)
 "Ua" = (
 /obj/effect/decal/cleanable/molten_object,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "Uj" = (
 /obj/structure/chair/comfy/shuttle{
@@ -726,7 +748,7 @@
 	dir = 4
 	},
 /obj/machinery/suit_storage_unit/open,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/airless,
 /area/awaymission/moonoutpost19/main)
 "UM" = (
 /obj/structure/sign/warning/vacuum/external,
@@ -740,11 +762,11 @@
 /obj/structure/chair/comfy/shuttle{
 	name = "tactical chair"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "Wh" = (
 /obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/plating/asteroid/lowpressure,
+/turf/open/floor/plating/asteroid/airless,
 /area/awaymission/moonoutpost19/main)
 "WA" = (
 /obj/item/retractor,
@@ -755,7 +777,7 @@
 "WB" = (
 /obj/effect/decal/cleanable/robot_debris/old,
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating/asteroid/lowpressure,
+/turf/open/floor/plating/asteroid/airless,
 /area/awaymission/moonoutpost19/main)
 "WT" = (
 /obj/machinery/door/poddoor{
@@ -772,7 +794,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark/airless,
 /area/awaymission/moonoutpost19/main)
 "Xj" = (
 /mob/living/simple_animal/hostile/carp,
@@ -780,7 +802,7 @@
 /area/space)
 "Xu" = (
 /obj/structure/mecha_wreckage/gygax/dark,
-/turf/open/floor/plating/asteroid/lowpressure,
+/turf/open/floor/plating/asteroid/airless,
 /area/awaymission/moonoutpost19/main)
 "XB" = (
 /obj/effect/decal/cleanable/robot_debris/gib,
@@ -1625,7 +1647,7 @@ Eh
 uk
 hr
 rL
-Jf
+TL
 Jc
 kS
 AH
@@ -1687,11 +1709,11 @@ Jc
 RO
 RO
 Jc
-Jf
+TL
 aq
 vD
-AH
-Jf
+aH
+TL
 Jc
 zg
 AH
@@ -1754,9 +1776,9 @@ Jc
 RO
 Jc
 Rj
-AH
+aH
 Gm
-Jf
+TL
 KD
 Jc
 FE
@@ -1883,15 +1905,15 @@ vy
 Em
 Jc
 uC
-Jf
+TL
 Vk
 si
 DI
 eB
 Qt
 Ua
-Jf
-Jf
+TL
+TL
 dd
 Jc
 yJ
@@ -1948,16 +1970,16 @@ dF
 NA
 Fk
 Tb
-Jf
-kj
-Jf
-Jf
+TL
+IO
+TL
+TL
 NH
 XK
-Jf
-Jf
-Jf
-Jf
+TL
+TL
+TL
+TL
 Qx
 nR
 zn
@@ -2018,12 +2040,12 @@ jz
 DP
 IS
 FW
-AH
+aH
 eB
-Jf
-Jf
+TL
+TL
 SS
-Jf
+TL
 sZ
 Jc
 zn
@@ -2222,7 +2244,7 @@ Jf
 AH
 Jc
 Pa
-Jf
+TL
 NA
 Fk
 rL

--- a/_maps/RandomRuins/SpaceRuins/infiltratorwreckage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infiltratorwreckage.dmm
@@ -2,16 +2,12 @@
 "ah" = (
 /obj/effect/decal/cleanable/ash/large,
 /turf/open/floor/plating/asteroid/lowpressure,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "aq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/mineral/plastitanium,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "az" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -20,30 +16,67 @@
 /obj/item/mmi/syndie,
 /obj/item/mmi/syndie,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "aU" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "ch" = (
 /obj/effect/decal/cleanable/robot_debris/limb,
+/mob/living/simple_animal/hostile/nanotrasen/ranged/assault{
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	attack_sound = 'sound\weapons\blade1.ogg';
+	attack_verb_continuous = "slashes";
+	attack_verb_simple = "slash";
+	casingtype = /obj/item/ammo_casing/mm712x82;
+	damage_coeff = list("brute" = 0.7, "fire" = 1.2, "toxin" = 1, "clone" = 1, "stamina" = 0, "oxygen" = 1);
+	deathmessage = "falls apart!";
+	deathsound = 'sound\voice\borg_deathsound.ogg';
+	desc = "A heavily armed, malfunctioning Syndicate Assault Cyborg. You should run.";
+	has_unlimited_silicon_privilege = 1;
+	health = 1250;
+	icon = 'icons/mob/robots.dmi';
+	icon_gib = null;
+	icon_living = "synd_sec";
+	icon_state = "synd_sec";
+	light_color = "#B90E0A";
+	light_power = 1.5;
+	light_range = 2;
+	lighting_alpha = 128;
+	loot = list(/obj/effect/decal/cleanable/robot_debris);
+	maxHealth = 1250;
+	maxbodytemp = 1350;
+	melee_damage_lower = 40;
+	melee_damage_upper = 60;
+	minbodytemp = 0;
+	move_resist = 2999;
+	name = "Malfunctioning Syndicate Cyborg";
+	projectilesound = 'sound\weapons\gun\l6\shot_old.ogg';
+	projectiletype = /obj/projectile/bullet/mm712x82;
+	pull_force = 2999;
+	rapid = 3;
+	rapid_fire_delay = 2;
+	retreat_distance = 3;
+	speak = list("I'LL TEAR YOU APART!!","YOUR KNEECAPS WILL FLY!!","I WILL SCATTER YOUR NEURONS!!");
+	speak_chance = 5;
+	speak_emote = list("states","exclaims");
+	speech_span = "robot";
+	speed = 1;
+	unsuitable_atmos_damage = 0;
+	verb_ask = "queries";
+	verb_exclaim = "declares";
+	verb_say = "states";
+	verb_yell = "alarms"
+	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "cx" = (
 /mob/living/simple_animal/hostile/carp,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "dd" = (
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/decal/cleanable/greenglow,
@@ -51,24 +84,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "dh" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "di" = (
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "dF" = (
 /obj/structure/lattice,
 /obj/structure/fluff/broken_flooring{
@@ -76,49 +103,35 @@
 	icon_state = "plating"
 	},
 /turf/open/space/basic,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "dX" = (
 /turf/open/floor/plating/asteroid/lowpressure,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "eB" = (
 /obj/structure/grille,
 /obj/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "fg" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "fD" = (
 /obj/machinery/door/airlock/hatch{
 	welded = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "gc" = (
 /obj/structure/frame/machine,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "hr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "hu" = (
 /obj/structure/fluff/broken_flooring{
 	icon_state = "singular"
@@ -131,9 +144,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "iw" = (
 /obj/item/toy/figure/syndie{
 	desc = "The sole survivor.";
@@ -142,86 +153,68 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "jz" = (
 /obj/item/storage/box/handcuffs{
 	pixel_x = 3;
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "kj" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "kS" = (
 /obj/structure/table/reinforced,
-/obj/item/robot_module/saboteur{
-	desc = "A both rare and coveted cyborg module board. This one is designated as Saboteur.";
-	name = "Syndicate Cyborg Module: Saboteur";
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/robot_module/syndicate_medical{
-	desc = "A both rare and coveted cyborg module board. This one is designated as Medical.";
-	name = "Syndicate Cyborg Module: Medical"
-	},
 /obj/machinery/light/broken{
 	dir = 1
 	},
+/obj/item/borg/upgrade/transform/clown{
+	desc = "A module picking system, capable of using stored matter to build itself out into a fresh cyborg configuration. This one has no serial number, and no identifying marks.";
+	name = "cyborg module upgrade (Saboteur)";
+	new_module = /obj/item/robot_module/saboteur;
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/borg/upgrade/transform/clown{
+	desc = "A module picking system, capable of using stored matter to build itself out into a fresh cyborg configuration. This one has no serial number, and no identifying marks.";
+	name = "cyborg module upgrade (Medical)";
+	new_module = /obj/item/robot_module/syndicate_medical
+	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "lu" = (
 /obj/effect/acid/alien,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "mm" = (
 /obj/item/stack/sheet/mineral/plastitanium,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "mF" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "mT" = (
 /obj/effect/turf_decal/industrial/outline,
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "nF" = (
 /obj/effect/acid/alien,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "nP" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "nR" = (
 /obj/machinery/door/poddoor/preopen{
 	desc = "A heavy duty blast door. It is covered in blood.";
@@ -230,9 +223,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/circuit/red/off,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "of" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -240,30 +231,18 @@
 	},
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "oE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/broken{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
-"pY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "qu" = (
 /obj/effect/decal/cleanable/robot_debris/limb,
 /turf/open/floor/plating/asteroid/lowpressure,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "qI" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 6
@@ -272,9 +251,7 @@
 /obj/machinery/suit_storage_unit/open,
 /obj/machinery/light/small/broken,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "qJ" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4;
@@ -283,35 +260,25 @@
 /obj/effect/turf_decal/industrial/outline,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "ru" = (
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "rL" = (
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg2"
 	},
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "sb" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/industrial/outline,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "si" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "sF" = (
 /obj/structure/fluff/broken_flooring{
 	dir = 4;
@@ -325,70 +292,50 @@
 	},
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "sS" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/asteroid/lowpressure,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "sZ" = (
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "tr" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating/asteroid/lowpressure,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "tX" = (
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/plating/asteroid/lowpressure,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "ub" = (
 /obj/structure/shuttle/engine/propulsion,
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "uk" = (
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "uC" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil/white,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "uY" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "vy" = (
 /obj/item/stack/sheet/mineral/plastitanium,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "vD" = (
 /obj/structure/lattice,
 /obj/structure/fluff/broken_flooring{
@@ -396,30 +343,22 @@
 	icon_state = "plating"
 	},
 /turf/open/space/basic,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "wx" = (
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "yC" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "yJ" = (
 /obj/item/restraints/handcuffs,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/circuit/red/off,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "yY" = (
 /obj/structure/lattice,
 /obj/structure/fluff/broken_flooring{
@@ -427,55 +366,35 @@
 	icon_state = "plating"
 	},
 /turf/open/space/basic,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "zg" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/flash,
 /obj/item/assembly/flash,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "zn" = (
 /turf/open/floor/circuit/red/off,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "zN" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 9
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "zX" = (
 /obj/structure/fluff/broken_flooring{
 	icon_state = "pile"
 	},
 /turf/open/space/basic,
 /area/space)
-"zY" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
 "AH" = (
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Dp" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating/asteroid/lowpressure,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "DI" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4;
@@ -483,45 +402,33 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "DP" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1;
 	name = "tactical chair"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Eh" = (
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Em" = (
 /obj/item/stack/cable_coil/cut/red,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "EL" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating/asteroid/lowpressure,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Fk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Fs" = (
 /obj/item/surgicaldrill,
 /obj/item/circular_saw,
@@ -530,25 +437,19 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Fu" = (
 /obj/structure/shuttle/engine/propulsion/right,
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Fw" = (
 /obj/item/clothing/suit/space/syndicate{
 	pixel_x = 16;
 	pixel_y = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "FE" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil/yellow{
@@ -563,33 +464,25 @@
 /obj/item/stock_parts/cell/high,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "FS" = (
 /obj/item/tank/internals/emergency_oxygen/double{
 	pixel_x = 16;
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "FW" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8;
 	name = "tactical chair"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Gm" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Hb" = (
 /obj/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor/shutters{
@@ -598,9 +491,7 @@
 	},
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Hv" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 9
@@ -608,55 +499,36 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/table_frame,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Ig" = (
 /obj/item/stack/cable_coil/cut/red,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Iv" = (
 /mob/living/simple_animal/hostile/carp,
 /turf/open/floor/plating/asteroid/lowpressure,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "IF" = (
 /obj/item/gun/ballistic/automatic/pistol/suppressed,
 /turf/open/floor/plating/asteroid/lowpressure,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "IS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/broken{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "IV" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Jc" = (
 /turf/closed/wall/r_wall/syndicate,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Jf" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/carp/megacarp{
-	health = 125
-	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Jh" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -669,9 +541,7 @@
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/remains/human,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Jq" = (
 /obj/structure/sink{
 	dir = 8;
@@ -681,56 +551,40 @@
 	pixel_x = 30
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Kg" = (
 /obj/effect/turf_decal/industrial/outline,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "KD" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "KL" = (
 /obj/item/stack/cable_coil/red,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Mz" = (
 /obj/item/cautery,
 /obj/item/scalpel,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Nt" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "NA" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "NH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "OQ" = (
 /obj/structure/fluff/broken_flooring{
 	dir = 1;
@@ -738,22 +592,16 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Pa" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Pl" = (
 /obj/structure/table/reinforced,
 /obj/item/mmi/posibrain,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Pu" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4;
@@ -761,60 +609,47 @@
 	},
 /obj/effect/turf_decal/industrial/outline,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Pw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/circuit/red/off,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "PO" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/circuit/red/off,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Qa" = (
 /obj/effect/decal/remains/robot,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Qt" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Qu" = (
 /obj/machinery/door/airlock/external{
 	name = "E.V.A. Gear Storage";
 	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Qx" = (
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
-"QD" = (
-/turf/open/space/basic,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
+"QC" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/moonoutpost19/main)
 "Rj" = (
 /obj/structure/lattice,
 /obj/structure/fluff/broken_flooring{
@@ -824,25 +659,19 @@
 	dir = 1
 	},
 /turf/open/space/basic,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Ry" = (
 /obj/structure/table_frame,
 /obj/item/stack/sheet/plasteel,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "RL" = (
 /obj/structure/lattice,
 /obj/structure/fluff/broken_flooring{
 	icon_state = "pile"
 	},
 /turf/open/space/basic,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "RO" = (
 /turf/open/space/basic,
 /area/space)
@@ -852,39 +681,29 @@
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "SS" = (
 /obj/effect/decal/cleanable/molten_object/large,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Tb" = (
 /obj/structure/door_assembly/door_assembly_hatch{
 	anchored = 1;
 	broken = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Tp" = (
 /obj/structure/shuttle/engine/propulsion/left,
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Ua" = (
 /obj/effect/decal/cleanable/molten_object,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Uj" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4;
@@ -895,9 +714,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Um" = (
 /mob/living/simple_animal/hostile/carp/megacarp{
 	health = 125
@@ -910,15 +727,11 @@
 	},
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "UM" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/r_wall/syndicate,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Va" = (
 /obj/item/stack/sheet/mineral/plastitanium,
 /turf/open/space/basic,
@@ -928,30 +741,22 @@
 	name = "tactical chair"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Wh" = (
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/plating/asteroid/lowpressure,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "WA" = (
 /obj/item/retractor,
 /obj/item/hemostat,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "WB" = (
 /obj/effect/decal/cleanable/robot_debris/old,
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating/asteroid/lowpressure,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "WT" = (
 /obj/machinery/door/poddoor{
 	id = "smindicate";
@@ -968,9 +773,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "Xj" = (
 /mob/living/simple_animal/hostile/carp,
 /turf/open/space/basic,
@@ -978,47 +781,37 @@
 "Xu" = (
 /obj/structure/mecha_wreckage/gygax/dark,
 /turf/open/floor/plating/asteroid/lowpressure,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "XB" = (
 /obj/effect/decal/cleanable/robot_debris/gib,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "XE" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "XK" = (
 /obj/machinery/door/airlock/external{
 	name = "Ready Room";
 	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "YQ" = (
 /turf/closed/mineral/random/asteroid,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 "ZQ" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/table/reinforced,
 /obj/item/bodypart/l_arm/robot,
-/obj/item/bodypart/l_arm/robot,
+/obj/item/bodypart/l_arm/robot{
+	pixel_x = 5
+	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/no_grav{
-	always_unpowered = 1
-	})
+/area/awaymission/moonoutpost19/main)
 
 (1,1,1) = {"
 RO
@@ -1832,7 +1625,7 @@ Eh
 uk
 hr
 rL
-pY
+Jf
 Jc
 kS
 AH
@@ -1894,15 +1687,15 @@ Jc
 RO
 RO
 Jc
-pY
+Jf
 aq
 vD
 AH
-pY
+Jf
 Jc
 zg
 AH
-zY
+QC
 wx
 ZQ
 IV
@@ -1963,12 +1756,12 @@ Jc
 Rj
 AH
 Gm
-pY
+Jf
 KD
 Jc
 FE
 XB
-zY
+QC
 wx
 Pl
 Jc
@@ -2032,7 +1825,7 @@ IV
 Qu
 eB
 IV
-eB
+IV
 fD
 IV
 Jc
@@ -2090,15 +1883,15 @@ vy
 Em
 Jc
 uC
-pY
+Jf
 Vk
 si
 DI
 eB
 Qt
 Ua
-pY
-pY
+Jf
+Jf
 dd
 Jc
 yJ
@@ -2155,15 +1948,15 @@ dF
 NA
 Fk
 Tb
-pY
+Jf
 kj
-pY
-pY
+Jf
+Jf
 NH
 XK
-pY
-pY
-pY
+Jf
+Jf
+Jf
 Jf
 Qx
 nR
@@ -2227,10 +2020,10 @@ IS
 FW
 AH
 eB
-pY
-pY
+Jf
+Jf
 SS
-pY
+Jf
 sZ
 Jc
 zn
@@ -2282,8 +2075,8 @@ RO
 RO
 RO
 RO
-QD
-QD
+RO
+RO
 Fk
 RX
 Jc
@@ -2422,14 +2215,14 @@ RO
 RO
 RO
 Jc
-pY
+Jf
 AH
-pY
-pY
+Jf
+Jf
 AH
 Jc
 Pa
-pY
+Jf
 NA
 Fk
 rL
@@ -2488,7 +2281,7 @@ RO
 RO
 RO
 Jc
-pY
+Jf
 ru
 FS
 Fw

--- a/_maps/RandomRuins/SpaceRuins/infiltratorwreckage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infiltratorwreckage.dmm
@@ -1,0 +1,5246 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ah" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"aq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/sheet/mineral/plastitanium,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"az" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/mmi/syndie,
+/obj/item/mmi/syndie,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"aU" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"ch" = (
+/obj/effect/decal/cleanable/robot_debris/limb,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"cx" = (
+/mob/living/simple_animal/hostile/carp,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"dd" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"dh" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"di" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"dF" = (
+/obj/structure/lattice,
+/obj/structure/fluff/broken_flooring{
+	dir = 8;
+	icon_state = "plating"
+	},
+/turf/open/space/basic,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"dX" = (
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"eB" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"fg" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"fD" = (
+/obj/machinery/door/airlock/hatch{
+	welded = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"gc" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"hr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"hu" = (
+/obj/structure/fluff/broken_flooring{
+	icon_state = "singular"
+	},
+/turf/open/space/basic,
+/area/space)
+"hU" = (
+/obj/item/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"iw" = (
+/obj/item/toy/figure/syndie{
+	desc = "The sole survivor.";
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"jz" = (
+/obj/item/storage/box/handcuffs{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"kj" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"kS" = (
+/obj/structure/table/reinforced,
+/obj/item/robot_module/saboteur{
+	desc = "A both rare and coveted cyborg module board. This one is designated as Saboteur.";
+	name = "Syndicate Cyborg Module: Saboteur";
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/robot_module/syndicate_medical{
+	desc = "A both rare and coveted cyborg module board. This one is designated as Medical.";
+	name = "Syndicate Cyborg Module: Medical"
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"lu" = (
+/obj/effect/acid/alien,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"mm" = (
+/obj/item/stack/sheet/mineral/plastitanium,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"mF" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"mT" = (
+/obj/effect/turf_decal/industrial/outline,
+/obj/machinery/mecha_part_fabricator,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"nF" = (
+/obj/effect/acid/alien,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"nP" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"nR" = (
+/obj/machinery/door/poddoor/preopen{
+	desc = "A heavy duty blast door. It is covered in blood.";
+	id = 524;
+	name = "Infiltrator Containment Unit"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/circuit/red/off,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"of" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"oE" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"pY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"qu" = (
+/obj/effect/decal/cleanable/robot_debris/limb,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"qI" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/suit_storage_unit/open,
+/obj/machinery/light/small/broken,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"qJ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4;
+	name = "tactical chair"
+	},
+/obj/effect/turf_decal/industrial/outline,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"ru" = (
+/obj/item/storage/toolbox/syndicate,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"rL" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"sb" = (
+/obj/structure/table/optable,
+/obj/effect/turf_decal/industrial/outline,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"si" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"sF" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/turf/open/space/basic,
+/area/space)
+"sQ" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"sS" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"sZ" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"tr" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"tX" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"ub" = (
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"uk" = (
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"uC" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"uY" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"vy" = (
+/obj/item/stack/sheet/mineral/plastitanium,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"vD" = (
+/obj/structure/lattice,
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "plating"
+	},
+/turf/open/space/basic,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"wx" = (
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"yC" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"yJ" = (
+/obj/item/restraints/handcuffs,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/circuit/red/off,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"yY" = (
+/obj/structure/lattice,
+/obj/structure/fluff/broken_flooring{
+	dir = 1;
+	icon_state = "plating"
+	},
+/turf/open/space/basic,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"zg" = (
+/obj/structure/table/reinforced,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"zn" = (
+/turf/open/floor/circuit/red/off,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"zN" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"zX" = (
+/obj/structure/fluff/broken_flooring{
+	icon_state = "pile"
+	},
+/turf/open/space/basic,
+/area/space)
+"zY" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"AH" = (
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Dp" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"DI" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4;
+	name = "tactical chair"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"DP" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1;
+	name = "tactical chair"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Eh" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Em" = (
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"EL" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Fk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Fs" = (
+/obj/item/surgicaldrill,
+/obj/item/circular_saw,
+/obj/structure/table/reinforced,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Fu" = (
+/obj/structure/shuttle/engine/propulsion/right,
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Fw" = (
+/obj/item/clothing/suit/space/syndicate{
+	pixel_x = 16;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"FE" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil/yellow{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/cable_coil/yellow,
+/obj/item/stock_parts/cell/high{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/stock_parts/cell/high,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"FS" = (
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 16;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"FW" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8;
+	name = "tactical chair"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Gm" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Hb" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	id = "syndieshutters";
+	name = "blast shutters"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Hv" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/table_frame,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Ig" = (
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Iv" = (
+/mob/living/simple_animal/hostile/carp,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"IF" = (
+/obj/item/gun/ballistic/automatic/pistol/suppressed,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"IS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"IV" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Jc" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Jf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/carp/megacarp{
+	health = 125
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Jh" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/head/helmet/space/syndicate{
+	pixel_x = 7;
+	pixel_y = 14
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/remains/human,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Jq" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Kg" = (
+/obj/effect/turf_decal/industrial/outline,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"KD" = (
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"KL" = (
+/obj/item/stack/cable_coil/red,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Mz" = (
+/obj/item/cautery,
+/obj/item/scalpel,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Nt" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"NA" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"NH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"OQ" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 1;
+	icon_state = "plating"
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Pa" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Pl" = (
+/obj/structure/table/reinforced,
+/obj/item/mmi/posibrain,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Pu" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4;
+	name = "tactical chair"
+	},
+/obj/effect/turf_decal/industrial/outline,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Pw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/circuit/red/off,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"PO" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/circuit/red/off,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Qa" = (
+/obj/effect/decal/remains/robot,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Qt" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Qu" = (
+/obj/machinery/door/airlock/external{
+	name = "E.V.A. Gear Storage";
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Qx" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"QD" = (
+/turf/open/space/basic,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Rj" = (
+/obj/structure/lattice,
+/obj/structure/fluff/broken_flooring{
+	icon_state = "plating"
+	},
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Ry" = (
+/obj/structure/table_frame,
+/obj/item/stack/sheet/plasteel,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"RL" = (
+/obj/structure/lattice,
+/obj/structure/fluff/broken_flooring{
+	icon_state = "pile"
+	},
+/turf/open/space/basic,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"RO" = (
+/turf/open/space/basic,
+/area/space)
+"RX" = (
+/obj/item/stack/sheet/mineral/plastitanium,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"SS" = (
+/obj/effect/decal/cleanable/molten_object/large,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Tb" = (
+/obj/structure/door_assembly/door_assembly_hatch{
+	anchored = 1;
+	broken = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Tp" = (
+/obj/structure/shuttle/engine/propulsion/left,
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Ua" = (
+/obj/effect/decal/cleanable/molten_object,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Uj" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4;
+	name = "tactical chair"
+	},
+/obj/effect/turf_decal/industrial/outline,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Um" = (
+/mob/living/simple_animal/hostile/carp/megacarp{
+	health = 125
+	},
+/turf/open/space/basic,
+/area/space)
+"UG" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"UM" = (
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Va" = (
+/obj/item/stack/sheet/mineral/plastitanium,
+/turf/open/space/basic,
+/area/space)
+"Vk" = (
+/obj/structure/chair/comfy/shuttle{
+	name = "tactical chair"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Wh" = (
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"WA" = (
+/obj/item/retractor,
+/obj/item/hemostat,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"WB" = (
+/obj/effect/decal/cleanable/robot_debris/old,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"WT" = (
+/obj/machinery/door/poddoor{
+	id = "smindicate";
+	name = "outer blast door"
+	},
+/obj/machinery/button/door{
+	id = "smindicate";
+	name = "external door control";
+	pixel_y = 26;
+	req_access_txt = "150"
+	},
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"Xj" = (
+/mob/living/simple_animal/hostile/carp,
+/turf/open/space/basic,
+/area/space)
+"Xu" = (
+/obj/structure/mecha_wreckage/gygax/dark,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"XB" = (
+/obj/effect/decal/cleanable/robot_debris/gib,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"XE" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"XK" = (
+/obj/machinery/door/airlock/external{
+	name = "Ready Room";
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"YQ" = (
+/turf/closed/mineral/random/asteroid,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+"ZQ" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/bodypart/l_arm/robot,
+/obj/item/bodypart/l_arm/robot,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered/no_grav{
+	always_unpowered = 1
+	})
+
+(1,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(2,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(3,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(4,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(5,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(6,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(7,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(8,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Xj
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(9,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+dX
+dX
+dX
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(10,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Um
+RO
+RO
+RO
+RO
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+RO
+Xj
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+dX
+dX
+dX
+dX
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(11,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+NA
+uY
+Jc
+Jc
+Jc
+mT
+Kg
+AH
+kj
+az
+Fs
+Mz
+of
+Tp
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+dX
+dX
+dX
+dX
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(12,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Va
+RO
+yY
+vy
+uk
+UG
+qI
+Jc
+AH
+AH
+ch
+AH
+XE
+fg
+sb
+of
+ub
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+dX
+Iv
+dX
+dX
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(13,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Eh
+uk
+hr
+rL
+pY
+Jc
+kS
+AH
+zN
+sQ
+Nt
+Jq
+WA
+of
+Fu
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+dX
+dX
+dX
+dX
+dX
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(14,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Jc
+Jc
+Jc
+Jc
+Jc
+RO
+RO
+Jc
+pY
+aq
+vD
+AH
+pY
+Jc
+zg
+AH
+zY
+wx
+ZQ
+IV
+Jc
+Jc
+Jc
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+dX
+dX
+dX
+dX
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(15,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Jc
+iw
+oE
+hU
+Jc
+Jc
+RO
+Jc
+Rj
+AH
+Gm
+pY
+KD
+Jc
+FE
+XB
+zY
+wx
+Pl
+Jc
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+dX
+dX
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(16,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Hb
+NA
+KL
+Qa
+Jc
+IV
+dh
+IV
+Jc
+Jc
+IV
+Qu
+eB
+IV
+eB
+fD
+IV
+Jc
+Jc
+Jc
+Jc
+Jc
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(17,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Hb
+nF
+vy
+Em
+Jc
+uC
+pY
+Vk
+si
+DI
+eB
+Qt
+Ua
+pY
+pY
+dd
+Jc
+yJ
+Pw
+Pw
+of
+Tp
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(18,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+mF
+dF
+NA
+Fk
+Tb
+pY
+kj
+pY
+pY
+NH
+XK
+pY
+pY
+pY
+Jf
+Qx
+nR
+zn
+PO
+zn
+of
+ub
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(19,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RL
+NA
+OQ
+lu
+Jc
+jz
+DP
+IS
+FW
+AH
+eB
+pY
+pY
+SS
+pY
+sZ
+Jc
+zn
+zn
+Pw
+of
+Fu
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(20,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+QD
+QD
+Fk
+RX
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+IV
+nP
+eB
+IV
+eB
+vD
+IV
+Jc
+Jc
+Jc
+Jc
+Jc
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(21,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Xj
+vD
+rL
+uY
+RO
+RO
+Jc
+Pu
+qJ
+Uj
+AH
+qJ
+Jc
+Pa
+cx
+Eh
+mm
+gc
+uY
+RO
+RO
+RO
+Xj
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(22,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Jc
+pY
+AH
+pY
+pY
+AH
+Jc
+Pa
+pY
+NA
+Fk
+rL
+dF
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(23,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Jc
+pY
+ru
+FS
+Fw
+AH
+Jc
+Ry
+Ig
+Fk
+NA
+NA
+Um
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(24,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Jc
+Hv
+yC
+Jh
+yC
+aU
+Jc
+Fk
+NA
+vy
+zX
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(25,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Jc
+Jc
+Jc
+WT
+UM
+Jc
+Jc
+di
+NA
+RO
+RO
+RO
+sF
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(26,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Xj
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Jc
+uY
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(27,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+hu
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+dX
+dX
+dX
+dX
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(28,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+dX
+dX
+dX
+Iv
+dX
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(29,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+dX
+dX
+dX
+dX
+dX
+dX
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(30,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+dX
+dX
+Iv
+dX
+dX
+dX
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(31,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+dX
+dX
+dX
+dX
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(32,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+dX
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(33,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Xj
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(34,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(35,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(36,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+Xj
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(37,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(38,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(39,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(40,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+dX
+Iv
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(41,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+dX
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(42,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+Xj
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(43,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+Xu
+WB
+dX
+dX
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(44,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+Dp
+sS
+dX
+dX
+tX
+dX
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(45,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+IF
+Wh
+dX
+dX
+dX
+dX
+ah
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+YQ
+YQ
+dX
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(46,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+dX
+tr
+dX
+dX
+dX
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+YQ
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(47,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+dX
+dX
+dX
+dX
+dX
+dX
+dX
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(48,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+dX
+EL
+dX
+dX
+dX
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(49,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+dX
+Wh
+qu
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(50,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+dX
+dX
+dX
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(51,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(52,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(53,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+YQ
+YQ
+YQ
+YQ
+YQ
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(54,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(55,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(56,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(57,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(58,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(59,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(60,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(61,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(62,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(63,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}
+(64,1,1) = {"
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+RO
+"}

--- a/_maps/RandomRuins/SpaceRuins/infiltratorwreckage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infiltratorwreckage.dmm
@@ -28,13 +28,13 @@
 /obj/effect/decal/cleanable/robot_debris/limb,
 /mob/living/simple_animal/hostile/nanotrasen/ranged/assault{
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
-	attack_sound = 'sound\weapons\blade1.ogg';
+	attack_sound = 'sound/weapons/blade1.ogg';
 	attack_verb_continuous = "slashes";
 	attack_verb_simple = "slash";
 	casingtype = /obj/item/ammo_casing/mm712x82;
 	damage_coeff = list("brute" = 0.7, "fire" = 1.2, "toxin" = 1, "clone" = 1, "stamina" = 0, "oxygen" = 1);
 	deathmessage = "falls apart!";
-	deathsound = 'sound\voice\borg_deathsound.ogg';
+	deathsound = 'sound/voice/borg_deathsound.ogg';
 	desc = "A heavily armed, malfunctioning Syndicate Assault Cyborg. You should run.";
 	has_unlimited_silicon_privilege = 1;
 	health = 1250;
@@ -54,7 +54,7 @@
 	minbodytemp = 0;
 	move_resist = 2999;
 	name = "Malfunctioning Syndicate Cyborg";
-	projectilesound = 'sound\weapons\gun\l6\shot_old.ogg';
+	projectilesound = 'sound/weapons/gun/l6/shot_old.ogg';
 	projectiletype = /obj/projectile/bullet/mm712x82;
 	pull_force = 2999;
 	rapid = 3;

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -332,3 +332,9 @@
 	suffix = "ArtGallery.dmm"
 	name = "Abandoned Art Gallery"
 	description = "This was once apart of a far larger exhibition of artwork though most of it is gone now, Though there seems to be a few things left arround by the visiters that were here most don't seem freindly. ."
+
+/datum/map_template/ruin/space/infiltratorwreckage
+	id = "infiltratorwreckage"
+	suffix = "infiltratorwreckage.dmm"
+	name = "Infiltrator Wreckage"
+	description = "The remains of what used to be a prideful Syndicate Infiltrator Vessel. What could have caused this?"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new SpaceRuin to the current pool, with early to midgame loot like a full syndicate toolbox, a supressed sketchin, and two Syndicate Cyborg Boards, Saboteur and Medical. This ruin features a challenging miniboss that may or may not make your life hell.
<img width="558" alt="Screenshot_2032" src="https://user-images.githubusercontent.com/88121917/188022152-13268820-0823-428a-9f09-47c2c6171a48.png">
(Screenshot outdated, missing the miniboss, otherwise the same)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because more ruins are needed, and the old ones are horrible.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: added infitratorwreckage.dmm to SpaceRuins
tweak: tweaked space.dm to allow for the ruin to spawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
