### PR TITLE
Fixes IPC parts not showing up in the mechfab

### DIFF
--- a/voidcrew/code/game/mecha/mech_fabricator.dm
+++ b/voidcrew/code/game/mecha/mech_fabricator.dm
@@ -1,3 +1,3 @@
 /obj/machinery/mecha_part_fabricator/Initialize(mapload)
 	. = ..()
-	part_sets |= list("IPC components")
+	part_sets |= list("IPC Components")


### PR DESCRIPTION
## About The Pull Request

It has to be capitalized or else it doesn't show up, because it has to be consistent between it and the designs

## Why It's Good For The Game

IPC parts might work now

## Changelog
:cl:
fix: IPC parts now show up in the mechfab again.
/:cl: