### PR TITLE
Cryogenics is now indestructible

### DIFF
--- a/voidcrew/code/game/machinery/cryopod.dm
+++ b/voidcrew/code/game/machinery/cryopod.dm
@@ -19,6 +19,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	// circuit = /obj/item/circuitboard/cryopodcontrol
 	density = FALSE
 	req_one_access = list(ACCESS_HEADS, ACCESS_ARMORY) //Heads of staff or the warden can go here to claim recover items from their department that people went were cryodormed with.
+	resistance_flags = INDESTRUCTIBLE|LAVA_PROOF|FIRE_PROOF|UNACIDABLE|ACID_PROOF
 
 	/// Used for logging people entering cryosleep and important items they are carrying. Shows crew members.
 	var/list/frozen_crew = list()
@@ -157,6 +158,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	density = TRUE
 	anchored = TRUE
 	state_open = TRUE
+	resistance_flags = INDESTRUCTIBLE|LAVA_PROOF|FIRE_PROOF|UNACIDABLE|ACID_PROOF
 
 	/// Time until the human inside is despawned. Reduced to 10% of this if player manually enters cryo.
 	var/time_till_despawn = 5 MINUTES


### PR DESCRIPTION
## About The Pull Request

Port from the rebase, cryo machines are now indestructible.

## Why It's Good For The Game

It's already against server rules to break these machines, so all it's really destructible for at the moment is to grief ships. 

## Changelog
:cl:
fix: Cryogenic consoles and freezers are now indestructible.
/:cl:
