### PR TITLE
fixes runtime with mind not existing on crewmate removal

### DIFF
--- a/voidcrew/code/modules/overmap/ships/simulated_ship_data.dm
+++ b/voidcrew/code/modules/overmap/ships/simulated_ship_data.dm
@@ -40,7 +40,7 @@
 
 			remove_faction_hud(FACTION_HUD_GENERAL, ex_crewmate)
 			var/datum/mind/ex_crewmate_mind = ex_crewmate.mind
-			var/datum/antagonist/to_remove = ex_crewmate_mind.has_antag_datum(source_template?.antag_datum)
+			var/datum/antagonist/to_remove = ex_crewmate_mind?.has_antag_datum(source_template?.antag_datum)
 			if (!isnull(to_remove))
 				ex_crewmate_mind.remove_antag_datum(to_remove)
 


### PR DESCRIPTION
It was trying to remove the antag datum from a mindless crewmate, i'm assuming crewmates can be mindless if it tries to remove a crew member while they're disconnected.
This adds a `?.` to the `get_antag_datum` which will prevent this runtime!!!