### PR TITLE
Fixes the CMO undersuit icon, removes odd light from tieguai

### DIFF
--- a/_maps/shuttles/shiptest/litieguai.dmm
+++ b/_maps/shuttles/shiptest/litieguai.dmm
@@ -19,9 +19,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/science)
 "aT" = (
@@ -470,9 +467,6 @@
 /turf/open/floor/plating,
 /area/ship/bridge)
 "iu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/ship/science)
 "iA" = (
@@ -541,11 +535,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/science)
+"kc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/science)
 "km" = (
 /obj/machinery/door/airlock/virology/glass,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -651,9 +656,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 8
@@ -796,19 +798,13 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
-/area/ship/hallway/fore)
+/area/ship/science)
 "oe" = (
 /obj/machinery/door/window/westright,
 /turf/open/floor/mineral/titanium/tiled/white,
@@ -896,7 +892,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/ship/hallway/fore)
+/area/ship/science)
 "qc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -920,9 +916,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/toilet)
 "qP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/window/westright{
 	dir = 2
 	},
@@ -940,9 +933,6 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "rd" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -1288,9 +1278,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "yl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
 	},
@@ -1301,7 +1288,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/ship/hallway/fore)
+/area/ship/science)
 "yA" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1311,9 +1298,6 @@
 "yM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 4
@@ -2231,15 +2215,6 @@
 /obj/structure/curtain,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/toilet)
-"Qm" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
-/turf/open/floor/plasteel/showroomfloor,
-/area/ship/science)
 "Qp" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -2248,6 +2223,12 @@
 "Qq" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/medical)
+"QD" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/science)
 "QK" = (
 /turf/open/floor/plating/grass,
 /area/ship/science)
@@ -2530,10 +2511,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/fore)
-"Uy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"Ui" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/science)
+"Uy" = (
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 1
 	},
@@ -2679,9 +2666,6 @@
 "VC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3359,9 +3343,9 @@ Ci
 Mj
 pK
 pK
-Wc
+kc
 nT
-Wc
+kc
 pK
 pK
 Wc
@@ -3394,13 +3378,13 @@ zg
 Ps
 Rk
 yd
-cI
-cI
-Yn
+QD
+QD
+Ui
 yl
-Yn
-cI
-cI
+Ui
+QD
+QD
 Yn
 cI
 Kv
@@ -3623,7 +3607,7 @@ rd
 iu
 qP
 Uy
-Qm
+Nq
 jN
 PH
 XW

--- a/_maps/shuttles/shiptest/litieguai.dmm
+++ b/_maps/shuttles/shiptest/litieguai.dmm
@@ -2890,13 +2890,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/fore)
-"Yr" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/science)
 "Yv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -3329,7 +3322,7 @@ LH
 GP
 Vs
 Vs
-Yr
+dI
 jB
 dI
 Vs

--- a/_maps/shuttles/shiptest/litieguai.dmm
+++ b/_maps/shuttles/shiptest/litieguai.dmm
@@ -347,7 +347,7 @@
 /area/ship/medical)
 "gb" = (
 /obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/clothing/under/suit/cmo,
+/obj/item/clothing/under/rank/medical/suit/cmo,
 /obj/item/clothing/suit/toggle/labcoat/cmo,
 /obj/item/clothing/shoes/sneakers/white,
 /obj/item/clothing/glasses/hud/health/sunglasses,

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -65,7 +65,7 @@
 /datum/outfit/job/cmo/medicaldirector
 	name = "Chief Medical Officer (Medical Director)"
 
-	uniform = /obj/item/clothing/under/suit/cmo
+	uniform = /obj/item/clothing/under/rank/medical/suit/cmo
 	alt_uniform = null
 	shoes = /obj/item/clothing/shoes/laceup
 	suit = /obj/item/clothing/suit/toggle/lawyer/cmo

--- a/whitesands/code/modules/clothing/under/jobs/medical.dm
+++ b/whitesands/code/modules/clothing/under/jobs/medical.dm
@@ -82,7 +82,7 @@
 	icon = 'icons/obj/clothing/under/medical.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/medical.dmi'
 
-/obj/item/clothing/under/suit/cmo/skirt
+/obj/item/clothing/under/rank/medical/suit/cmo/skirt
 	name = "medical director skirtsuit"
 	desc = "A skirtsuit with medical colors, meant to be worn by those who lead the medical department."
 	icon_state = "medical_director_skirt"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The CMO outfit had the wrong path to the undersuit, and the underskirt had an incorrect path, likely due to oversight from the original path changing. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The default "something has gone wrong" icon is very ugly.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The Chief Medical Officer should no longer have a broken jumpsuit icon
fix: The li Tieguai should no longer have a double light near to the bridge.
/:cl:
![image](https://user-images.githubusercontent.com/29469766/189472906-4ebc5dae-155e-4c61-8123-0421a2d34574.png)

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
