### PR TITLE
Fixes Imperialchurch

### DIFF
--- a/_maps/RandomRuins/IceRuins/imperialchurch.dmm
+++ b/_maps/RandomRuins/IceRuins/imperialchurch.dmm
@@ -1,505 +1,193 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"av" = (
+"aF" = (
 /obj/structure/curtain/cloth/fancy,
-/obj/structure/curtain/cloth/fancy,
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/icemoon)
-"aC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed,
-/area/icemoon)
-"aV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/guardian/punch,
-/obj/item/candle/tribal_torch,
-/turf/open/floor/wood,
-/area/icemoon)
-"bh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/template_noop,
-/area/template_noop)
-"bF" = (
+"aN" = (
 /obj/structure/chair/pew/right{
 	dir = 1
 	},
-/obj/effect/turf_decal/snow,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"cl" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/wine,
-/obj/item/reagent_containers/food/drinks/bottle/holywater,
-/turf/open/floor/wood,
-/area/icemoon)
-"cv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"cE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"dT" = (
-/obj/effect/turf_decal/snow,
-/turf/open/floor/plating/snowed,
-/area/icemoon)
-"eh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/dark/snowdin,
-/area/icemoon)
-"ep" = (
-/obj/structure/chair/pew{
-	dir = 1
-	},
-/turf/open/floor/plating/snowed,
-/area/icemoon)
-"eG" = (
-/obj/structure/chair/pew/left{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/icemoon)
-"eJ" = (
-/obj/structure/closet/cabinet,
-/obj/item/storage/book/bible,
-/obj/item/clothing/suit/hooded/chaplain_hoodie,
+"bb" = (
+/obj/structure/bed,
+/obj/item/bedsheet/chaplain,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/reagent_containers/food/drinks/bottle/holywater,
 /turf/open/floor/carpet/black,
 /area/icemoon)
-"fQ" = (
-/obj/structure/table/wood,
-/obj/item/candle/infinite,
-/turf/open/floor/wood,
-/area/icemoon)
-"gG" = (
-)
-"gT" = (
-/obj/effect/turf_decal/snow,
-/turf/open/floor/plating/snowed/smoothed,
-/area/icemoon)
-"hy" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"hO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"hV" = (
+"bf" = (
 /obj/structure/mineral_door/wood,
-/obj/structure/barricade/wooden/snowed,
-/turf/open/floor/wood,
-/area/icemoon)
-"iy" = (
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/snow,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/black,
 /area/icemoon)
-"iV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust{
-	pixel_y = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"jd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/guardian/protector,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"je" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/black/half{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/snow,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"jj" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/gloves/plate/blue,
-/obj/item/clothing/head/helmet/plate/crusader/blue,
-/obj/item/clothing/suit/armor/plate/crusader/blue,
-/obj/item/reagent_containers/food/drinks/bottle/holywater,
-/obj/item/nullrod,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"kD" = (
-/obj/effect/decal/remains/human,
-/obj/effect/turf_decal/snow,
-/turf/open/floor/plating/snowed,
-/area/icemoon)
-"kJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/mineral_door/iron,
-/obj/structure/barricade/wooden/snowed,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"kN" = (
-/obj/effect/decal/remains/human,
-/turf/closed/wall/mineral/iron,
-/area/icemoon)
-"kP" = (
-/obj/structure/chair/pew{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/snow,
-/turf/open/floor/plating/snowed/smoothed,
-/area/icemoon)
-"kR" = (
-/obj/structure/chair/pew/left{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/snow,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"me" = (
-/obj/item/candle/tribal_torch,
-/turf/open/floor/plating/snowed/smoothed,
-/area/icemoon)
-"nM" = (
-/obj/item/candle/tribal_torch,
-/turf/open/floor/wood,
-/area/icemoon)
-"nN" = (
-/obj/item/candle/tribal_torch,
-/turf/open/floor/plasteel/dark/snowdin,
-/area/icemoon)
-"nV" = (
-/obj/structure/chair/pew/left{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed/smoothed,
-/area/icemoon)
-"ow" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/guardian/gravitokinetic,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"oE" = (
-/obj/item/candle/tribal_torch,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/snow,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"oJ" = (
+"cg" = (
 /obj/structure/bed,
 /obj/item/bedsheet/chaplain,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/black,
 /area/icemoon)
-"pA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"qj" = (
-/obj/structure/curtain/cloth/fancy,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"qo" = (
+"cQ" = (
 /obj/item/candle/tribal_torch,
 /obj/effect/turf_decal/snow,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/icemoon)
-"qG" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/black,
+"cU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/suit/hooded/bee_costume,
+/obj/item/toy/plush/beeplushie,
+/obj/item/melee/beesword,
+/turf/open/floor/carpet/red,
 /area/icemoon)
-"qI" = (
+"de" = (
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/obj/effect/decal/remains/human,
+/obj/effect/turf_decal/snow,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon)
+"ed" = (
 /obj/structure/chair/pew{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark/snowdin,
+/turf/open/floor/plating/snowed,
 /area/icemoon)
-"ra" = (
-/obj/structure/chair/pew/left{
-	dir = 1
-	},
-/obj/effect/turf_decal/snow,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"rj" = (
-/turf/open/floor/carpet/black,
-/area/icemoon)
-"sj" = (
-/obj/item/candle/tribal_torch,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/snow,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"sp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/snow,
-/obj/item/candle/tribal_torch,
-/turf/open/floor/wood,
-/area/icemoon)
-"sw" = (
-/turf/closed/wall/mineral/iron,
-/area/icemoon)
-"sC" = (
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/snow,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"sT" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"sV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/mineral/iron,
-/area/icemoon)
-"ti" = (
-/obj/item/candle/tribal_torch,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"tI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/candle/tribal_torch,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"tJ" = (
-/turf/open/floor/plating/snowed/smoothed,
-/area/icemoon)
-"uB" = (
-/obj/structure/closet/cabinet,
-/obj/item/storage/book/bible,
-/obj/item/clothing/suit/hooded/chaplain_hoodie,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/reagent_containers/food/drinks/bottle/holywater,
-/turf/open/floor/carpet/black,
-/area/icemoon)
-"vq" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/black/half{
-	dir = 8
-	},
-/obj/item/candle/tribal_torch,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"vP" = (
-/obj/structure/closet/cabinet,
-/obj/item/storage/book/bible,
-/obj/item/clothing/suit/hooded/chaplain_hoodie,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/reagent_containers/food/drinks/bottle/holywater,
-/turf/open/floor/carpet/black,
-/area/icemoon)
-"vU" = (
-/mob/living/simple_animal/hostile/guardian/gravitokinetic,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"vZ" = (
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
-/obj/effect/turf_decal/snow,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"wp" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/head/helmet/chaplain/witchunter_hat,
-/obj/item/clothing/suit/armor/riot/chaplain/witchhunter,
-/obj/item/nullrod/scythe/talking/chainsword,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"wM" = (
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/remains/human,
-/obj/effect/turf_decal/snow,
-/obj/effect/turf_decal/snow,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"wP" = (
+"eR" = (
 /obj/structure/chair/pew{
 	dir = 1
 	},
 /obj/effect/turf_decal/snow,
 /turf/open/floor/plating/snowed,
 /area/icemoon)
-"wV" = (
-/obj/structure/table/wood,
-/obj/item/papercutter,
-/obj/item/paper_bin,
-/obj/item/pen/fountain/solgov,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/black,
-/area/icemoon)
-"xd" = (
+"fD" = (
 /mob/living/simple_animal/hostile/guardian/punch,
 /turf/open/floor/wood,
 /area/icemoon)
-"xp" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
+"fW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/snow,
+/turf/open/floor/wood,
 /area/icemoon)
-"xz" = (
-/obj/structure/railing{
-	dir = 6
+"gh" = (
+/obj/structure/chair/pew/left{
+	dir = 1
 	},
-/obj/effect/turf_decal/corner/black/three_quarters,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/snow,
 /turf/open/floor/plasteel,
 /area/icemoon)
-"yd" = (
-/obj/structure/mineral_door/wood,
-/obj/effect/decal/cleanable/dirt/dust,
+"gy" = (
+/obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/icemoon)
-"ym" = (
+"gH" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/corner/black/half,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"gV" = (
+/obj/item/candle/tribal_torch,
 /obj/effect/turf_decal/snow,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed,
+/turf/open/floor/plasteel,
 /area/icemoon)
-"yq" = (
-/obj/item/candle/tribal_torch,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed,
-/area/icemoon)
-"zd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/black,
-/area/icemoon)
-"zH" = (
+"ha" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/candle/tribal_torch,
 /turf/open/floor/wood,
 /area/icemoon)
-"Ao" = (
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
-/obj/effect/decal/remains/human,
-/obj/effect/turf_decal/snow,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed/smoothed,
-/area/icemoon)
-"Aw" = (
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/snowdin,
-/area/icemoon)
-"AF" = (
-/obj/effect/turf_decal/snow,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"AI" = (
-/obj/structure/curtain/cloth/fancy,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"AX" = (
-/obj/structure/mineral_door/wood,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/black,
-/area/icemoon)
-"Bn" = (
-/mob/living/simple_animal/hostile/guardian/gravitokinetic,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"By" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/icemoon)
-"BD" = (
+"hU" = (
 /obj/structure/chair/pew/left{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/snowdin,
 /area/icemoon)
-"Cg" = (
+"ic" = (
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"id" = (
+/obj/structure/mineral_door/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/icemoon)
+"in" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon)
+"iG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon)
+"jj" = (
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/snow,
+/turf/open/floor/plating/snowed,
+/area/icemoon)
+"jt" = (
+/mob/living/simple_animal/hostile/guardian/gravitokinetic,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"jA" = (
+/obj/effect/turf_decal/snow,
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon)
+"jM" = (
 /obj/structure/chair/pew{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"Cj" = (
+/obj/effect/turf_decal/snow,
 /turf/open/floor/plating/snowed,
 /area/icemoon)
-"CC" = (
+"kn" = (
+/mob/living/simple_animal/hostile/guardian/protector,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"kq" = (
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/obj/effect/turf_decal/snow,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"lz" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
 	},
 /obj/effect/turf_decal/snow,
 /turf/open/floor/wood,
 /area/icemoon)
-"CH" = (
-/obj/structure/chair/pew/left{
-	dir = 1
-	},
+"lL" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed,
-/area/icemoon)
-"CQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/guardian/ranged,
-/turf/open/floor/plasteel,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/icemoon)
-"FL" = (
+"lW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/candle/tribal_torch,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"me" = (
 /obj/structure/closet/cabinet,
 /obj/item/storage/box/holy_grenades,
 /obj/item/ammo_box/c38_box,
@@ -510,232 +198,114 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/icemoon)
-"He" = (
-/obj/structure/chair/pew/left{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark/snowdin,
-/area/icemoon)
-"Hh" = (
-/obj/structure/chair/pew/left{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/icemoon)
-"HA" = (
-/obj/structure/curtain/cloth/fancy,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"If" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/cabinet,
-/obj/item/clothing/suit/hooded/bee_costume,
-/obj/item/toy/plush/beeplushie,
-/obj/item/melee/beesword,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"Il" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/black,
-/area/icemoon)
-"Iw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/template_noop,
-/area/template_noop)
-"Ix" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark/snowdin,
-/area/icemoon)
-"IS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/snow,
-/turf/open/floor/wood,
-/area/icemoon)
-"Jh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed,
-/area/icemoon)
-"Jj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/snow,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"Jn" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/effect/turf_decal/corner/black/three_quarters{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"JT" = (
-/turf/open/floor/wood,
-/area/icemoon)
-"KD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"Lh" = (
-/obj/structure/chair/pew{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed,
-/area/icemoon)
-"Lv" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/corner/black/half,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"LS" = (
-/obj/item/candle/tribal_torch,
+"mY" = (
 /obj/effect/decal/remains/human,
 /obj/effect/turf_decal/snow,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"LW" = (
-/turf/template_noop,
-/area/template_noop)
-"Mu" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/corner/black/half,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/clothing/under/costume/kilt/highlander,
-/obj/item/clothing/head/beret/highlander,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"MC" = (
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/icemoon)
-"Nm" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/black/half{
-	dir = 4
-	},
-/obj/item/candle/tribal_torch,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"Nw" = (
-/obj/structure/table/wood,
-/obj/item/storage/book/bible/syndicate,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/icemoon)
-"Nz" = (
-/mob/living/simple_animal/hostile/guardian/protector,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"NK" = (
-/turf/open/floor/plasteel/stairs{
-	dir = 1
-	},
-/area/icemoon)
-"Oi" = (
-/obj/structure/chair/pew{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/snowed,
 /area/icemoon)
-"Ol" = (
+"nd" = (
 /obj/structure/chair/pew/right{
 	dir = 1
 	},
-/turf/open/floor/plating/snowed,
+/turf/open/floor/plasteel/dark/snowdin,
 /area/icemoon)
-"Pa" = (
+"nF" = (
 /obj/item/candle/tribal_torch,
+/turf/open/floor/plasteel/dark/snowdin,
+/area/icemoon)
+"nL" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/turf_decal/corner/black/three_quarters,
 /obj/effect/turf_decal/snow,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/icemoon)
-"Pl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed/smoothed,
-/area/icemoon)
-"PE" = (
+"ob" = (
 /obj/structure/chair/pew/right{
 	dir = 1
 	},
-/obj/effect/turf_decal/snow,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"Qe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/icemoon)
-"QP" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/corner/black/half,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"Ry" = (
-/obj/structure/chair/pew{
-	dir = 1
-	},
 /obj/effect/turf_decal/snow,
 /turf/open/floor/plasteel,
 /area/icemoon)
-"Se" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/black/half{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/icemoon)
-"SU" = (
+"oI" = (
 /obj/structure/chair/pew/left{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"oT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/snow,
+/turf/open/floor/wood,
+/area/icemoon)
+"pc" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"pf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"pp" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/snow,
 /turf/open/floor/plasteel,
 /area/icemoon)
-"Tc" = (
+"px" = (
+/obj/effect/turf_decal/snow,
+/turf/open/floor/plating/snowed,
+/area/icemoon)
+"pH" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/black/half{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/snow,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"pK" = (
 /turf/closed/wall/mineral/iron,
 /area/icemoon)
-"Tf" = (
+"pL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/dark/snowdin,
+/area/icemoon)
+"qb" = (
 /obj/item/candle/tribal_torch,
+/obj/effect/decal/remains/human,
 /obj/effect/turf_decal/snow,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/icemoon)
-"TM" = (
-/obj/item/candle/tribal_torch,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed/smoothed,
+"qe" = (
+/obj/structure/chair/pew{
+	dir = 1
+	},
+/obj/effect/turf_decal/snow,
+/turf/open/floor/plasteel,
 /area/icemoon)
-"TX" = (
+"qg" = (
+/obj/structure/curtain/cloth/fancy,
+/obj/structure/curtain/cloth/fancy,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"qr" = (
 /obj/structure/altar_of_gods,
 /obj/item/storage/book/bible,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -745,954 +315,1077 @@
 /obj/item/claymore/highlander,
 /turf/open/floor/carpet/red,
 /area/icemoon)
-"Uo" = (
-/obj/structure/chair/pew/left{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
+"qx" = (
 /obj/effect/turf_decal/snow,
-/turf/open/floor/plating/snowed,
+/turf/open/floor/plasteel,
 /area/icemoon)
-"Vv" = (
-/turf/open/floor/carpet/red,
+"qz" = (
+/obj/effect/turf_decal/snow,
+/turf/open/floor/wood,
 /area/icemoon)
-"VE" = (
-/obj/structure/chair/pew{
+"rf" = (
+/obj/structure/table/wood,
+/obj/item/papercutter,
+/obj/item/paper_bin,
+/obj/item/pen/fountain/solgov,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/icemoon)
+"rr" = (
+/obj/structure/chair/pew/right{
 	dir = 1
 	},
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating/snowed,
+/obj/effect/turf_decal/snow,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
 /area/icemoon)
-"Wi" = (
+"rI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/stairs{
 	dir = 1
 	},
 /area/icemoon)
-"Wl" = (
-/mob/living/simple_animal/hostile/guardian/gravitokinetic,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"Xa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/snow,
-/turf/open/floor/wood,
-/area/icemoon)
-"Xe" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"Xn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+"rM" = (
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
 /turf/open/floor/plating/snowed,
 /area/icemoon)
-"Xs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark/snowdin,
-/area/icemoon)
-"Xw" = (
-/obj/effect/turf_decal/snow,
-/turf/open/floor/wood,
-/area/icemoon)
-"XA" = (
-/mob/living/simple_animal/hostile/guardian/ranged,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed,
-/area/icemoon)
-"XR" = (
+"sc" = (
 /mob/living/simple_animal/hostile/guardian/protector,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/icemoon)
-"Yj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed/smoothed,
-/area/icemoon)
-"Yn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/remains/human,
-/turf/open/floor/carpet/red,
-/area/icemoon)
-"YO" = (
-/obj/structure/bed,
-/obj/item/bedsheet/chaplain,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/black,
-/area/icemoon)
-"YX" = (
-/turf/open/floor/plasteel,
-/area/icemoon)
-"Ze" = (
-/obj/effect/decal/cleanable/dirt/dust,
+"sj" = (
+/obj/structure/table/wood,
+/obj/item/storage/book/bible/syndicate,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/icemoon)
-"ZA" = (
+"so" = (
+/mob/living/simple_animal/hostile/guardian/gravitokinetic,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"tm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/mineral/iron,
+/area/icemoon)
+"tu" = (
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/snow,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"tB" = (
+/obj/structure/closet/cabinet,
+/obj/item/storage/book/bible,
+/obj/item/clothing/suit/hooded/chaplain_hoodie,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
+/turf/open/floor/carpet/black,
+/area/icemoon)
+"uq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed,
+/area/icemoon)
+"uD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mineral_door/iron,
+/obj/structure/barricade/wooden/snowed,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"uZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/mineral/iron,
+/area/icemoon)
+"ve" = (
+/obj/structure/closet/cabinet,
+/obj/item/storage/book/bible,
+/obj/item/clothing/suit/hooded/chaplain_hoodie,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
+/turf/open/floor/carpet/black,
+/area/icemoon)
+"vq" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/corner/black/half,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"wl" = (
+/obj/item/candle/tribal_torch,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"wJ" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"wP" = (
+/obj/structure/curtain/cloth/fancy,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"wT" = (
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/snow,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"wV" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/black/three_quarters{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"xB" = (
+/obj/item/candle/tribal_torch,
+/turf/open/floor/wood,
+/area/icemoon)
+"yt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/guardian/ranged,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"yU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/icemoon)
+"yX" = (
+/turf/template_noop,
+/area/template_noop)
+"zP" = (
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"zT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"AJ" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
+/turf/open/floor/wood,
+/area/icemoon)
+"Bf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"Bn" = (
+/obj/structure/chair/pew{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed,
+/area/icemoon)
+"BB" = (
+/turf/open/floor/carpet/black,
+/area/icemoon)
+"CH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/guardian/protector,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"Dh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"Di" = (
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon)
+"DG" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"DM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/snow,
+/obj/item/candle/tribal_torch,
+/turf/open/floor/wood,
+/area/icemoon)
+"DX" = (
+/turf/open/floor/wood,
+/area/icemoon)
+"Es" = (
+/obj/item/candle/tribal_torch,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/snow,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"Ez" = (
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/snowdin,
+/area/icemoon)
+"ES" = (
+/obj/item/candle/tribal_torch,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/snow,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"EV" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/head/helmet/chaplain/witchunter_hat,
+/obj/item/clothing/suit/armor/riot/chaplain/witchhunter,
+/obj/item/nullrod/scythe/talking/chainsword,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"Fu" = (
+/mob/living/simple_animal/hostile/guardian/gravitokinetic,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"GY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/snowdin,
+/area/icemoon)
+"IJ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/black/half{
+	dir = 8
+	},
+/obj/item/candle/tribal_torch,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"IT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"Js" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed,
+/area/icemoon)
+"Kh" = (
+/obj/structure/chair/pew{
+	dir = 1
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/snowed,
+/area/icemoon)
+"KN" = (
+/obj/structure/chair/pew{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"KR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"Li" = (
 /obj/structure/chair/pew{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/snow,
-/turf/open/floor/plating/snowed,
+/turf/open/floor/plating/snowed/smoothed,
 /area/icemoon)
-"ZS" = (
-/obj/structure/chair/pew/right{
+"Ly" = (
+/obj/structure/mineral_door/wood,
+/obj/structure/barricade/wooden/snowed,
+/turf/open/floor/wood,
+/area/icemoon)
+"LK" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/black/half{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"LV" = (
+/obj/structure/chair/pew{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed,
+/area/icemoon)
+"Mw" = (
+/obj/effect/turf_decal/snow,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed,
+/area/icemoon)
+"MR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/guardian/gravitokinetic,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"MX" = (
+/obj/structure/table/wood,
+/obj/item/candle/infinite,
+/turf/open/floor/wood,
+/area/icemoon)
+"Nb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed,
+/area/icemoon)
+"Ns" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/guardian/punch,
+/obj/item/candle/tribal_torch,
+/turf/open/floor/wood,
+/area/icemoon)
+"ND" = (
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/obj/effect/turf_decal/snow,
 /turf/open/floor/plasteel,
 /area/icemoon)
-"ZT" = (
+"NV" = (
+/obj/item/candle/tribal_torch,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon)
+"NX" = (
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/icemoon)
+"Ox" = (
 /obj/structure/railing{
 	dir = 6
 	},
 /obj/effect/turf_decal/corner/black/three_quarters,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"Oy" = (
+/obj/structure/closet/cabinet,
+/obj/item/storage/book/bible,
+/obj/item/clothing/suit/hooded/chaplain_hoodie,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
+/turf/open/floor/carpet/black,
+/area/icemoon)
+"OC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/snowdin,
+/area/icemoon)
+"PQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/icemoon)
+"PZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust{
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"QC" = (
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/icemoon)
+"Rf" = (
+/mob/living/simple_animal/hostile/guardian/ranged,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed,
+/area/icemoon)
+"Ro" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/icemoon)
+"Rx" = (
+/obj/item/candle/tribal_torch,
+/obj/effect/turf_decal/snow,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"SP" = (
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/obj/effect/turf_decal/snow,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"Tb" = (
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed,
+/area/icemoon)
+"Uf" = (
+/obj/item/candle/tribal_torch,
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon)
+"Ui" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/black/half{
+	dir = 4
+	},
+/obj/item/candle/tribal_torch,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"Us" = (
+/turf/open/floor/plasteel,
+/area/icemoon)
+"Uw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/icemoon)
+"UO" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/gloves/plate/blue,
+/obj/item/clothing/head/helmet/plate/crusader/blue,
+/obj/item/clothing/suit/armor/plate/crusader/blue,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
+/obj/item/nullrod,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/icemoon)
+"Vo" = (
+/turf/open/floor/plating/snowed,
+/area/icemoon)
+"WO" = (
+/obj/structure/chair/pew{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/snowdin,
+/area/icemoon)
+"Xl" = (
+/turf/open/floor/plasteel/stairs{
+	dir = 1
+	},
+/area/icemoon)
+"XL" = (
+/obj/effect/decal/remains/human,
+/turf/closed/wall/mineral/iron,
+/area/icemoon)
+"Yl" = (
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon)
+"Zq" = (
+/obj/item/candle/tribal_torch,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed,
+/area/icemoon)
+"Zv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/icemoon)
+"ZP" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/corner/black/half,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/under/costume/kilt/highlander,
+/obj/item/clothing/head/beret/highlander,
+/turf/open/floor/plasteel,
+/area/icemoon)
+"ZZ" = (
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/obj/effect/turf_decal/snow,
 /obj/effect/turf_decal/snow,
 /turf/open/floor/plasteel,
 /area/icemoon)
 
 (1,1,1) = {"
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-bh
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-gG
+pK
+pK
+pK
+pK
+uZ
+uZ
+uZ
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+uZ
+uZ
+uZ
+uZ
+pK
+pK
+XL
+pK
 "}
 (2,1,1) = {"
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
+pK
+xB
+fW
+tm
+Oy
+BB
+pK
+Dh
+ic
+so
+zP
+Us
+Us
+vq
+ic
+ic
+yt
+jj
+jA
+kq
+Yl
+hU
+Vo
+Tb
+GY
+Ez
+iG
+Di
+OC
+hU
+qx
+pK
 "}
 (3,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-sw
-sw
-sw
-Tc
-Tc
-Tc
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-Tc
-Tc
-Tc
-Tc
-sw
-sw
-kN
-sw
-bh
-LW
-LW
-LW
+pK
+fW
+fW
+bf
+yU
+cg
+uZ
+cU
+Bf
+Dh
+qg
+Dh
+Ui
+nL
+Dh
+ic
+Js
+Bn
+Yl
+ed
+uq
+LV
+pL
+ed
+Js
+jM
+jA
+KN
+pp
+WO
+pp
+tm
 "}
 (4,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-nM
-IS
-sV
-uB
-rj
-sw
-cE
-Vv
-Wl
-HA
-YX
-YX
-QP
-Vv
-Vv
-CQ
-Uo
-gT
-ra
-tJ
-BD
-Cj
-CH
-Xs
-He
-Pl
-nV
-Ix
-BD
-AF
-sw
-LW
-LW
-LW
-LW
+pK
+fW
+fW
+uZ
+uZ
+uZ
+tm
+lW
+Dh
+Dh
+zP
+Dh
+rI
+Xl
+DG
+sc
+Zq
+NX
+cQ
+rr
+wl
+wT
+Rx
+ZZ
+nF
+SP
+ES
+ob
+Es
+nd
+gV
+tm
 "}
 (5,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-IS
-IS
-yd
-zd
-oJ
-Tc
-If
-KD
-cE
-av
-cE
-Nm
-ZT
-cE
-Vv
-aC
-ep
-tJ
-Oi
-Jh
-Lh
-eh
-Oi
-aC
-ZA
-gT
-Cg
-Jj
-qI
-Jj
-sV
-LW
-LW
-LW
-LW
+pK
+oT
+fW
+pK
+tB
+yU
+tm
+ic
+Bf
+so
+zP
+Dh
+pH
+wV
+Dh
+Bf
+ic
+lL
+Dh
+Dh
+pf
+DG
+Dh
+Dh
+Bf
+ic
+Dh
+Dh
+Dh
+pc
+Dh
+tm
 "}
 (6,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-IS
-IS
-Tc
-Tc
-Tc
-sV
-tI
-cE
-cE
-HA
-cE
-Wi
-NK
-Xe
-XR
-yq
-MC
-Tf
-PE
-ti
-iy
-qo
-wM
-nN
-vZ
-oE
-sC
-sj
-Aw
-Pa
-sV
-LW
-LW
-LW
-LW
+pK
+oT
+fW
+bf
+yU
+bb
+uZ
+UO
+Bf
+Bf
+wP
+IT
+qr
+ZP
+Bf
+MR
+CH
+KR
+Dh
+IT
+Bf
+Dh
+Bf
+Dh
+Dh
+wJ
+Bf
+lL
+Dh
+Bf
+Dh
+uD
 "}
 (7,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-Xa
-IS
-sw
-eJ
-zd
-sV
-Vv
-KD
-Wl
-HA
-cE
-je
-Jn
-cE
-KD
-Vv
-hy
-cE
-cE
-cv
-Xe
-cE
-cE
-KD
-Vv
-cE
-cE
-cE
-xp
-cE
-sV
-bh
-LW
-LW
-LW
+pK
+fW
+fW
+uZ
+uZ
+pK
+uZ
+Dh
+Bf
+Fu
+aF
+Dh
+LK
+Ox
+Dh
+IT
+Dh
+ic
+lL
+PZ
+lL
+Dh
+Dh
+Bf
+Dh
+lL
+Dh
+ic
+Dh
+Bf
+Dh
+uZ
 "}
 (8,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-Xa
-IS
-yd
-zd
-YO
-Tc
-jj
-KD
-KD
-qj
-Yn
-TX
-Mu
-KD
-ow
-jd
-pA
-cE
-Yn
-KD
-cE
-KD
-cE
-cE
-sT
-KD
-hy
-cE
-KD
-cE
-kJ
-bh
-LW
-LW
-LW
+pK
+DM
+fW
+tm
+Oy
+PQ
+uZ
+lW
+Dh
+Bf
+aF
+ic
+Xl
+Xl
+Dh
+kn
+Es
+gh
+Es
+oI
+cQ
+tu
+Uf
+QC
+Zq
+kq
+NV
+Ez
+qb
+hU
+Rx
+uZ
 "}
 (9,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-IS
-IS
-Tc
-Tc
-sw
-Tc
-cE
-KD
-vU
-AI
-cE
-Se
-xz
-cE
-Yn
-cE
-Vv
-hy
-iV
-hy
-cE
-cE
-KD
-cE
-hy
-cE
-Vv
-cE
-KD
-cE
-Tc
-Iw
-LW
-LW
-LW
+pK
+Uw
+Uw
+id
+yU
+cg
+tm
+EV
+Dh
+ic
+aF
+Dh
+IJ
+wV
+Bf
+Dh
+iG
+Li
+Vo
+Bn
+in
+qe
+px
+Kh
+Vo
+qe
+Mw
+eR
+mY
+Bn
+Vo
+pK
 "}
 (10,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-sp
-IS
-sV
-uB
-Il
-Tc
-tI
-cE
-KD
-AI
-Vv
-NK
-NK
-cE
-Nz
-sj
-SU
-sj
-eG
-Tf
-kR
-me
-Hh
-yq
-ra
-TM
-He
-LS
-BD
-qo
-Tc
-bh
-LW
-LW
-LW
+pK
+Uw
+oT
+tm
+uZ
+pK
+pK
+Bf
+Dh
+jt
+wP
+Us
+Us
+gH
+Dh
+Dh
+Rf
+de
+zT
+rM
+iG
+aN
+iG
+wT
+Nb
+NX
+Yl
+ND
+Vo
+nd
+Vo
+pK
 "}
 (11,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-Qe
-Qe
-AX
-zd
-oJ
-sV
-wp
-cE
-Vv
-AI
-cE
-vq
-Jn
-KD
-cE
-Pl
-kP
-Cj
-ep
-Yj
-Ry
-dT
-VE
-Cj
-Ry
-ym
-wP
-kD
-ep
-Cj
-sw
-LW
-LW
-LW
-LW
+pK
+Uw
+fW
+uZ
+ve
+PQ
+pK
+Zv
+uZ
+uZ
+uZ
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
 "}
 (12,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-Qe
-Xa
-sV
-Tc
-sw
-sw
-KD
-cE
-Bn
-qj
-YX
-YX
-Lv
-cE
-cE
-XA
-Ao
-hO
-Ol
-Pl
-ZS
-Pl
-iy
-Xn
-MC
-tJ
-bF
-Cj
-Aw
-Cj
-sw
-LW
-LW
-LW
-LW
+pK
+oT
+DX
+bf
+PQ
+bb
+uZ
+Uw
+tm
+me
+fW
+MX
+DX
+pK
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
 "}
 (13,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-Qe
-IS
-Tc
-vP
-Il
-sw
-Ze
-Tc
-Tc
-Tc
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-LW
-LW
-LW
-LW
+pK
+fW
+Uw
+uZ
+pK
+uZ
+tm
+Uw
+uZ
+sj
+yU
+gy
+lz
+pK
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
 "}
 (14,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-Xa
-JT
-yd
-Il
-YO
-Tc
-Qe
-sV
-FL
-IS
-fQ
-JT
-sw
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
+pK
+DX
+Uw
+fW
+fW
+fW
+fW
+Uw
+pK
+AJ
+yU
+rf
+qz
+pK
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
 "}
 (15,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-IS
-Qe
-Tc
-sw
-Tc
-sV
-Qe
-Tc
-Nw
-zd
-qG
-CC
-sw
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
+pK
+Ns
+Ro
+Uw
+fW
+fW
+ha
+Uw
+Ly
+fW
+Ro
+fD
+qz
+pK
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
 "}
 (16,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-JT
-Qe
-IS
-IS
-IS
-IS
-Qe
-sw
-cl
-zd
-wV
-Xw
-sw
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-"}
-(17,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-aV
-By
-Qe
-IS
-IS
-zH
-Qe
-hV
-IS
-By
-xd
-Xw
-sw
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-"}
-(18,1,1) = {"
-LW
-LW
-LW
-LW
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-sw
-Tc
-sw
-sw
-sw
-sw
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-"}
-(19,1,1) = {"
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-"}
-(20,1,1) = {"
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
-LW
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+pK
+uZ
+pK
+pK
+pK
+pK
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
+yX
 "}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The imperial church map SOMEHOW breaks the assumption that every tile has both a turf and an area and I have no idea how it managed to have a null tile in sdmm, but it did. This fixes that, and resizes the map to be no larger than necessary, as it was all turf passthrough anyways so no functional change was made.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtimes are bad and break things.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The imperial church map will no longer create runtimes when spawning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
