### PR TITLE
KOS Merlin-class Power Projector

### DIFF
--- a/_maps/configs/KOS_merlin.json
+++ b/_maps/configs/KOS_merlin.json
@@ -1,0 +1,35 @@
+{
+	"$schema": "https://raw.githubusercontent.com/shiptest-ss13/Shiptest/master/_maps/ship_config_schema.json",
+	"map_name": "Merlin-class Power Projector",
+	"map_short_name": "Merlin-class",
+	"prefix": "KOS",
+	"namelists": ["MYTHOLOGICAL"],
+	"map_path": "_maps/shuttles/shiptest/voidcrew/merlin.dmm",
+	"map_id": "merlin",
+	"limit": 1,
+	"job_slots": {
+		"ArchWizard": {
+			"outfit": "/datum/outfit/job/captain/wizard",
+			"officer": true,
+			"slots": 1
+		},
+		"Artifact Curator": {
+			"outfit": "/datum/outfit/job/head_of_personnel/wizard",
+			"officer": true,
+			"slots": 1
+		},
+		"Destruction Specialist": {
+			"outfit": "/datum/outfit/job/security/wizard",
+			"slots": 8
+		},
+		"Restoration Specialist": {
+			"outfit": "/datum/outfit/job/doctor/wizard",
+			"slots": 2
+		},
+		"Novice Wizard": {
+			"outfit": "/datum/outfit/job/assistant/wizard",
+			"slots": 4
+		}
+	},
+	"cost": 2500
+}

--- a/_maps/shuttles/shiptest/voidcrew/merlin.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/merlin.dmm
@@ -1398,6 +1398,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/closet/crate/bin{
+	pixel_y = 10;
+	desc = "A place to put used spellbooks. Read responsibly!";
+	name = "spellbook disposal"
+	},
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
 "nS" = (
@@ -1670,6 +1675,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/item/storage/book/bible,
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
 "rd" = (
@@ -2722,6 +2728,11 @@
 "zI" = (
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
+"zL" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen)
 "zR" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/wood/ebony,
@@ -2776,6 +2787,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen/kitchen)
 "AB" = (
@@ -3638,7 +3650,6 @@
 /turf/open/floor/carpet/royalblue,
 /area/ship/hallway/central)
 "Is" = (
-/obj/structure/table/wood/fancy/black,
 /obj/machinery/computer/helm/viewscreen{
 	dir = 8;
 	pixel_x = 32
@@ -3646,6 +3657,7 @@
 /obj/item/stack/sheet/mineral/diamond/twenty,
 /obj/item/stack/sheet/mineral/gold/fifty,
 /obj/item/stack/sheet/mineral/silver/fifty,
+/obj/machinery/ore_silo,
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
 "Iz" = (
@@ -4510,6 +4522,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/central)
+"Rj" = (
+/obj/structure/bodycontainer/crematorium/creamatorium{
+	dir = 8;
+	id = "merlin_crematorium"
+	},
+/obj/machinery/button/crematorium{
+	id = "merlin_crematorium";
+	pixel_x = -6;
+	pixel_y = -26
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical)
 "Rl" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/rollingpin,
@@ -6262,7 +6286,7 @@ MG
 MG
 MG
 ZU
-KD
+zL
 mi
 zy
 QU
@@ -6410,7 +6434,7 @@ xZ
 ya
 sQ
 Al
-Al
+Rj
 ya
 MG
 MG

--- a/_maps/shuttles/shiptest/voidcrew/merlin.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/merlin.dmm
@@ -273,11 +273,15 @@
 /turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "cR" = (
-/obj/structure/table/wood,
-/obj/item/candle/infinite,
-/obj/item/storage/box/matches,
+/obj/structure/table/wood/fancy/green,
+/obj/item/book/granter/spell/forcewall{
+	pixel_x = 5
+	},
+/obj/item/book/granter/spell/forcewall{
+	pixel_x = -5
+	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library)
+/area/ship/security/armory)
 "cS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -352,11 +356,17 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "dC" = (
-/obj/structure/chair/sofa/right{
-	dir = 4
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
 	},
-/turf/open/floor/carpet/green,
-/area/ship/maintenance/port)
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/starboard)
 "dU" = (
 /obj/machinery/power/smes{
 	name = "mana storage unit";
@@ -1084,17 +1094,9 @@
 /turf/open/floor/wood/mahogany,
 /area/ship/storage)
 "lh" = (
-/obj/machinery/power/rtg/advanced{
-	name = "mana field condenser"
-	},
-/obj/structure/window/plasma/reinforced/spawner/east{
-	color = "#008000"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/turf/open/floor/mineral/diamond,
-/area/ship/maintenance/starboard)
+/obj/structure/chair/sofa/left,
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port)
 "lk" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
@@ -1578,9 +1580,11 @@
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
 "qT" = (
-/obj/machinery/vending/snack/green,
-/turf/open/floor/carpet/green,
-/area/ship/maintenance/port)
+/obj/structure/table/wood,
+/obj/item/candle/infinite,
+/obj/item/storage/box/matches,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library)
 "rd" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/knife/butcher,
@@ -1776,6 +1780,10 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/wood/bamboo,
 /area/ship/cargo)
+"tJ" = (
+/obj/machinery/vending/snack/green,
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port)
 "tL" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
@@ -2573,15 +2581,9 @@
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/port)
 "AF" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/monkey/punpun,
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/port)
+/area/ship/maintenance/starboard)
 "AJ" = (
 /obj/structure/window/plasma/reinforced/fulltile{
 	color = "#008000"
@@ -2747,9 +2749,15 @@
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "Cu" = (
-/obj/structure/chair/sofa/left,
-/turf/open/floor/carpet/green,
-/area/ship/maintenance/port)
+/obj/structure/table/wood/fancy/green,
+/obj/item/book/granter/spell/cards{
+	pixel_x = -5
+	},
+/obj/item/book/granter/spell/cards{
+	pixel_x = 5
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory)
 "Cx" = (
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/table/wood/fancy/royalblue,
@@ -3091,7 +3099,7 @@
 /turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "Fg" = (
-/mob/living/carbon/monkey/punpun,
+/obj/item/grown/bananapeel,
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/starboard)
 "Fl" = (
@@ -3306,9 +3314,15 @@
 /turf/open/floor/carpet/royalblue,
 /area/ship/hallway/central)
 "Hr" = (
-/obj/item/grown/bananapeel,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/starboard)
+/area/ship/maintenance/port)
 "HA" = (
 /obj/machinery/computer/rdconsole{
 	dir = 8
@@ -3684,6 +3698,12 @@
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/security/armory)
+"KJ" = (
+/obj/structure/chair/sofa/right{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port)
 "KM" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -4324,7 +4344,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/cyan{
-	icon_state = "2-4"
+	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
@@ -5225,8 +5245,8 @@ jg
 zw
 iR
 LB
-lh
-lh
+dC
+dC
 gv
 gv
 kc
@@ -5239,9 +5259,9 @@ MG
 MG
 Eo
 zE
-AF
-AF
-AF
+SX
+SX
+SX
 MM
 Eo
 Eo
@@ -5280,9 +5300,9 @@ MG
 MG
 MG
 Eo
-qT
+tJ
 aZ
-dC
+KJ
 Qf
 vE
 VZ
@@ -5311,7 +5331,7 @@ gv
 eb
 WY
 Eg
-Fg
+AF
 Eg
 lK
 LB
@@ -5323,7 +5343,7 @@ MG
 MG
 Eo
 Eo
-Cu
+lh
 Qf
 gc
 xB
@@ -5353,8 +5373,8 @@ gJ
 gJ
 aH
 TW
-Hr
 Fg
+AF
 LB
 LB
 MG
@@ -5366,8 +5386,8 @@ MG
 MG
 Zm
 tc
-SX
-SX
+Hr
+Hr
 AB
 aT
 Ut
@@ -6516,10 +6536,10 @@ Uo
 oC
 oC
 oC
-CP
+cR
 DD
 LM
-cR
+qT
 DK
 gQ
 DD
@@ -6555,7 +6575,7 @@ Tk
 Tk
 TB
 Uo
-CY
+Cu
 CP
 CY
 ZR

--- a/_maps/shuttles/shiptest/voidcrew/merlin.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/merlin.dmm
@@ -126,14 +126,17 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/maintenance/aft)
 "aZ" = (
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
+/obj/structure/chair/sofa/corner{
+	dir = 4
 	},
-/turf/open/floor/wood/bamboo,
-/area/ship/maintenance/aft)
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port)
 "bf" = (
 /obj/structure/closet/secure_closet/engineering_electrical{
 	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
@@ -182,10 +185,7 @@
 /area/ship/maintenance/aft)
 "bC" = (
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /turf/closed/wall/mineral/uranium/safe{
 	desc = "A wall plated with emerald.";
@@ -270,19 +270,14 @@
 "cP" = (
 /obj/structure/bed,
 /obj/item/bedsheet/wiz,
-/turf/open/floor/wood/ebony,
+/turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "cR" = (
-/obj/structure/table/wood/fancy/green,
-/obj/item/book/granter/spell/knock{
-	pixel_x = -5
-	},
-/obj/item/book/granter/spell/knock{
-	pixel_x = 5
-	},
-/obj/machinery/light,
+/obj/structure/table/wood,
+/obj/item/candle/infinite,
+/obj/item/storage/box/matches,
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory)
+/area/ship/crew/library)
 "cS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -357,14 +352,11 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "dC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/sofa/right{
+	dir = 4
 	},
-/turf/closed/wall/mineral/uranium/safe{
-	desc = "A wall plated with emerald.";
-	name = "emerald wall"
-	},
-/area/ship/maintenance/central)
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port)
 "dU" = (
 /obj/machinery/power/smes{
 	name = "mana storage unit";
@@ -419,8 +411,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/carpet/stellar,
 /area/ship/crew/library)
 "er" = (
@@ -453,28 +449,14 @@
 	},
 /obj/item/reagent_containers/glass/beaker/bluespace{
 	icon_state = "potblue";
-	name = "beaker of holding"
+	name = "beaker of holding";
+	can_have_cap = 0
 	},
 /obj/item/slimepotion/genderchange{
 	pixel_x = 5
 	},
 /obj/item/slimepotion/lavaproof{
 	pixel_x = 10
-	},
-/obj/item/slimepotion/peacepotion{
-	pixel_x = 15
-	},
-/obj/item/slimepotion/spaceproof{
-	pixel_x = 20
-	},
-/obj/item/slimepotion/speed{
-	pixel_x = 25
-	},
-/obj/item/slimepotion/transference{
-	pixel_x = 30
-	},
-/obj/item/reagent_containers/glass/bottle/potion/flight{
-	pixel_x = 35
 	},
 /turf/open/floor/mineral/silver,
 /area/ship/medical)
@@ -566,9 +548,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
 /obj/structure/window/plasma/reinforced/spawner/west{
 	color = "#008000"
 	},
@@ -623,19 +602,10 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
 "gc" = (
-/obj/machinery/power/rtg/advanced{
-	name = "mana field condenser"
+/obj/structure/chair/comfy/brown{
+	dir = 1
 	},
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/obj/structure/window/plasma/reinforced/spawner/east{
-	color = "#008000"
-	},
-/obj/structure/window/plasma/reinforced/spawner{
-	color = "#008000"
-	},
-/turf/open/floor/mineral/diamond,
+/turf/open/floor/carpet/green,
 /area/ship/maintenance/port)
 "gu" = (
 /obj/effect/turf_decal/atmos/plasma,
@@ -720,6 +690,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
 /turf/open/floor/light,
 /area/ship/medical)
 "he" = (
@@ -786,6 +759,9 @@
 /obj/structure/closet/radiation{
 	anchored = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "hQ" = (
@@ -793,6 +769,9 @@
 /obj/item/storage/toolbox/electrical,
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
@@ -940,6 +919,9 @@
 "jb" = (
 /obj/structure/closet/secure_closet/atmospherics{
 	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
@@ -1102,27 +1084,17 @@
 /turf/open/floor/wood/mahogany,
 /area/ship/storage)
 "lh" = (
-/obj/structure/table/wood/fancy,
-/obj/item/skub{
-	pixel_y = 16
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/skub{
-	pixel_y = 11
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
 	},
-/obj/item/skub{
-	pixel_y = 4
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
 	},
-/obj/machinery/door/window/survival_pod{
-	req_access_txt = "1";
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ship/maintenance/fore)
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/starboard)
 "lk" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
@@ -1184,12 +1156,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/ship/maintenance/fore)
 "lK" = (
-/turf/closed/wall/mineral/uranium/safe{
-	desc = "A wall plated with emerald.";
-	name = "emerald wall"
-	},
-/turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen)
+/obj/machinery/vending/snack/green,
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/starboard)
 "lM" = (
 /obj/machinery/smartfridge/bloodbank/preloaded,
 /turf/closed/wall/mineral/uranium/safe{
@@ -1370,14 +1339,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
@@ -1387,7 +1356,7 @@
 /obj/item/upgradescroll,
 /obj/item/upgradescroll,
 /obj/item/upgradescroll,
-/turf/open/floor/wood/ebony,
+/turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "nV" = (
 /obj/structure/cable{
@@ -1489,9 +1458,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
 "pO" = (
@@ -1572,7 +1538,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/wood/ebony,
+/turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "qE" = (
 /obj/structure/cable{
@@ -1612,11 +1578,9 @@
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
 "qT" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/mineral/silver,
-/area/ship/medical)
+/obj/machinery/vending/snack/green,
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port)
 "rd" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/knife/butcher,
@@ -1710,7 +1674,7 @@
 /area/ship/cargo)
 "sg" = (
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/ebony,
+/turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "sh" = (
 /obj/structure/cable{
@@ -1734,9 +1698,6 @@
 "sF" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
 	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -1803,9 +1764,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/port)
@@ -1818,20 +1776,6 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/wood/bamboo,
 /area/ship/cargo)
-"tJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/stasis{
-	name = "Mana preservation unit"
-	},
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -28;
-	desc = "Uses a high-frequency jolt of Mana to restart circulatory systems.";
-	name = "Wall-mounted mana-jolter"
-	},
-/turf/open/floor/mineral/silver,
-/area/ship/medical)
 "tL" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
@@ -1879,7 +1823,16 @@
 /area/ship/maintenance/central)
 "tW" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/item/research_notes/loot/genius,
+/obj/item/research_notes/loot/medium,
+/obj/item/research_notes/loot/tiny,
+/obj/item/research_notes/loot/tiny,
+/obj/item/research_notes/loot/tiny,
+/obj/item/research_notes/loot/tiny,
+/obj/item/research_notes/loot/tiny,
+/obj/item/research_notes/loot/tiny,
+/obj/item/research_notes/loot/tiny,
+/obj/item/research_notes/loot/tiny,
+/obj/item/research_notes/loot/tiny,
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
 "tY" = (
@@ -1906,6 +1859,12 @@
 	},
 /obj/structure/closet/secure_closet/engineering_welding{
 	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
@@ -2066,11 +2025,11 @@
 /turf/open/floor/mineral/diamond,
 /area/ship/maintenance/starboard)
 "vv" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/aft)
@@ -2161,7 +2120,7 @@
 	desc = "50% carp, 100% magic, 150% horrible, 200% a wizard's best friend.";
 	name = "Bunglesworth"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/yew,
 /area/ship/bridge)
 "wt" = (
 /obj/machinery/processor,
@@ -2198,7 +2157,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/wood/ebony,
+/turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "wI" = (
 /obj/structure/chair/bronze{
@@ -2274,6 +2233,7 @@
 /obj/effect/mob_spawn/human/corpse/wizard{
 	name = "Pingus"
 	},
+/obj/item/research_notes/loot/tiny,
 /turf/open/floor/engine/plasma,
 /area/ship/storage)
 "xy" = (
@@ -2384,6 +2344,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "yG" = (
@@ -2475,7 +2438,8 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/open/floor/wood/ebony,
+/obj/machinery/power/apc/auto_name/west,
+/turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "zr" = (
 /obj/machinery/power/smes/shuttle/precharged{
@@ -2527,9 +2491,6 @@
 /turf/open/floor/mineral/diamond,
 /area/ship/maintenance/port)
 "zE" = (
-/obj/structure/cable/cyan{
-	icon_state = "2-4"
-	},
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
@@ -2612,14 +2573,15 @@
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/port)
 "AF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
 	},
-/turf/open/floor/carpet/stellar,
-/area/ship/crew/library)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port)
 "AJ" = (
 /obj/structure/window/plasma/reinforced/fulltile{
 	color = "#008000"
@@ -2688,17 +2650,14 @@
 /turf/open/floor/carpet/royalblack,
 /area/ship/crew/dorm/dormtwo)
 "Bz" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/aft)
@@ -2729,7 +2688,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi';
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	},
-/turf/open/floor/wood/ebony,
+/turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "BW" = (
 /obj/machinery/power/rtg/advanced{
@@ -2788,36 +2747,57 @@
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "Cu" = (
-/obj/structure/table/wood/fancy/green,
-/obj/item/book/granter/spell/summonitem{
-	pixel_x = 5
-	},
-/obj/item/book/granter/spell/summonitem{
-	pixel_x = -5
-	},
-/turf/open/floor/wood/bamboo,
-/area/ship/security/armory)
+/obj/structure/chair/sofa/left,
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port)
 "Cx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/table/wood/fancy/royalblue,
 /turf/open/floor/mineral/silver,
 /area/ship/medical)
 "Cy" = (
 /obj/structure/table/wood/fancy/green,
-/obj/item/gun/energy/xray{
-	fire_sound = 'sound/magic/staff_change.ogg';
+/obj/item/gun/energy/taser{
 	icon = 'icons/obj/guns/magic.dmi';
-	icon_state = "staffofsapping";
-	item_state = "staffofsapping";
-	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
-	lefthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
-	desc = "A powerful offensive staff that can fire blasts of eldrich energy that pass through walls.";
-	name = "Gamma Staff";
+	icon_state = "telewand";
+	name = "wand of stunning";
+	desc = "A wand which send a weak blast of energy designed to incapacitate";
+	fire_sound = 'sound/magic/wand_teleport.ogg';
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi';
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
+	},
+/obj/item/gun/energy/taser{
+	icon = 'icons/obj/guns/magic.dmi';
+	icon_state = "telewand";
+	name = "wand of stunning";
+	desc = "A wand which send a weak blast of energy designed to incapacitate";
 	pixel_x = 5
 	},
+/obj/item/gun/energy/taser{
+	icon = 'icons/obj/guns/magic.dmi';
+	icon_state = "telewand";
+	name = "wand of stunning";
+	desc = "A wand which send a weak blast of energy designed to incapacitate";
+	pixel_x = 10;
+	fire_sound = 'sound/magic/wand_teleport.ogg';
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi';
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
+	},
+/obj/item/gun/energy/taser{
+	icon = 'icons/obj/guns/magic.dmi';
+	icon_state = "telewand";
+	name = "wand of stunning";
+	desc = "A wand which send a weak blast of energy designed to incapacitate";
+	pixel_x = -5;
+	fire_sound = 'sound/magic/wand_teleport.ogg';
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi';
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory)
+"CA" = (
+/obj/structure/fluff/divine/convertaltar,
+/obj/machinery/light/floor,
 /obj/item/gun/energy/xray{
 	fire_sound = 'sound/magic/staff_change.ogg';
 	icon = 'icons/obj/guns/magic.dmi';
@@ -2828,42 +2808,6 @@
 	desc = "A powerful offensive staff that can fire blasts of eldrich energy that pass through walls.";
 	name = "Gamma Staff"
 	},
-/obj/item/gun/energy/xray{
-	fire_sound = 'sound/magic/staff_change.ogg';
-	icon = 'icons/obj/guns/magic.dmi';
-	icon_state = "staffofsapping";
-	item_state = "staffofsapping";
-	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
-	lefthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
-	desc = "A powerful offensive staff that can fire blasts of eldrich energy that pass through walls.";
-	name = "Gamma Staff";
-	pixel_x = -5
-	},
-/obj/item/gun/energy/xray{
-	fire_sound = 'sound/magic/staff_change.ogg';
-	icon = 'icons/obj/guns/magic.dmi';
-	icon_state = "staffofsapping";
-	item_state = "staffofsapping";
-	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
-	lefthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
-	desc = "A powerful offensive staff that can fire blasts of eldrich energy that pass through walls.";
-	name = "Gamma Staff";
-	pixel_x = -10
-	},
-/turf/open/floor/wood/bamboo,
-/area/ship/security/armory)
-"CA" = (
-/obj/structure/altar_of_gods,
-/obj/item/gun/energy/pulse/carbine{
-	icon = 'icons/obj/guns/magic.dmi';
-	icon_state = "staffofanimation";
-	pin = /obj/item/firing_pin/magic;
-	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi';
-	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
-	desc = "An extremely powerful wand, created using the soul of the powerful wizard, Rodney XII";
-	name = "Rodney's Gift"
-	},
-/obj/machinery/light/floor,
 /turf/open/floor/carpet/black,
 /area/ship/storage)
 "CF" = (
@@ -3046,19 +2990,8 @@
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
 "Eg" = (
-/obj/machinery/power/rtg/advanced{
-	name = "mana field condenser"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
-	},
-/obj/structure/window/plasma/reinforced/spawner/west{
-	color = "#008000"
-	},
-/obj/structure/window/plasma/reinforced/spawner/north{
-	color = "#008000"
-	},
-/turf/open/floor/mineral/diamond,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/turf/open/floor/carpet/green,
 /area/ship/maintenance/starboard)
 "Ei" = (
 /obj/machinery/door/airlock{
@@ -3067,9 +3000,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
@@ -3089,7 +3019,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/bookcase/random,
 /turf/open/floor/carpet/stellar,
 /area/ship/crew/library)
 "ED" = (
@@ -3159,17 +3088,12 @@
 /area/ship/medical)
 "Fd" = (
 /obj/structure/closet/crate/bin,
-/turf/open/floor/wood/ebony,
+/turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "Fg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/carpet/stellar,
-/area/ship/crew/library)
+/mob/living/carbon/monkey/punpun,
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/starboard)
 "Fl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3195,13 +3119,10 @@
 /turf/open/floor/carpet/red_gold,
 /area/ship/hallway/central)
 "Fs" = (
+/obj/machinery/airalarm/directional/south,
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/starboard)
 "Fu" = (
@@ -3222,9 +3143,6 @@
 /turf/open/floor/engine/plasma,
 /area/ship/maintenance/aft)
 "FF" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
 	},
@@ -3342,6 +3260,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "GV" = (
@@ -3385,17 +3306,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/ship/hallway/central)
 "Hr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/light,
-/area/ship/medical)
+/obj/item/grown/bananapeel,
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/starboard)
 "HA" = (
 /obj/machinery/computer/rdconsole{
 	dir = 8
@@ -3412,7 +3325,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/wood/ebony,
+/turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "HN" = (
 /obj/structure/window/plasma/reinforced/spawner/north{
@@ -3515,7 +3428,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 2
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -3638,7 +3551,7 @@
 /obj/structure/closet/cabinet,
 /obj/item/clothing/suit/space/hardsuit/wizard,
 /obj/item/clothing/gloves/combat/wizard,
-/turf/open/floor/wood/ebony,
+/turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "Kc" = (
 /obj/structure/cable{
@@ -3706,6 +3619,9 @@
 	desc = "Used for pulsing wires, with magic"
 	},
 /obj/item/storage/toolbox/mechanical,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "Kp" = (
@@ -3718,6 +3634,16 @@
 /area/ship/crew/dorm)
 "Kr" = (
 /obj/structure/table/wood/fancy/royalblue,
+/obj/item/reagent_containers/glass/bottle/potion/flight{
+	pixel_x = 5
+	},
+/obj/item/slimepotion/speed,
+/obj/item/slimepotion/spaceproof{
+	pixel_x = -5
+	},
+/obj/item/slimepotion/peacepotion{
+	pixel_x = -10
+	},
 /turf/open/floor/mineral/silver,
 /area/ship/medical)
 "Kw" = (
@@ -3758,12 +3684,6 @@
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/security/armory)
-"KJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/mineral/silver,
-/area/ship/medical)
 "KM" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3959,6 +3879,9 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
@@ -4186,19 +4109,7 @@
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "Qf" = (
-/obj/machinery/power/rtg/advanced{
-	name = "mana field condenser"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
-	},
-/obj/structure/window/plasma/reinforced/spawner/west{
-	color = "#008000"
-	},
-/obj/structure/window/plasma/reinforced/spawner{
-	color = "#008000"
-	},
-/turf/open/floor/mineral/diamond,
+/turf/open/floor/carpet/green,
 /area/ship/maintenance/port)
 "Qn" = (
 /obj/structure/chair/bronze{
@@ -4213,10 +4124,12 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 2
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
 "Qt" = (
@@ -4286,13 +4199,13 @@
 /turf/open/floor/carpet/orange,
 /area/ship/security/armory)
 "RN" = (
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
 	},
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
-/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
@@ -4362,14 +4275,14 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/maintenance/aft)
 "SD" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/aft)
@@ -4413,9 +4326,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/port)
@@ -4426,9 +4336,6 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/cargo)
 "Ti" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 2
 	},
@@ -4438,7 +4345,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/bookcase/random,
+/obj/structure/chair/bronze{
+	dir = 4
+	},
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
 "Tk" = (
@@ -4448,12 +4357,12 @@
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/fore)
 "Tl" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/components/binary/pump/layer4{
 	dir = 1;
 	on = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/aft)
@@ -4477,6 +4386,9 @@
 /obj/item/pipe_dispenser{
 	name = "Rapid Pipe Conjurer (RPC)";
 	desc = "A device used to rapidly pipe things, using magic"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
@@ -4516,19 +4428,7 @@
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "TW" = (
-/obj/machinery/power/rtg/advanced{
-	name = "mana field condenser"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/obj/structure/window/plasma/reinforced/spawner/east{
-	color = "#008000"
-	},
-/obj/structure/window/plasma/reinforced/spawner/north{
-	color = "#008000"
-	},
-/turf/open/floor/mineral/diamond,
+/turf/open/floor/carpet/green,
 /area/ship/maintenance/starboard)
 "TY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
@@ -4543,9 +4443,6 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
 "Ua" = (
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
 /obj/machinery/computer/cargo/express{
 	dir = 8
 	},
@@ -4559,6 +4456,10 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/west,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 4
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/maintenance/fore)
 "Uc" = (
@@ -4640,7 +4541,7 @@
 /area/ship/hallway/fore)
 "UN" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/wood/ebony,
+/turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "UV" = (
 /obj/structure/cable{
@@ -4670,7 +4571,7 @@
 /turf/open/floor/carpet/red_gold,
 /area/ship/hallway/central)
 "Vh" = (
-/obj/structure/altar_of_gods,
+/obj/structure/fluff/divine/convertaltar,
 /obj/item/mjollnir,
 /obj/machinery/light/floor,
 /turf/open/floor/carpet/black,
@@ -4687,7 +4588,7 @@
 /area/ship/cargo)
 "VE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/wood/ebony,
+/turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "VW" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -4921,6 +4822,12 @@
 /obj/structure/closet/secure_closet/engineering_personal{
 	anchored = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "Zi" = (
@@ -4965,10 +4872,10 @@
 /area/ship/crew/dorm)
 "ZS" = (
 /obj/structure/cable/cyan{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
 /obj/structure/cable/cyan{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/starboard)
@@ -5296,7 +5203,7 @@ wN
 wN
 Eo
 yZ
-aZ
+OG
 FF
 Ti
 Bz
@@ -5318,8 +5225,8 @@ jg
 zw
 iR
 LB
-gv
-gv
+lh
+lh
 gv
 gv
 kc
@@ -5332,9 +5239,9 @@ MG
 MG
 Eo
 zE
-SX
-SX
-SX
+AF
+AF
+AF
 MM
 Eo
 Eo
@@ -5342,18 +5249,18 @@ Eo
 Eo
 Eo
 Ei
-dC
-dC
-dC
-dC
-dC
+vJ
+vJ
+vJ
+vJ
+vJ
 bC
 bC
-dC
-dC
-dC
-dC
-dC
+vJ
+vJ
+vJ
+vJ
+vJ
 pE
 LB
 LB
@@ -5373,9 +5280,9 @@ MG
 MG
 MG
 Eo
-zD
-Ut
-Ut
+qT
+aZ
+dC
 Qf
 vE
 VZ
@@ -5404,9 +5311,9 @@ gv
 eb
 WY
 Eg
-ql
-ql
-jE
+Fg
+Eg
+lK
 LB
 MG
 MG
@@ -5416,8 +5323,8 @@ MG
 MG
 Eo
 Eo
-wx
-wN
+Cu
+Qf
 gc
 xB
 wg
@@ -5446,8 +5353,8 @@ gJ
 gJ
 aH
 TW
-gv
-kc
+Hr
+Fg
 LB
 LB
 MG
@@ -5487,8 +5394,8 @@ ql
 ql
 Ds
 an
-sF
-sF
+ZS
+ZS
 ZS
 hA
 MG
@@ -5548,7 +5455,7 @@ nD
 nD
 nD
 nD
-lh
+lJ
 lJ
 lJ
 nD
@@ -5613,7 +5520,7 @@ Mm
 RQ
 zj
 Jf
-KJ
+EY
 GC
 ya
 MG
@@ -5655,8 +5562,8 @@ pW
 ya
 EY
 hd
-qT
-tJ
+GN
+mL
 ya
 MG
 MG
@@ -5696,7 +5603,7 @@ ya
 ya
 lM
 EY
-Hr
+sQ
 Cx
 ya
 ya
@@ -6054,7 +5961,7 @@ ZU
 tL
 ZU
 mZ
-lK
+ZU
 ZU
 pW
 Di
@@ -6444,8 +6351,8 @@ jZ
 oC
 DD
 nO
-Fg
-AF
+jz
+jz
 jz
 GH
 DD
@@ -6487,7 +6394,7 @@ oC
 DD
 Ki
 EB
-bg
+jz
 jz
 tY
 DD
@@ -6528,7 +6435,7 @@ Qt
 xf
 DD
 LM
-bg
+jz
 bg
 jz
 tW
@@ -6609,10 +6516,10 @@ Uo
 oC
 oC
 oC
-cR
+CP
 DD
 LM
-DK
+cR
 DK
 gQ
 DD
@@ -6648,7 +6555,7 @@ Tk
 Tk
 TB
 Uo
-Cu
+CY
 CP
 CY
 ZR

--- a/_maps/shuttles/shiptest/voidcrew/merlin.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/merlin.dmm
@@ -1,0 +1,8182 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ag" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/light,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"an" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"ar" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/green,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"ay" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/carpet/purple,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"az" = (
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/carpet/green,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"aD" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4;
+	name = "mana precharger"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"aE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Conducting Chamber";
+	req_access_txt = "19"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"aH" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"aL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/light,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"aT" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/window/plasma/reinforced/spawner/west{
+	color = "#008000"
+	},
+/obj/structure/window/plasma/reinforced/spawner/north{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"aV" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/plasteel/grimy,
+/area/ship/maintenance/fore{
+	name = "Skub closet"
+	})
+"aW" = (
+/obj/machinery/vending/snack/green,
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"aZ" = (
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"bf" = (
+/obj/structure/closet/secure_closet/engineering_electrical{
+	anchored = 1
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"bg" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"bq" = (
+/obj/machinery/chem_dispenser/fullupgrade{
+	name = "chemical conjurer";
+	desc = "Creates and dispenses chemicals using magis spells, like 'hocus pocus'."
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"bt" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"bv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"bx" = (
+/obj/machinery/chem_master{
+	name = "ChemMagic 3000";
+	desc = "Used to separate chemicals and distribute them in a variety of forms, using magic"
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"bB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"bC" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"bI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"bJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"bW" = (
+/obj/machinery/stasis{
+	name = "Mana preservation unit"
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"cg" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"ch" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"cl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table/wood/fancy/red_gold,
+/turf/open/floor/carpet/red_gold,
+/area/ship/hallway/central)
+"cA" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"cF" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 5
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/carpet/green,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"cI" = (
+/obj/structure/window/plasma/reinforced/spawner{
+	color = "#008000"
+	},
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/turf/open/floor/engine,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"cP" = (
+/obj/structure/bed,
+/obj/item/bedsheet/wiz,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/dorm/dormtwo{
+	name = "Archmage's Quarters"
+	})
+"cR" = (
+/obj/structure/table/wood/fancy/green,
+/obj/item/book/granter/spell/knock{
+	pixel_x = -5
+	},
+/obj/item/book/granter/spell/knock{
+	pixel_x = 5
+	},
+/obj/machinery/light,
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"cS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"cU" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"da" = (
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"dg" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"dh" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"dm" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 4
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"dw" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/obj/machinery/meter/atmos,
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/turf/open/floor/engine/plasma,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"dB" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"dC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"dU" = (
+/obj/machinery/power/smes{
+	name = "mana storage unit";
+	charge = 2e+006
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"dV" = (
+/obj/machinery/rnd/production/circuit_imprinter{
+	name = "circuitboard conjurer"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"eb" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/obj/structure/window/plasma/reinforced/spawner{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"ek" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"ep" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"er" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"ey" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/light,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"eR" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/slimepotion/lovepotion{
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/glass/beaker/bluespace{
+	icon_state = "potblue";
+	name = "beaker of holding"
+	},
+/obj/item/slimepotion/genderchange{
+	pixel_x = 5
+	},
+/obj/item/slimepotion/lavaproof{
+	pixel_x = 10
+	},
+/obj/item/slimepotion/peacepotion{
+	pixel_x = 15
+	},
+/obj/item/slimepotion/spaceproof{
+	pixel_x = 20
+	},
+/obj/item/slimepotion/speed{
+	pixel_x = 25
+	},
+/obj/item/slimepotion/transference{
+	pixel_x = 30
+	},
+/obj/item/reagent_containers/glass/bottle/potion/flight{
+	pixel_x = 35
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"eV" = (
+/obj/structure/window/plasma/reinforced/spawner/north{
+	color = "#008000"
+	},
+/turf/open/floor/engine/air{
+	icon_state = "wood-broken2"
+	},
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"fc" = (
+/obj/structure/window/plasma/reinforced/fulltile{
+	color = "#008000"
+	},
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "wizardship4"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"fg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"fi" = (
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"fj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"fv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"fy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"fz" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner/west{
+	color = "#008000"
+	},
+/obj/structure/window/plasma/reinforced/spawner/north{
+	color = "#008000"
+	},
+/turf/open/floor/engine,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"fC" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4;
+	name = "phlogiston heater"
+	},
+/turf/open/floor/plating,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"fF" = (
+/obj/effect/decal/cleanable/wrapping,
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"fK" = (
+/obj/machinery/autolathe{
+	name = "mana condenser"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"fL" = (
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"fR" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Mana requillary";
+	req_access_txt = "16"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"fX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"gb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"gc" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/obj/structure/window/plasma/reinforced/spawner{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"gu" = (
+/obj/effect/turf_decal/atmos/plasma,
+/turf/open/floor/engine/plasma,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"gv" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"gC" = (
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/carpet/red_gold,
+/area/ship/hallway/central)
+"gJ" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"gN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/light,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"gO" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/carpet/purple,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"gQ" = (
+/obj/machinery/blackbox_recorder{
+	name = "The George Lopez tapes";
+	desc = "This device holds every episode of the George Lopez show, restored digitally in glorious 1080i"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"hc" = (
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/obj/structure/window/plasma/reinforced/spawner/north{
+	color = "#008000"
+	},
+/turf/open/floor/engine,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"hd" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/light,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"he" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/light,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"hf" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/machinery/button/door{
+	id = "wizardship4_rear";
+	name = "Blast Doors";
+	pixel_x = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"hA" = (
+/obj/structure/window/plasma/reinforced/fulltile{
+	color = "#008000"
+	},
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "wizardship4"
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"hG" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"hP" = (
+/obj/structure/closet/radiation{
+	anchored = 1
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"hQ" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 5
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"hS" = (
+/obj/machinery/mecha_part_fabricator,
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"hZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"ia" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"ib" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/west,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"ic" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"ik" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/stack/spacecash/c10000,
+/obj/item/stack/spacecash/c10000,
+/obj/item/stack/spacecash/c10000,
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"il" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/fireaxecabinet{
+	pixel_y = 28
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"im" = (
+/obj/machinery/atmospherics/miner/toxins{
+	icon = 'icons/obj/items_and_weapons.dmi';
+	icon_state = "skub";
+	desc = "The Skub is emitting gas at an alarming rate";
+	name = "activated Skub"
+	},
+/turf/open/floor/engine/plasma,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"in" = (
+/obj/structure/chair/wood/wings{
+	dir = 1
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"ir" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"iF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"iG" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/o2,
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"iJ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"iK" = (
+/obj/effect/turf_decal/atmos/air,
+/turf/open/floor/engine/air{
+	icon_state = "wood-broken2"
+	},
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"iP" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"iR" = (
+/obj/machinery/atmospherics/miner/nitrogen{
+	icon = 'icons/obj/items_and_weapons.dmi';
+	icon_state = "skub";
+	desc = "The Skub is emitting gas at an alarming rate";
+	name = "activated Skub"
+	},
+/turf/open/floor/engine/air{
+	icon_state = "wood-broken6"
+	},
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"iV" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4;
+	name = "phlogiston expeller"
+	},
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "wizardship4"
+	},
+/turf/open/floor/plating,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"jb" = (
+/obj/structure/closet/secure_closet/atmospherics{
+	anchored = 1
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"jg" = (
+/obj/machinery/atmospherics/miner/nitrogen{
+	icon = 'icons/obj/items_and_weapons.dmi';
+	icon_state = "skub";
+	desc = "The Skub is emitting gas at an alarming rate";
+	name = "activated Skub"
+	},
+/obj/structure/window/plasma/reinforced/spawner/north{
+	color = "#008000"
+	},
+/turf/open/floor/engine/air{
+	icon_state = "wood-broken2"
+	},
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"ji" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/light,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"jj" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/sord,
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"jk" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Skub closet";
+	req_access_txt = "1"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/squid_ink,
+/turf/open/floor/plasteel/grimy,
+/area/ship/maintenance/fore{
+	name = "Skub closet"
+	})
+"jr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"jy" = (
+/turf/open/floor/engine,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"jz" = (
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"jD" = (
+/obj/machinery/airalarm/directional/south,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"jE" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/machinery/light,
+/obj/structure/window/plasma/reinforced/spawner/west{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"jI" = (
+/obj/structure/window/plasma/reinforced/spawner/north{
+	color = "#008000"
+	},
+/obj/structure/window/plasma/reinforced/spawner/west{
+	color = "#008000"
+	},
+/turf/open/floor/carpet/black,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"jZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"ka" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"kc" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/machinery/light,
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"kv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/dorm)
+"ky" = (
+/obj/machinery/deepfryer,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"kJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"kS" = (
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/dorm)
+"kU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"lh" = (
+/obj/structure/table/wood/fancy,
+/obj/item/skub{
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/skub{
+	pixel_y = 11
+	},
+/obj/item/skub{
+	pixel_y = 4
+	},
+/obj/machinery/door/window/survival_pod{
+	req_access_txt = "1";
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/maintenance/fore{
+	name = "Skub closet"
+	})
+"lk" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner/west{
+	color = "#008000"
+	},
+/turf/open/floor/engine,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"ls" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/dorm)
+"lx" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"lD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
+"lJ" = (
+/obj/structure/table/wood/fancy,
+/obj/item/skub{
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/skub{
+	pixel_y = 11
+	},
+/obj/item/skub{
+	pixel_y = 4
+	},
+/obj/machinery/door/window/survival_pod{
+	req_access_txt = "1";
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/maintenance/fore{
+	name = "Skub closet"
+	})
+"lM" = (
+/obj/machinery/smartfridge/bloodbank/preloaded,
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"lR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Archives"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"mi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"ms" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Artifact Vault";
+	req_access_txt = "16"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"mw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"mL" = (
+/obj/machinery/stasis{
+	name = "Mana preservation unit"
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -28;
+	desc = "Uses a high-frequency jolt of Mana to restart circulatory systems.";
+	name = "Wall-mounted mana-jolter"
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"mW" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"mZ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"ni" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"nj" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"nx" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/light,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"ny" = (
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"nz" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"nC" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 6
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"nD" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/maintenance/fore{
+	name = "Skub closet"
+	})
+"nI" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/storage/firstaid,
+/obj/item/storage/firstaid,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"nK" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"nL" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/machinery/light,
+/obj/structure/window/plasma/reinforced/spawner/west{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"nM" = (
+/obj/structure/window/plasma/reinforced/fulltile{
+	color = "#008000"
+	},
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "wizardship4"
+	},
+/turf/open/floor/plating,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"nN" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"nO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"nS" = (
+/obj/structure/table/wood/fancy/green,
+/obj/item/scrying,
+/obj/item/upgradescroll,
+/obj/item/upgradescroll,
+/obj/item/upgradescroll,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/dorm/dormtwo{
+	name = "Archmage's Quarters"
+	})
+"nV" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/carpet/red_gold,
+/area/ship/hallway/central)
+"od" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 4
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"ol" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"oz" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"oC" = (
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"oE" = (
+/obj/machinery/suit_storage_unit,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/suit/space/hardsuit/wizard,
+/obj/item/clothing/gloves/combat/wizard,
+/obj/machinery/door/window/survival_pod{
+	req_access_txt = "1";
+	dir = 4
+	},
+/turf/open/floor/bronze,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"oL" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Cargo"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"oT" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"pd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"pe" = (
+/turf/open/floor/carpet/black,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"pi" = (
+/obj/machinery/grill,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"ps" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"px" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"pE" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Mana Channeling Chamber"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"pO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/light,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"pS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/chair/bronze{
+	dir = 1
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"pU" = (
+/obj/machinery/suit_storage_unit,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/suit/space/hardsuit/wizard,
+/obj/machinery/airalarm/directional/south,
+/obj/item/clothing/gloves/combat/wizard,
+/obj/machinery/light,
+/turf/open/floor/bronze,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"pW" = (
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"qa" = (
+/obj/machinery/door/poddoor{
+	id = "wizardship4_v1"
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"qf" = (
+/turf/open/floor/engine/plasma,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"ql" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced/spawner/west{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"qw" = (
+/obj/structure/constructshell,
+/obj/structure/constructshell,
+/obj/structure/constructshell,
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"qA" = (
+/obj/machinery/door/poddoor{
+	id = "wizardship4_top"
+	},
+/obj/structure/fans/tiny{
+	name = "vaccum barrier projector";
+	desc = "A tiny fan, projecting an invisible barrier that doesnt allow gas to pass."
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"qD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/crew/dorm/dormtwo{
+	name = "Archmage's Quarters"
+	})
+"qE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/dorm)
+"qN" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/donkpockets/donkpocketgondola,
+/obj/item/storage/box/donkpockets/donkpocketgondola,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/machinery/light,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"qQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"qT" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"rd" = (
+/obj/structure/table/reinforced,
+/obj/item/kitchen/knife/butcher,
+/obj/item/sharpener,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"rg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"rj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"rn" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/fireaxecabinet{
+	pixel_y = -28
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"rv" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"rA" = (
+/obj/machinery/computer/helm,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"rB" = (
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"rS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "wizardship4";
+	name = "Window shutters";
+	pixel_x = -26
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"rV" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4;
+	name = "mana thruster"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "wizardship4"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"sg" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/dorm/dormtwo{
+	name = "Archmage's Quarters"
+	})
+"sh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/kirbyplants/random,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"so" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"sF" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"sL" = (
+/obj/structure/window/plasma/reinforced/fulltile{
+	color = "#008000"
+	},
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "wizardship4"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"sQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/light,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"sR" = (
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/turf/open/floor/engine/plasma,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"sT" = (
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"sX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"sY" = (
+/obj/item/circuitboard/machine/rdserver,
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/red,
+/obj/item/stock_parts/scanning_module/triphasic,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"ta" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"tc" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"ti" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"tt" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"tJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/stasis{
+	name = "Mana preservation unit"
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -28;
+	desc = "Uses a high-frequency jolt of Mana to restart circulatory systems.";
+	name = "Wall-mounted mana-jolter"
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"tL" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Food Conjuration Chamber"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"tP" = (
+/obj/machinery/door/poddoor{
+	id = "wizardship4_rear"
+	},
+/obj/structure/fans/tiny{
+	name = "vaccum barrier projector";
+	desc = "A tiny fan, projecting an invisible barrier that doesnt allow gas to pass."
+	},
+/obj/docking_port/mobile{
+	dir = 4;
+	launch_status = 0;
+	port_direction = 8
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"tQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/light,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"tS" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable/cyan,
+/turf/open/floor/plating/catwalk_floor,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"tW" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/item/research_notes/loot/genius,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"tY" = (
+/obj/structure/chair/bronze{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"ua" = (
+/obj/machinery/atmospherics/miner/oxygen{
+	icon = 'icons/obj/items_and_weapons.dmi';
+	icon_state = "skub";
+	desc = "The Skub is emitting gas at an alarming rate";
+	name = "activated Skub"
+	},
+/turf/open/floor/engine/air{
+	icon_state = "wood-broken6"
+	},
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"uc" = (
+/obj/machinery/computer/helm/viewscreen{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/structure/closet/secure_closet/engineering_welding{
+	anchored = 1
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"ud" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"uk" = (
+/obj/structure/window/plasma/reinforced/fulltile{
+	color = "#008000"
+	},
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "wizardship4"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"um" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"ux" = (
+/obj/machinery/button/door{
+	id = "wizardship4_v2";
+	name = "Vault 2";
+	pixel_y = 24
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"uA" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"uB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/light,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"uD" = (
+/obj/machinery/rnd/production/protolathe{
+	name = "experimental mana condenser"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"uJ" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/catwalk_floor,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"uP" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/crate/miningcar{
+	name = "mining car"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/storage/firstaid,
+/obj/item/clothing/glasses/meson{
+	icon_state = "jamjar_glasses";
+	desc = "Used by wizards to see the terrain of an area.";
+	name = "glasses of terrain-sight"
+	},
+/obj/item/clothing/glasses/meson{
+	icon_state = "jamjar_glasses";
+	desc = "Used by wizards to see the terrain of an area.";
+	name = "glasses of terrain-sight"
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/item/gun/energy/plasmacutter/adv{
+	icon = 'icons/obj/guns/magic.dmi';
+	icon_state = "staffofstorms";
+	desc = "A staff that expels blasts of heated plasma that are magically tuned to mine rocks and ores with maximum efficiency.";
+	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi';
+	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
+	name = "Staff of Greater Mining"
+	},
+/obj/item/mining_scanner{
+	desc = "A grimoire penned by the mighty magus Antoras. Revelations of Rock is regarded as one of the most important and influential tomes to ever grace the Federation, granting it's reader the ability to divine minerals. And we mean REALLY divine. The book contains detailed information on hundreds of thousands of types of soil, minerals, gemstones, and more. A wizard wielding this tome could indeed, within seconds, precisely deduce how many individual grains of sand were on a planet. This tome alone is touted as the grandfather of the modern Wizard Federation, and certainly is responsible for your gem-encrusted hardsuits and your emerald-plated vessel. Your operations will, through the power of this stony grimoire, surely proceed smooth as slate and clear as crystal. That.. being said... It would appear that some, okay well, MOST of the pages have been ripped out of this copy. Through your wizardly intellect however, you deduce that missing pages will not lessen it's power. After all, tomes don't ACTUALLY utilize those pages, right?";
+	icon = 'icons/obj/library.dmi';
+	icon_state = "book";
+	name = "The Grimoire of Rock Revelation"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"uR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"uW" = (
+/obj/machinery/shower{
+	pixel_y = 12;
+	layer = 4.2
+	},
+/obj/structure/curtain,
+/obj/machinery/door/window/survival_pod{
+	dir = 4
+	},
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"uY" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"uZ" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"va" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced/spawner/west{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"vv" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"vx" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/carpet/red_gold,
+/area/ship/hallway/central)
+"vE" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"vJ" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"vL" = (
+/obj/machinery/sleeper{
+	icon_state = "sleeper_clockwork-open";
+	dir = 4;
+	name = "mana injector"
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"vN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"vS" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"we" = (
+/obj/structure/window/plasma/reinforced/fulltile{
+	color = "#008000"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"wg" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"wj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/dogbed/cayenne{
+	name = "Bunglesworth's bed"
+	},
+/mob/living/simple_animal/hostile/carp/ranged/chaos{
+	faction = list("neutral");
+	desc = "50% carp, 100% magic, 150% horrible, 200% a wizard's best friend.";
+	name = "Bunglesworth"
+	},
+/turf/open/floor/wood,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"wt" = (
+/obj/machinery/processor,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"wu" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"wv" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"wx" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"wy" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/crew/dorm/dormtwo{
+	name = "Archmage's Quarters"
+	})
+"wI" = (
+/obj/structure/chair/bronze{
+	dir = 2
+	},
+/turf/open/floor/carpet/purple,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"wL" = (
+/obj/structure/sign/poster/official/help_others{
+	pixel_x = -32
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"wN" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"wO" = (
+/obj/machinery/shower{
+	pixel_y = 12;
+	layer = 4.2
+	},
+/obj/structure/curtain,
+/obj/machinery/door/window/survival_pod{
+	dir = 4
+	},
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"wQ" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"xc" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"xf" = (
+/obj/structure/table/wood/fancy/green,
+/obj/item/book/granter/spell/charge{
+	pixel_x = -5
+	},
+/obj/item/book/granter/spell/charge{
+	pixel_x = 5
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"xt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"xv" = (
+/obj/effect/mob_spawn/human/corpse/wizard{
+	name = "Pingus"
+	},
+/turf/open/floor/engine/plasma,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"xy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"xA" = (
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"xB" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"xI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/light,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"xJ" = (
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/turf/open/floor/carpet/black,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"xZ" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"ya" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/red_gold,
+/area/ship/hallway/central)
+"yf" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"yl" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4;
+	name = "phlogiston heater"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"yp" = (
+/obj/machinery/atmospherics/components/binary/pump,
+/turf/open/floor/plating,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"yq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
+"yr" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"yw" = (
+/obj/structure/window/plasma/reinforced/fulltile{
+	color = "#008000"
+	},
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "wizardship4"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"yA" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"yG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"yH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"yL" = (
+/obj/machinery/rnd/destructive_analyzer,
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"yP" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"yZ" = (
+/obj/structure/closet/crate/miningcar{
+	name = "mining car"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/storage/firstaid,
+/obj/item/clothing/glasses/meson{
+	icon_state = "jamjar_glasses";
+	desc = "Used by wizards to see the terrain of an area.";
+	name = "glasses of terrain-sight"
+	},
+/obj/item/clothing/glasses/meson{
+	icon_state = "jamjar_glasses";
+	desc = "Used by wizards to see the terrain of an area.";
+	name = "glasses of terrain-sight"
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/item/gun/energy/plasmacutter/adv{
+	icon = 'icons/obj/guns/magic.dmi';
+	icon_state = "staffofstorms";
+	desc = "A staff that expels blasts of heated plasma that are magically tuned to mine rocks and ores with maximum efficiency.";
+	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi';
+	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
+	name = "Staff of Greater Mining"
+	},
+/obj/item/mining_scanner{
+	desc = "A grimoire penned by the mighty magus Antoras. Revelations of Rock is regarded as one of the most important and influential tomes to ever grace the Federation, granting it's reader the ability to divine minerals. And we mean REALLY divine. The book contains detailed information on hundreds of thousands of types of soil, minerals, gemstones, and more. A wizard wielding this tome could indeed, within seconds, precisely deduce how many individual grains of sand were on a planet. This tome alone is touted as the grandfather of the modern Wizard Federation, and certainly is responsible for your gem-encrusted hardsuits and your emerald-plated vessel. Your operations will, through the power of this stony grimoire, surely proceed smooth as slate and clear as crystal. That.. being said... It would appear that some, okay well, MOST of the pages have been ripped out of this copy. Through your wizardly intellect however, you deduce that missing pages will not lessen it's power. After all, tomes don't ACTUALLY utilize those pages, right?";
+	icon = 'icons/obj/library.dmi';
+	icon_state = "book";
+	name = "The Grimoire of Rock Revelation"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"zc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"zh" = (
+/turf/open/floor/carpet/purple,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"zj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/light,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"zp" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/crew/dorm/dormtwo{
+	name = "Archmage's Quarters"
+	})
+"zr" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4;
+	name = "mana precharger"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"zw" = (
+/obj/machinery/atmospherics/miner/nitrogen{
+	icon = 'icons/obj/items_and_weapons.dmi';
+	icon_state = "skub";
+	desc = "The Skub is emitting gas at an alarming rate";
+	name = "activated Skub"
+	},
+/turf/open/floor/engine/air{
+	icon_state = "wood-broken4"
+	},
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"zy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"zz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
+"zD" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced/spawner/west{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"zE" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"zF" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"zI" = (
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"zR" = (
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"Ab" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4;
+	name = "mana thruster"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "wizardship4"
+	},
+/turf/open/floor/plating,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"Ae" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"Al" = (
+/obj/machinery/sleeper{
+	icon_state = "sleeper_clockwork-open";
+	dir = 8;
+	name = "mana injector"
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"Ao" = (
+/obj/structure/window/plasma/reinforced/spawner/west{
+	color = "#008000"
+	},
+/turf/open/floor/carpet/black,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"As" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/dorm)
+"Av" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"AB" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"AF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"AJ" = (
+/obj/structure/window/plasma/reinforced/fulltile{
+	color = "#008000"
+	},
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "wizardship4"
+	},
+/turf/open/floor/plating,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"AU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/red_gold,
+/area/ship/hallway/central)
+"AV" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"AY" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4{
+	dir = 1;
+	pixel_x = -1
+	},
+/turf/open/floor/engine/air{
+	icon_state = "wood-broken7"
+	},
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Bc" = (
+/obj/machinery/computer/helm/viewscreen{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"Be" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"Bh" = (
+/obj/machinery/button/door{
+	id = "wizardship4_top";
+	name = "Blast Doors";
+	pixel_y = 24
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"Bq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/dormtwo{
+	name = "Archmage's Quarters"
+	})
+"Bz" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"BK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Mana Channeling Chamber"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"BV" = (
+/obj/item/book/granter/spell/charge,
+/obj/structure/table/wood/fancy/green,
+/obj/item/gun/energy/shrink_ray{
+	icon = 'icons/obj/device.dmi';
+	icon_state = "scanner_wand";
+	name = "Wand of Shrinking";
+	desc = "This is a frightening magical artefact that enhances the magnetic pull of atoms in a localized space to temporarily make an object shrink. That or it's alien technology. Either way, it shrinks stuff.";
+	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi';
+	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/crew/dorm/dormtwo{
+	name = "Archmage's Quarters"
+	})
+"BW" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"BZ" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Cj" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"Cl" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"Cr" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"Cs" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Cu" = (
+/obj/structure/table/wood/fancy/green,
+/obj/item/book/granter/spell/summonitem{
+	pixel_x = 5
+	},
+/obj/item/book/granter/spell/summonitem{
+	pixel_x = -5
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"Cx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/wood/fancy/royalblue,
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"Cy" = (
+/obj/structure/table/wood/fancy/green,
+/obj/item/gun/energy/xray{
+	fire_sound = 'sound/magic/staff_change.ogg';
+	icon = 'icons/obj/guns/magic.dmi';
+	icon_state = "staffofsapping";
+	item_state = "staffofsapping";
+	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
+	lefthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
+	desc = "A powerful offensive staff that can fire blasts of eldrich energy that pass through walls.";
+	name = "Gamma Staff";
+	pixel_x = 5
+	},
+/obj/item/gun/energy/xray{
+	fire_sound = 'sound/magic/staff_change.ogg';
+	icon = 'icons/obj/guns/magic.dmi';
+	icon_state = "staffofsapping";
+	item_state = "staffofsapping";
+	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
+	lefthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
+	desc = "A powerful offensive staff that can fire blasts of eldrich energy that pass through walls.";
+	name = "Gamma Staff"
+	},
+/obj/item/gun/energy/xray{
+	fire_sound = 'sound/magic/staff_change.ogg';
+	icon = 'icons/obj/guns/magic.dmi';
+	icon_state = "staffofsapping";
+	item_state = "staffofsapping";
+	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
+	lefthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
+	desc = "A powerful offensive staff that can fire blasts of eldrich energy that pass through walls.";
+	name = "Gamma Staff";
+	pixel_x = -5
+	},
+/obj/item/gun/energy/xray{
+	fire_sound = 'sound/magic/staff_change.ogg';
+	icon = 'icons/obj/guns/magic.dmi';
+	icon_state = "staffofsapping";
+	item_state = "staffofsapping";
+	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
+	lefthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
+	desc = "A powerful offensive staff that can fire blasts of eldrich energy that pass through walls.";
+	name = "Gamma Staff";
+	pixel_x = -10
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"CA" = (
+/obj/structure/altar_of_gods,
+/obj/item/gun/energy/pulse/carbine{
+	icon = 'icons/obj/guns/magic.dmi';
+	icon_state = "staffofanimation";
+	pin = /obj/item/firing_pin/magic;
+	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi';
+	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
+	desc = "An extremely powerful wand, created using the soul of the powerful wizard, Rodney XII";
+	name = "Rodney's Gift"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/black,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"CF" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/storage/box/beakers,
+/obj/item/gun/magic/wand/resurrection,
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"CL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/xenoblood/xgibs/core,
+/turf/open/floor/carpet/purple,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"CM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"CP" = (
+/obj/structure/table/wood/fancy/green,
+/obj/item/book/granter/spell/fireball{
+	pixel_x = 5
+	},
+/obj/item/book/granter/spell/fireball{
+	pixel_x = -5
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"CT" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light,
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"CU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"CV" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/machinery/light,
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"CX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"CY" = (
+/obj/structure/table/wood/fancy/green,
+/obj/item/book/granter/spell/forcewall{
+	pixel_x = -5
+	},
+/obj/item/book/granter/spell/forcewall{
+	pixel_x = 5
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"De" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/dormtwo{
+	name = "Archmage's Quarters"
+	})
+"Dg" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"Di" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"Dk" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Ds" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/window/plasma/reinforced/spawner/west{
+	color = "#008000"
+	},
+/obj/structure/window/plasma/reinforced/spawner{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"Dw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Dx" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"DD" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"DG" = (
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/turf/open/floor/engine,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"DK" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"DU" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/soulstone/anybody{
+	pixel_x = 5
+	},
+/obj/item/soulstone/anybody{
+	pixel_y = 3
+	},
+/obj/item/soulstone/anybody{
+	pixel_x = -5
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"Eg" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced/spawner/west{
+	color = "#008000"
+	},
+/obj/structure/window/plasma/reinforced/spawner/north{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"Ei" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Mana Channeling Chamber"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"Ej" = (
+/obj/structure/window/plasma/reinforced/spawner{
+	color = "#008000"
+	},
+/turf/open/floor/engine,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"Eo" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"EB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/bookcase/random,
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"ED" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"EG" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"EI" = (
+/obj/machinery/selling_pad,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"ER" = (
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"EU" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"EV" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/head/wizard/yellow,
+/obj/item/clothing/head/wizard/red,
+/obj/item/clothing/head/wizard/marisa,
+/obj/item/clothing/head/wizard/black,
+/obj/item/clothing/head/wizard,
+/obj/item/clothing/suit/wizrobe/yellow,
+/obj/item/clothing/suit/wizrobe/red,
+/obj/item/clothing/suit/wizrobe/marisa,
+/obj/item/clothing/suit/wizrobe/black,
+/obj/item/clothing/suit/wizrobe,
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"EY" = (
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"Fd" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/dorm/dormtwo{
+	name = "Archmage's Quarters"
+	})
+"Fg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"Fl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Enchantment Storage";
+	req_access_txt = "1"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"Fr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/red_gold,
+/area/ship/hallway/central)
+"Fs" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"Fu" = (
+/obj/machinery/door/poddoor{
+	id = "wizardship4_rear"
+	},
+/obj/structure/fans/tiny{
+	name = "vaccum barrier projector";
+	desc = "A tiny fan, projecting an invisible barrier that doesnt allow gas to pass."
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"FD" = (
+/obj/machinery/light/floor,
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/turf/open/floor/engine/plasma,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"FF" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"FG" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"FH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/red_gold,
+/area/ship/hallway/central)
+"FI" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"FJ" = (
+/obj/machinery/mineral/ore_redemption{
+	req_access = null
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"FO" = (
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"FZ" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 4
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"Ge" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"Gv" = (
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"Gx" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"GC" = (
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"GF" = (
+/obj/machinery/suit_storage_unit,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/suit/space/hardsuit/wizard,
+/obj/item/clothing/gloves/combat/wizard,
+/turf/open/floor/bronze,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"GH" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/table/wood,
+/obj/item/instrument/recorder{
+	desc = "Just like in school, playing ability and all. This one is magical, although you are unsure of what the enchantment is.";
+	name = "magic recorder"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"GK" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/head/wizard/yellow,
+/obj/item/clothing/head/wizard/red,
+/obj/item/clothing/head/wizard/marisa,
+/obj/item/clothing/head/wizard/black,
+/obj/item/clothing/head/wizard,
+/obj/item/clothing/suit/wizrobe/yellow,
+/obj/item/clothing/suit/wizrobe/red,
+/obj/item/clothing/suit/wizrobe/marisa,
+/obj/item/clothing/suit/wizrobe/black,
+/obj/item/clothing/suit/wizrobe,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"GN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"GU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"GV" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"Hl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/xenoblood,
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"Hn" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/carpet/red_gold,
+/area/ship/hallway/central)
+"Ho" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
+"Hr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/light,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"HA" = (
+/obj/machinery/computer/rdconsole{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"HM" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/crew/dorm/dormtwo{
+	name = "Archmage's Quarters"
+	})
+"HN" = (
+/obj/structure/window/plasma/reinforced/spawner/north{
+	color = "#008000"
+	},
+/turf/open/floor/engine,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"Ia" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"If" = (
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"Ii" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"Ir" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
+"Is" = (
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/computer/helm/viewscreen{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/item/stack/sheet/mineral/diamond/twenty,
+/obj/item/stack/sheet/mineral/gold/fifty,
+/obj/item/stack/sheet/mineral/silver/fifty,
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"Iz" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"IO" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"IQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/stasis{
+	name = "Mana preservation unit"
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"IR" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/carpet/red_gold,
+/area/ship/hallway/central)
+"Ja" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Jb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"Jc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/meter/atmos/layer4,
+/obj/structure/window/plasma/reinforced/spawner/north{
+	color = "#008000"
+	},
+/turf/open/floor/engine/air{
+	icon_state = "wood-broken6"
+	},
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Jf" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/light,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"Jj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"Jm" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/crew/dorm/dormtwo{
+	name = "Archmage's Quarters"
+	})
+"Jo" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "ArchMage's Quarters";
+	req_access_txt = "20"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"Jr" = (
+/obj/structure/table/wood/fancy/red_gold,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/red_gold,
+/area/ship/hallway/central)
+"JE" = (
+/obj/structure/table/wood/fancy/red_gold,
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"JO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"JV" = (
+/obj/machinery/computer/monitor{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"JY" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/suit/space/hardsuit/wizard,
+/obj/item/clothing/gloves/combat/wizard,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/dorm/dormtwo{
+	name = "Archmage's Quarters"
+	})
+"Kc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"Kh" = (
+/obj/structure/window/plasma/reinforced/fulltile{
+	color = "#008000"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Ki" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"Kj" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"Kk" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 5
+	},
+/obj/item/multitool/old{
+	name = "magictool";
+	desc = "Used for pulsing wires, with magic"
+	},
+/obj/item/multitool/old{
+	name = "magictool";
+	desc = "Used for pulsing wires, with magic"
+	},
+/obj/item/multitool/old{
+	name = "magictool";
+	desc = "Used for pulsing wires, with magic"
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Kp" = (
+/obj/structure/bed,
+/obj/item/bedsheet/wiz,
+/obj/structure/curtain/cloth/fancy{
+	layer = 3.9
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"Kr" = (
+/obj/structure/table/wood/fancy/royalblue,
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"Kw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"Kx" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"KD" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"KG" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 6
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/carpet/green,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"KH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"KJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"KM" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"KS" = (
+/obj/machinery/light,
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"KU" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"KV" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/hallway/central)
+"KW" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"Lc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"Le" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Archives"
+	},
+/turf/open/floor/light,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"Lh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/dorm)
+"Li" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"Lx" = (
+/obj/structure/cursed_slot_machine,
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/dorm)
+"LB" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/carpet/red_gold,
+/area/ship/hallway/central)
+"LM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"LQ" = (
+/obj/machinery/modular_computer/console/preset/command,
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"Mc" = (
+/obj/structure/window/plasma/reinforced/fulltile{
+	color = "#008000"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Mm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
+"Mq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
+"My" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"MC" = (
+/obj/machinery/computer/crew,
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"ME" = (
+/obj/machinery/airalarm/directional/west,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"MG" = (
+/turf/template_noop,
+/area/template_noop)
+"MK" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Mana requillary";
+	req_access_txt = "16"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"MM" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable/cyan,
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"MO" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"Nf" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Nn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Nu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"Ny" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"NC" = (
+/obj/machinery/computer/communications,
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"NM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"NQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"NV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/purple,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"NZ" = (
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/obj/machinery/computer/cryopod{
+	dir = 1;
+	pixel_y = 25
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"Oa" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
+"Og" = (
+/obj/machinery/door/poddoor{
+	id = "wizardship4_v2"
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"Om" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"Ou" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"Ov" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"OG" = (
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"ON" = (
+/obj/machinery/computer/secure_data{
+	dir = 1
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"OQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"OX" = (
+/obj/structure/window/plasma/reinforced/spawner/north{
+	color = "#008000"
+	},
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/turf/open/floor/carpet/black,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"Pi" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/fire,
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"Pj" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Ps" = (
+/obj/structure/table/wood/fancy/green,
+/obj/item/gun/energy/laser/captain/scattershot{
+	icon = 'icons/obj/guns/magic.dmi';
+	icon_state = "nothingwand";
+	pixel_x = -5;
+	desc = "A wand used by Wizards who specialize in offensive magic";
+	name = "wand of many orbs";
+	item_state = "wand";
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi';
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi';
+	fire_sound = 'sound/magic/wand_teleport.ogg'
+	},
+/obj/item/gun/energy/laser/captain/scattershot{
+	icon = 'icons/obj/guns/magic.dmi';
+	icon_state = "nothingwand";
+	desc = "A wand used by Wizards who specialize in offensive magic";
+	name = "wand of many orbs";
+	item_state = "wand";
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi';
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi';
+	fire_sound = 'sound/magic/wand_teleport.ogg'
+	},
+/obj/item/gun/energy/laser/captain/scattershot{
+	icon = 'icons/obj/guns/magic.dmi';
+	icon_state = "nothingwand";
+	pixel_x = 10;
+	desc = "A wand used by Wizards who specialize in offensive magic";
+	name = "wand of many orbs";
+	item_state = "wand";
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi';
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi';
+	fire_sound = 'sound/magic/wand_teleport.ogg'
+	},
+/obj/item/gun/energy/laser/captain/scattershot{
+	icon = 'icons/obj/guns/magic.dmi';
+	icon_state = "nothingwand";
+	pixel_x = 5;
+	desc = "A wand used by Wizards who specialize in offensive magic";
+	name = "wand of many orbs";
+	item_state = "wand";
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi';
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi';
+	fire_sound = 'sound/magic/wand_teleport.ogg'
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"Px" = (
+/obj/structure/cable/cyan,
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/machinery/power/apc/auto_name/south,
+/turf/open/floor/carpet/green,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"PI" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"PL" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"PM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"PR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Qc" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 10
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Qf" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced/spawner/west{
+	color = "#008000"
+	},
+/obj/structure/window/plasma/reinforced/spawner{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"Qn" = (
+/obj/structure/chair/bronze{
+	dir = 1
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"Qr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"Qt" = (
+/turf/open/floor/carpet/orange,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"QH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"QP" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
+"QT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"QU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"QW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"Rl" = (
+/obj/structure/table/reinforced,
+/obj/item/kitchen/rollingpin,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"RI" = (
+/obj/machinery/button/door{
+	id = "wizardship4_v1";
+	name = "Vault 1";
+	pixel_y = 24
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"RK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/orange,
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"RN" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"RQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Wound Nullification Chamber"
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"RS" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner/west{
+	color = "#008000"
+	},
+/obj/structure/window/plasma/reinforced/spawner{
+	color = "#008000"
+	},
+/turf/open/floor/engine,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"Sf" = (
+/obj/machinery/chem_heater{
+	name = "box of warming";
+	desc = "A box that can warm chemicals"
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"Sk" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Sq" = (
+/obj/machinery/light,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"Sx" = (
+/obj/structure/closet/secure_closet/freezer/cream_pie,
+/obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/item/reagent_containers/food/snacks/pie/cream,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"Sz" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/industrial/outline/yellow,
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"SD" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"SH" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"SQ" = (
+/obj/structure/window/plasma/reinforced/fulltile{
+	color = "#008000"
+	},
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "wizardship4"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/dorm)
+"ST" = (
+/obj/structure/window/plasma/reinforced/fulltile{
+	color = "#008000"
+	},
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "wizardship4"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"SX" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"Tg" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 10
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"Ti" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Tj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"Tk" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"Tl" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Ts" = (
+/obj/machinery/vending/autodrobe/all_access,
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"Tv" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 22
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"Tx" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/item/pipe_dispenser{
+	name = "Rapid Pipe Conjurer (RPC)";
+	desc = "A device used to rapidly pipe things, using magic";
+	pixel_y = 5
+	},
+/obj/item/pipe_dispenser{
+	name = "Rapid Pipe Conjurer (RPC)";
+	desc = "A device used to rapidly pipe things, using magic"
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"TB" = (
+/obj/machinery/airalarm/directional/south,
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 4
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"TE" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"TK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"TM" = (
+/obj/structure/window/plasma/reinforced/spawner/north{
+	color = "#008000"
+	},
+/turf/open/floor/carpet/black,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"TU" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 5
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"TW" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/obj/structure/window/plasma/reinforced/spawner/north{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"TY" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"Ua" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/machinery/computer/cargo/express{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"Ub" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/west,
+/turf/open/floor/plasteel/grimy,
+/area/ship/maintenance/fore{
+	name = "Skub closet"
+	})
+"Uc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"Uf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"Uh" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"Uo" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/security/armory{
+	name = "Enchantment Storage"
+	})
+"Up" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"Ut" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced/spawner/west{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"Uy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"UB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Waiting Room"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/fore{
+	name = "Waiting Room"
+	})
+"UN" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/dorm/dormtwo{
+	name = "Archmage's Quarters"
+	})
+"UV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/maintenance/fore{
+	name = "Skub closet"
+	})
+"UY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/ian{
+	pixel_y = 32
+	},
+/turf/open/floor/light,
+/area/ship/medical{
+	name = "Wound Nullification Chamber"
+	})
+"Va" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/red_gold,
+/area/ship/hallway/central)
+"Vh" = (
+/obj/structure/altar_of_gods,
+/obj/item/mjollnir,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/black,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"VA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"VE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/dorm/dormtwo{
+	name = "Archmage's Quarters"
+	})
+"VW" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Artificer's Chambers"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"VZ" = (
+/obj/machinery/power/rtg/advanced{
+	name = "mana field condenser"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/obj/structure/window/plasma/reinforced/spawner/north{
+	color = "#008000"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"We" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/layer2{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/plating,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"Wk" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"Wp" = (
+/obj/structure/chair/bronze{
+	dir = 1
+	},
+/turf/open/floor/carpet/purple,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"Ws" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"WF" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"WG" = (
+/turf/open/floor/carpet/red_gold,
+/area/ship/hallway/central)
+"WI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"WJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"WQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge{
+	name = "Conducting Chamber"
+	})
+"WV" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"WY" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"Xf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
+"Xr" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"Xt" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"XH" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"XM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"XS" = (
+/obj/machinery/computer/selling_pad_control{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"Yj" = (
+/obj/structure/janitorialcart{
+	dir = 4
+	},
+/obj/item/storage/bag/trash,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/grimy,
+/area/ship/maintenance/fore{
+	name = "Skub closet"
+	})
+"Ym" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4;
+	name = "phlogiston expeller"
+	},
+/obj/structure/window/plasma/reinforced/spawner/east{
+	color = "#008000"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "wizardship4"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo{
+	name = "Merchant's Chambers"
+	})
+"Yo" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/science{
+	name = "Artificer's Chambers"
+	})
+"YD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"YG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central{
+	name = "Mana Channeling Chamber"
+	})
+"YH" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"YO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"YR" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/engine/plasma,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Ze" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	anchored = 1
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft{
+	name = "Artisan's Chambers"
+	})
+"Zi" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/library{
+	name = "Archives"
+	})
+"Zm" = (
+/obj/structure/window/plasma/reinforced/fulltile{
+	color = "#008000"
+	},
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "wizardship4"
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/port{
+	name = "Mana Requillary"
+	})
+"Zy" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"ZE" = (
+/obj/structure/table/wood/fancy/red_gold,
+/turf/open/floor/carpet/red_gold,
+/area/ship/hallway/central)
+"ZN" = (
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/storage{
+	name = "Artifact Vault"
+	})
+"ZO" = (
+/turf/open/floor/plasteel/grimy,
+/area/ship/maintenance/fore{
+	name = "Skub closet"
+	})
+"ZR" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/crew/dorm)
+"ZS" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/starboard{
+	name = "Mana Requillary"
+	})
+"ZU" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/crew/canteen/kitchen{
+	name = "Food Conjuration Chamber"
+	})
+"ZW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/stellar,
+/area/ship/crew/dorm)
+
+(1,1,1) = {"
+Wk
+fc
+rV
+rV
+Ym
+Ym
+Ym
+Wk
+Wk
+fc
+fc
+fc
+cA
+cA
+Fu
+tP
+Fu
+cA
+cA
+cA
+cA
+cA
+cA
+cA
+cA
+cA
+cA
+cA
+AJ
+AJ
+AJ
+Xr
+Xr
+iV
+iV
+iV
+Ab
+Ab
+AJ
+Xr
+"}
+(2,1,1) = {"
+Wk
+uW
+zr
+zr
+yl
+yl
+yl
+Wk
+az
+KG
+ar
+ar
+oL
+hf
+YH
+Dk
+TU
+cA
+im
+gu
+YR
+im
+cA
+nC
+Cs
+PL
+hG
+VW
+EU
+EU
+cF
+Px
+Xr
+fC
+fC
+fC
+aD
+aD
+wO
+Xr
+"}
+(3,1,1) = {"
+fc
+rB
+ic
+ic
+Tg
+FZ
+FZ
+Li
+Gx
+GV
+tt
+cA
+cA
+il
+fX
+ER
+Nf
+cA
+FD
+sR
+dw
+FD
+cA
+Nf
+ER
+rj
+rn
+cA
+cA
+ti
+lx
+SH
+WV
+dm
+dm
+Kx
+Cj
+Cj
+If
+AJ
+"}
+(4,1,1) = {"
+fc
+Ua
+fz
+lk
+RS
+Ge
+Ge
+oT
+KW
+VA
+cA
+cA
+Sz
+Sk
+Pj
+fy
+Nf
+cA
+cA
+Kh
+we
+cA
+cA
+Nf
+fg
+FI
+vS
+aW
+cA
+Xr
+hS
+dh
+ni
+uY
+uY
+uY
+nz
+FG
+Yo
+AJ
+"}
+(5,1,1) = {"
+Wk
+Wk
+HN
+jy
+Ej
+Ej
+rB
+bI
+fj
+cA
+cA
+xc
+OG
+Sk
+fX
+ER
+Qc
+My
+Dk
+yP
+od
+yp
+Dk
+BZ
+ER
+rj
+cU
+cA
+cA
+cA
+cA
+Lc
+pd
+Ia
+Ia
+Ia
+Ia
+WF
+Xr
+Xr
+"}
+(6,1,1) = {"
+MG
+Wk
+hc
+DG
+DG
+cI
+XS
+EI
+cA
+cA
+Sz
+FJ
+OG
+Sk
+fX
+ER
+ER
+ER
+ER
+ER
+ER
+ER
+ER
+ER
+ER
+rj
+vS
+Kh
+eV
+ua
+cA
+cA
+HA
+fK
+uD
+dV
+yL
+Hl
+hZ
+We
+"}
+(7,1,1) = {"
+MG
+Eo
+Eo
+Eo
+Eo
+Eo
+Eo
+Eo
+Eo
+uP
+OG
+PR
+OG
+vv
+Ja
+bB
+CX
+CX
+CX
+CX
+CX
+CX
+Dw
+Dw
+bB
+yf
+Tl
+Mc
+Jc
+AY
+iK
+cA
+AV
+AV
+AV
+AV
+AV
+AV
+AV
+MG
+"}
+(8,1,1) = {"
+MG
+Eo
+Eo
+wx
+wN
+wN
+wN
+wN
+Eo
+yZ
+aZ
+FF
+Ti
+Bz
+Nn
+yA
+hQ
+Kk
+Tx
+uc
+Ze
+bf
+jb
+hP
+yA
+GU
+SD
+Kh
+jg
+zw
+iR
+AV
+gv
+gv
+gv
+gv
+kc
+AV
+AV
+MG
+"}
+(9,1,1) = {"
+MG
+MG
+Eo
+zE
+SX
+SX
+SX
+MM
+Eo
+Eo
+Eo
+Eo
+Eo
+Ei
+dC
+dC
+dC
+dC
+dC
+bC
+bC
+dC
+dC
+dC
+dC
+dC
+pE
+AV
+AV
+AV
+AV
+AV
+RN
+sF
+sF
+sF
+Fs
+AV
+MG
+MG
+"}
+(10,1,1) = {"
+MG
+MG
+Eo
+zD
+Ut
+Ut
+Qf
+vE
+VZ
+wN
+wN
+CV
+Eo
+CM
+nN
+nN
+nN
+nN
+tS
+dU
+dU
+uJ
+ME
+nN
+nN
+nN
+jr
+AV
+BW
+gv
+gv
+eb
+WY
+Eg
+ql
+ql
+jE
+AV
+MG
+MG
+"}
+(11,1,1) = {"
+MG
+MG
+Eo
+Eo
+wx
+wN
+gc
+xB
+wg
+wg
+wg
+wg
+MK
+ED
+YG
+Uh
+YG
+YG
+YG
+ka
+nj
+kJ
+kJ
+kJ
+ir
+Uy
+Dg
+fR
+gJ
+gJ
+gJ
+gJ
+aH
+TW
+gv
+kc
+AV
+AV
+MG
+MG
+"}
+(12,1,1) = {"
+MG
+MG
+MG
+Zm
+tc
+SX
+SX
+AB
+aT
+Ut
+Ut
+nL
+Eo
+vN
+fi
+XM
+fi
+fi
+fi
+Uc
+zc
+fi
+fi
+fi
+XM
+fi
+CT
+AV
+va
+ql
+ql
+Ds
+an
+sF
+sF
+ZS
+hA
+MG
+MG
+MG
+"}
+(13,1,1) = {"
+MG
+MG
+MG
+Eo
+zD
+Ut
+Ut
+Ut
+zF
+Eo
+Eo
+Eo
+Eo
+vJ
+vJ
+vJ
+vJ
+vJ
+vJ
+BK
+vJ
+vJ
+vJ
+vJ
+vJ
+vJ
+vJ
+AV
+AV
+AV
+AV
+iP
+ql
+ql
+ql
+jE
+AV
+MG
+MG
+MG
+"}
+(14,1,1) = {"
+MG
+MG
+MG
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+lh
+lJ
+lJ
+nD
+mw
+Xf
+Up
+Nu
+Nu
+cS
+OQ
+pW
+pW
+pW
+pW
+pW
+pW
+pW
+pW
+cg
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+MG
+MG
+MG
+"}
+(15,1,1) = {"
+MG
+MG
+MG
+MG
+nD
+aV
+Yj
+ZO
+ZO
+Ub
+UV
+UV
+UV
+jk
+er
+Oa
+Ny
+zz
+Jj
+QP
+uR
+Mm
+rg
+Mm
+rg
+lD
+rg
+Mm
+Kc
+Mm
+RQ
+zj
+Jf
+KJ
+GC
+TE
+MG
+MG
+MG
+MG
+"}
+(16,1,1) = {"
+MG
+MG
+MG
+MG
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
+pW
+Di
+pW
+pW
+pW
+um
+pW
+pW
+pW
+pW
+pW
+WI
+pW
+iF
+Ae
+pW
+TE
+EY
+hd
+qT
+tJ
+TE
+MG
+MG
+MG
+MG
+"}
+(17,1,1) = {"
+MG
+MG
+MG
+MG
+ZU
+ZU
+ud
+ny
+Iz
+ib
+iJ
+iJ
+Zy
+ZU
+pW
+Ir
+pW
+xZ
+xZ
+xZ
+xZ
+xZ
+xZ
+xZ
+xZ
+xZ
+xZ
+TE
+TE
+TE
+lM
+EY
+Hr
+Cx
+TE
+TE
+MG
+MG
+MG
+MG
+"}
+(18,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+ZU
+nK
+ny
+zR
+mi
+ny
+ny
+qN
+ZU
+pW
+Di
+pW
+xZ
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+xZ
+TE
+nI
+wL
+bq
+EY
+pO
+eR
+nM
+MG
+MG
+MG
+MG
+MG
+"}
+(19,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+ZU
+Sx
+ny
+zR
+mi
+KD
+ny
+Rl
+ZU
+pW
+Ho
+bJ
+xZ
+qf
+xZ
+xZ
+xZ
+xZ
+xZ
+xZ
+xZ
+xZ
+TE
+Pi
+EY
+bx
+EY
+sQ
+Kr
+nM
+MG
+MG
+MG
+MG
+MG
+"}
+(20,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+ZU
+ZU
+Tv
+ny
+mi
+KD
+ny
+rd
+ZU
+pW
+Di
+pW
+xZ
+qf
+xZ
+jI
+Ao
+Ao
+qa
+ol
+ZN
+xZ
+TE
+iG
+EY
+Sf
+EY
+ey
+TE
+TE
+MG
+MG
+MG
+MG
+MG
+"}
+(21,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+ZU
+ky
+ny
+mi
+pi
+ny
+Rl
+ZU
+pW
+Ir
+pW
+xZ
+qf
+xZ
+TM
+Vh
+pe
+qa
+fL
+Kw
+xZ
+TE
+Cr
+EY
+CF
+EY
+ji
+nM
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(22,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+ZU
+ky
+ny
+mi
+KD
+ny
+rd
+ZU
+pW
+Di
+pW
+xZ
+qf
+xZ
+OX
+xJ
+xJ
+qa
+QT
+WJ
+xZ
+TE
+ag
+aL
+aL
+aL
+uB
+nM
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(23,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+ZU
+ZU
+Tv
+mi
+pi
+ny
+wt
+ZU
+pW
+Ir
+pW
+xZ
+qf
+xZ
+xZ
+xZ
+xZ
+xZ
+RI
+kU
+xZ
+TE
+UY
+bW
+bW
+bW
+TE
+TE
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(24,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+ZU
+Av
+mi
+ny
+CU
+nx
+ZU
+pW
+Di
+pW
+xZ
+qf
+qf
+qf
+qf
+qf
+xZ
+wu
+ia
+xZ
+TE
+tQ
+bW
+bW
+mL
+TE
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(25,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+ZU
+KD
+mi
+zy
+QU
+ny
+ZU
+QW
+Mq
+pW
+xZ
+qf
+xZ
+xZ
+xZ
+xZ
+xZ
+ux
+Ii
+xZ
+TE
+xI
+IQ
+bW
+bW
+TE
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(26,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+ZU
+ZU
+tL
+ZU
+mZ
+KD
+ZU
+pW
+Di
+pW
+xZ
+qf
+xZ
+jI
+Ao
+Ao
+Og
+fL
+Ii
+xZ
+TE
+sQ
+vL
+vL
+TE
+TE
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(27,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+sL
+Va
+WG
+FH
+gC
+WG
+gC
+Ir
+pW
+xZ
+qf
+xZ
+TM
+CA
+pe
+Og
+fL
+ek
+xZ
+TE
+gN
+GN
+EY
+TE
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(28,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+sL
+nV
+Hn
+AU
+cl
+ya
+cl
+ch
+pW
+xZ
+xv
+xZ
+OX
+xJ
+xJ
+Og
+fL
+Ii
+xZ
+TE
+sQ
+Al
+Al
+TE
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(29,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+KV
+KV
+Jr
+FH
+IR
+WG
+IR
+Ir
+KS
+xZ
+qf
+xZ
+xZ
+xZ
+xZ
+xZ
+xZ
+ms
+xZ
+DD
+Le
+DD
+DD
+DD
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(30,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+sL
+IR
+FH
+gC
+WG
+gC
+Di
+pW
+xZ
+qf
+qf
+qf
+qf
+qf
+xZ
+DD
+rv
+Ou
+Ou
+EG
+DK
+yw
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(31,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+sL
+LB
+FH
+ZE
+WG
+ZE
+Ir
+pW
+Uo
+Uo
+Uo
+Uo
+Uo
+DD
+DD
+DD
+YO
+DK
+DK
+YD
+DK
+yw
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(32,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+KV
+KV
+FH
+IR
+WG
+IR
+Cl
+NM
+Uo
+GF
+GF
+GF
+pU
+DD
+sY
+zI
+so
+bv
+bv
+he
+DD
+DD
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(33,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+sL
+vx
+Fr
+Fr
+Fr
+yq
+pW
+Uo
+oE
+oE
+oE
+oE
+DD
+DK
+gb
+dg
+sX
+zI
+fv
+yw
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(34,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+sL
+yH
+Bc
+pW
+Dx
+JO
+cg
+Uo
+uA
+px
+ta
+PM
+Fl
+Qr
+QH
+ep
+Zi
+Be
+yr
+yw
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(35,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+uZ
+uZ
+uZ
+uZ
+uZ
+UB
+Uo
+Uo
+mW
+KH
+jZ
+oC
+DD
+nO
+Fg
+AF
+jz
+GH
+DD
+DD
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(36,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+uk
+JE
+in
+bt
+TK
+Uo
+Ps
+oC
+RK
+Qt
+oC
+DD
+Ki
+EB
+bg
+jz
+tY
+DD
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(37,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+uk
+JE
+in
+fF
+Om
+Uo
+Cy
+oC
+Qt
+Qt
+xf
+DD
+LM
+bg
+bg
+jz
+tW
+DD
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(38,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+uZ
+uZ
+Bh
+sT
+xt
+Uo
+Uo
+IO
+Qt
+Qt
+xf
+DD
+TY
+Tj
+DK
+Sq
+DD
+DD
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(39,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+xA
+qA
+xA
+sT
+ps
+Ov
+Uo
+oC
+oC
+oC
+cR
+DD
+LM
+DK
+DK
+gQ
+DD
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(40,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+KU
+qA
+sT
+Tk
+Tk
+TB
+Uo
+Cu
+CP
+CY
+ZR
+ZR
+lR
+ZR
+ZR
+ZR
+ZR
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(41,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+Jm
+Jm
+Jm
+Jm
+Jm
+Jm
+Jm
+ZR
+ZR
+ZR
+NZ
+XH
+da
+da
+ZR
+ZR
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(42,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+Jm
+cP
+zp
+HM
+Fd
+Jm
+Kp
+FO
+Ts
+FO
+XH
+FO
+FO
+SQ
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(43,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+Jm
+JY
+sg
+Bq
+BV
+Jm
+Kp
+kS
+kS
+kv
+ZW
+NQ
+PI
+ZR
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(44,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+Jm
+Jm
+VE
+De
+nS
+Jm
+Kp
+kS
+Lx
+As
+qE
+EV
+ZR
+ZR
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(45,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+Jm
+wy
+qD
+UN
+Jm
+Kp
+kS
+kS
+ls
+Lh
+GK
+ZR
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(46,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+oz
+oz
+Jo
+oz
+oz
+Kp
+MO
+sh
+dB
+wQ
+Xt
+SQ
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(47,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+oz
+oz
+yG
+jj
+oz
+oz
+oz
+oz
+aE
+oz
+oz
+oz
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(48,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+oz
+Kj
+WQ
+Ws
+rS
+qQ
+xy
+KM
+DU
+oz
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(49,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+oz
+wv
+Jb
+Gv
+zh
+NV
+Gv
+Jb
+qw
+oz
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(50,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+oz
+oz
+LQ
+Qn
+zh
+CL
+Gv
+jD
+oz
+oz
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(51,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+ST
+MC
+pS
+ay
+gO
+Uf
+wj
+ST
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(52,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+ST
+ST
+NC
+Wp
+wI
+ON
+ST
+ST
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(53,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+ST
+rA
+Wp
+wI
+JV
+ST
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(54,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+oz
+oz
+ik
+Is
+oz
+oz
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(55,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+oz
+oz
+oz
+oz
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}
+(56,1,1) = {"
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+oz
+oz
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+"}

--- a/_maps/shuttles/shiptest/voidcrew/merlin.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/merlin.dmm
@@ -10,9 +10,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/light,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "an" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
@@ -21,9 +19,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "ar" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/cable/cyan{
@@ -34,17 +30,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "ay" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/carpet/purple,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "az" = (
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
@@ -54,9 +46,7 @@
 	},
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/carpet/green,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "aD" = (
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 4;
@@ -66,9 +56,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "aE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -85,9 +73,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "aH" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
@@ -102,9 +88,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "aL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 1
@@ -114,9 +98,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/light,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "aT" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -134,60 +116,44 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "aV" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/grimy,
-/area/ship/maintenance/fore{
-	name = "Skub closet"
-	})
+/area/ship/maintenance/fore)
 "aW" = (
 /obj/machinery/vending/snack/green,
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "aZ" = (
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "bf" = (
 /obj/structure/closet/secure_closet/engineering_electrical{
 	anchored = 1
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "bg" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/carpet/stellar,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "bq" = (
 /obj/machinery/chem_dispenser/fullupgrade{
 	name = "chemical conjurer";
 	desc = "Creates and dispenses chemicals using magis spells, like 'hocus pocus'."
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "bt" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "bv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 1
@@ -197,18 +163,14 @@
 	},
 /obj/structure/bookcase/random,
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "bx" = (
 /obj/machinery/chem_master{
 	name = "ChemMagic 3000";
 	desc = "Used to separate chemicals and distribute them in a variety of forms, using magic"
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "bB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 1
@@ -217,9 +179,7 @@
 	dir = 8
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "bC" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -239,9 +199,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "bJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -254,9 +212,7 @@
 	name = "Mana preservation unit"
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "cg" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/mahogany,
@@ -288,9 +244,7 @@
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "cF" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
@@ -305,9 +259,7 @@
 	dir = 5
 	},
 /turf/open/floor/carpet/green,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "cI" = (
 /obj/structure/window/plasma/reinforced/spawner{
 	color = "#008000"
@@ -316,16 +268,12 @@
 	color = "#008000"
 	},
 /turf/open/floor/engine,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "cP" = (
 /obj/structure/bed,
 /obj/item/bedsheet/wiz,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/dorm/dormtwo{
-	name = "Archmage's Quarters"
-	})
+/area/ship/crew/dorm/dormtwo)
 "cR" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/book/granter/spell/knock{
@@ -336,9 +284,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "cS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -358,9 +304,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "da" = (
 /obj/machinery/cryopod{
 	dir = 1
@@ -373,9 +317,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "dh" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
@@ -384,17 +326,13 @@
 	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "dm" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible{
 	dir = 4
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "dw" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
@@ -404,9 +342,7 @@
 	color = "#008000"
 	},
 /turf/open/floor/engine/plasma,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "dB" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -456,9 +392,7 @@
 	name = "circuitboard conjurer"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "eb" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -473,9 +407,7 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "ek" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -488,9 +420,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "ep" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -498,9 +428,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/stellar,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "er" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -523,9 +451,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/light,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "eR" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/slimepotion/lovepotion{
@@ -557,9 +483,7 @@
 	pixel_x = 35
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "eV" = (
 /obj/structure/window/plasma/reinforced/spawner/north{
 	color = "#008000"
@@ -567,9 +491,48 @@
 /turf/open/floor/engine/air{
 	icon_state = "wood-broken2"
 	},
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
+"eX" = (
+/obj/structure/table/wood/fancy/red_gold,
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy{
+	desc = "Magical raisins, the best in all of spess.";
+	name = "magic raisins";
+	pixel_y = 10;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy{
+	desc = "Magical raisins, the best in all of spess.";
+	name = "magic raisins";
+	pixel_x = 10
+	},
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy{
+	desc = "Magical raisins, the best in all of spess.";
+	name = "magic raisins";
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy{
+	desc = "Magical raisins, the best in all of spess.";
+	name = "magic raisins";
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy{
+	desc = "Magical raisins, the best in all of spess.";
+	name = "magic raisins";
+	pixel_x = 10
+	},
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy{
+	desc = "Magical raisins, the best in all of spess.";
+	name = "magic raisins";
+	pixel_y = 10;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy{
+	desc = "Magical raisins, the best in all of spess.";
+	name = "magic raisins";
+	pixel_x = 5
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/fore)
 "fc" = (
 /obj/structure/window/plasma/reinforced/fulltile{
 	color = "#008000"
@@ -579,15 +542,11 @@
 	id = "wizardship4"
 	},
 /turf/open/floor/plating,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "fg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "fi" = (
 /turf/open/floor/wood/bamboo,
 /area/ship/maintenance/central{
@@ -598,25 +557,19 @@
 	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "fv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "fy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "fz" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
@@ -631,37 +584,27 @@
 	color = "#008000"
 	},
 /turf/open/floor/engine,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "fC" = (
 /obj/machinery/atmospherics/components/unary/shuttle/heater{
 	dir = 4;
 	name = "phlogiston heater"
 	},
 /turf/open/floor/plating,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "fF" = (
 /obj/effect/decal/cleanable/wrapping,
 /turf/open/floor/wood/mahogany,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "fK" = (
 /obj/machinery/autolathe{
 	name = "mana condenser"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "fL" = (
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "fR" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -676,23 +619,17 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "fX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "gb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "gc" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -707,15 +644,11 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "gu" = (
 /obj/effect/turf_decal/atmos/plasma,
 /turf/open/floor/engine/plasma,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "gv" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -727,9 +660,7 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "gC" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
@@ -751,9 +682,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "gN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -768,27 +697,21 @@
 	dir = 1
 	},
 /turf/open/floor/light,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "gO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/carpet/purple,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "gQ" = (
 /obj/machinery/blackbox_recorder{
 	name = "The George Lopez tapes";
 	desc = "This device holds every episode of the George Lopez show, restored digitally in glorious 1080i"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "hc" = (
 /obj/structure/window/plasma/reinforced/spawner/east{
 	color = "#008000"
@@ -797,9 +720,7 @@
 	color = "#008000"
 	},
 /turf/open/floor/engine,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "hd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -808,9 +729,7 @@
 	dir = 8
 	},
 /turf/open/floor/light,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "he" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -823,9 +742,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "hf" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/cable/cyan{
@@ -846,9 +763,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "hA" = (
 /obj/structure/window/plasma/reinforced/fulltile{
 	color = "#008000"
@@ -858,9 +773,7 @@
 	id = "wizardship4"
 	},
 /turf/open/floor/plating,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "hG" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/cable/cyan{
@@ -876,17 +789,13 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "hP" = (
 /obj/structure/closet/radiation{
 	anchored = 1
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "hQ" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/item/storage/toolbox/electrical,
@@ -894,15 +803,11 @@
 	pixel_y = 5
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "hS" = (
 /obj/machinery/mecha_part_fabricator,
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "hZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 1
@@ -911,9 +816,7 @@
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "ia" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -926,18 +829,14 @@
 	},
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "ib" = (
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "ic" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -946,18 +845,14 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "ik" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/stack/spacecash/c10000,
 /obj/item/stack/spacecash/c10000,
 /obj/item/stack/spacecash/c10000,
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "il" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -969,9 +864,7 @@
 	pixel_y = 28
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "im" = (
 /obj/machinery/atmospherics/miner/toxins{
 	icon = 'icons/obj/items_and_weapons.dmi';
@@ -980,17 +873,13 @@
 	name = "activated Skub"
 	},
 /turf/open/floor/engine/plasma,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "in" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "ir" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
@@ -1013,24 +902,18 @@
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/o2,
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "iJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "iK" = (
 /obj/effect/turf_decal/atmos/air,
 /turf/open/floor/engine/air{
 	icon_state = "wood-broken2"
 	},
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "iP" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -1039,9 +922,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "iR" = (
 /obj/machinery/atmospherics/miner/nitrogen{
 	icon = 'icons/obj/items_and_weapons.dmi';
@@ -1052,9 +933,7 @@
 /turf/open/floor/engine/air{
 	icon_state = "wood-broken6"
 	},
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "iV" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4;
@@ -1067,17 +946,13 @@
 	id = "wizardship4"
 	},
 /turf/open/floor/plating,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "jb" = (
 /obj/structure/closet/secure_closet/atmospherics{
 	anchored = 1
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "jg" = (
 /obj/machinery/atmospherics/miner/nitrogen{
 	icon = 'icons/obj/items_and_weapons.dmi';
@@ -1091,9 +966,7 @@
 /turf/open/floor/engine/air{
 	icon_state = "wood-broken2"
 	},
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "ji" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -1105,12 +978,14 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/light,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "jj" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/sord,
+/obj/item/clothing/suit/wizrobe/magusred,
+/obj/item/clothing/suit/wizrobe/magusblue,
+/obj/item/clothing/head/wizard/magus,
+/obj/item/clothing/head/wizard/magus,
 /turf/open/floor/wood/yew,
 /area/ship/bridge{
 	name = "Conducting Chamber"
@@ -1126,9 +1001,7 @@
 	},
 /obj/effect/decal/cleanable/squid_ink,
 /turf/open/floor/plasteel/grimy,
-/area/ship/maintenance/fore{
-	name = "Skub closet"
-	})
+/area/ship/maintenance/fore)
 "jr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -1146,21 +1019,15 @@
 	})
 "jy" = (
 /turf/open/floor/engine,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "jz" = (
 /turf/open/floor/carpet/stellar,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "jD" = (
 /obj/machinery/airalarm/directional/south,
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "jE" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -1173,9 +1040,7 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "jI" = (
 /obj/structure/window/plasma/reinforced/spawner/north{
 	color = "#008000"
@@ -1184,17 +1049,13 @@
 	color = "#008000"
 	},
 /turf/open/floor/carpet/black,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "jZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "ka" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1224,9 +1085,7 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "kv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -1236,9 +1095,7 @@
 "ky" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "kJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 2
@@ -1261,9 +1118,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "lh" = (
 /obj/structure/table/wood/fancy,
 /obj/item/skub{
@@ -1285,9 +1140,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ship/maintenance/fore{
-	name = "Skub closet"
-	})
+/area/ship/maintenance/fore)
 "lk" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
@@ -1299,9 +1152,7 @@
 	color = "#008000"
 	},
 /turf/open/floor/engine,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "ls" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
@@ -1319,9 +1170,7 @@
 	dir = 10
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "lD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1351,18 +1200,21 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ship/maintenance/fore{
-	name = "Skub closet"
-	})
+/area/ship/maintenance/fore)
+"lK" = (
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen)
 "lM" = (
 /obj/machinery/smartfridge/bloodbank/preloaded,
 /turf/closed/wall/mineral/uranium/safe{
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "lR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1384,9 +1236,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "ms" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1403,9 +1253,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "mw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/kirbyplants/random,
@@ -1421,18 +1269,14 @@
 	name = "Wall-mounted mana-jolter"
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "mW" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "mZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -1442,9 +1286,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "ni" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -1453,9 +1295,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "nj" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1473,15 +1313,12 @@
 "nx" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/light,
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "ny" = (
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "nz" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -1490,26 +1327,20 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "nC" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 6
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "nD" = (
 /turf/closed/wall/mineral/uranium/safe{
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/maintenance/fore{
-	name = "Skub closet"
-	})
+/area/ship/maintenance/fore)
 "nI" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/storage/firstaid,
@@ -1518,18 +1349,14 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "nK" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "nL" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -1542,9 +1369,7 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "nM" = (
 /obj/structure/window/plasma/reinforced/fulltile{
 	color = "#008000"
@@ -1554,9 +1379,7 @@
 	id = "wizardship4"
 	},
 /turf/open/floor/plating,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "nN" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -1579,9 +1402,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "nS" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/scrying,
@@ -1589,9 +1410,7 @@
 /obj/item/upgradescroll,
 /obj/item/upgradescroll,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/dorm/dormtwo{
-	name = "Archmage's Quarters"
-	})
+/area/ship/crew/dorm/dormtwo)
 "nV" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1604,28 +1423,20 @@
 	dir = 4
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "ol" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "oz" = (
 /turf/closed/wall/mineral/uranium/safe{
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "oC" = (
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "oE" = (
 /obj/machinery/suit_storage_unit,
 /obj/item/tank/internals/emergency_oxygen/engi,
@@ -1636,9 +1447,7 @@
 	dir = 4
 	},
 /turf/open/floor/bronze,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "oL" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/cable/cyan{
@@ -1653,9 +1462,7 @@
 	name = "Cargo"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "oT" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -1664,36 +1471,26 @@
 	dir = 6
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "pd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "pe" = (
 /turf/open/floor/carpet/black,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "pi" = (
 /obj/machinery/grill,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "ps" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/open/floor/carpet/royalblue,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "px" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1702,9 +1499,7 @@
 	dir = 6
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "pE" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
@@ -1734,18 +1529,14 @@
 	dir = 1
 	},
 /turf/open/floor/light,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "pS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/chair/bronze{
 	dir = 1
 	},
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "pU" = (
 /obj/machinery/suit_storage_unit,
 /obj/item/tank/internals/emergency_oxygen/engi,
@@ -1754,9 +1545,7 @@
 /obj/item/clothing/gloves/combat/wizard,
 /obj/machinery/light,
 /turf/open/floor/bronze,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "pW" = (
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/central)
@@ -1765,14 +1554,10 @@
 	id = "wizardship4_v1"
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "qf" = (
 /turf/open/floor/engine/plasma,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "ql" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -1784,17 +1569,13 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "qw" = (
 /obj/structure/constructshell,
 /obj/structure/constructshell,
 /obj/structure/constructshell,
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "qA" = (
 /obj/machinery/door/poddoor{
 	id = "wizardship4_top"
@@ -1804,9 +1585,7 @@
 	desc = "A tiny fan, projecting an invisible barrier that doesnt allow gas to pass."
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "qD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1818,9 +1597,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/crew/dorm/dormtwo{
-	name = "Archmage's Quarters"
-	})
+/area/ship/crew/dorm/dormtwo)
 "qE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1845,9 +1622,7 @@
 /obj/effect/spawner/lootdrop/donkpockets,
 /obj/machinery/light,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "qQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1859,25 +1634,19 @@
 	dir = 1
 	},
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "qT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "rd" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/knife/butcher,
 /obj/item/sharpener,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "rg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1898,9 +1667,7 @@
 	dir = 8
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "rn" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -1909,9 +1676,7 @@
 	pixel_y = -28
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "rv" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1923,23 +1688,17 @@
 	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "rA" = (
 /obj/machinery/computer/helm,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "rB" = (
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "rS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1956,9 +1715,7 @@
 	pixel_x = -26
 	},
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "rV" = (
 /obj/machinery/power/shuttle/engine/electric{
 	dir = 4;
@@ -1974,15 +1731,11 @@
 	id = "wizardship4"
 	},
 /turf/open/floor/plating,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "sg" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/dorm/dormtwo{
-	name = "Archmage's Quarters"
-	})
+/area/ship/crew/dorm/dormtwo)
 "sh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2001,9 +1754,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "sF" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
@@ -2015,9 +1766,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "sL" = (
 /obj/structure/window/plasma/reinforced/fulltile{
 	color = "#008000"
@@ -2039,39 +1788,29 @@
 	dir = 8
 	},
 /turf/open/floor/light,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "sR" = (
 /obj/structure/window/plasma/reinforced/spawner/east{
 	color = "#008000"
 	},
 /turf/open/floor/engine/plasma,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "sT" = (
 /turf/open/floor/wood/mahogany,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "sX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "sY" = (
 /obj/item/circuitboard/machine/rdserver,
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil/red,
 /obj/item/stock_parts/scanning_module/triphasic,
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "ta" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2083,9 +1822,7 @@
 	dir = 6
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "tc" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
@@ -2095,22 +1832,16 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "ti" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "tt" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "tJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -2124,9 +1855,7 @@
 	name = "Wall-mounted mana-jolter"
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "tL" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
@@ -2136,9 +1865,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "tP" = (
 /obj/machinery/door/poddoor{
 	id = "wizardship4_rear"
@@ -2153,9 +1880,7 @@
 	port_direction = 8
 	},
 /turf/open/floor/plating,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "tQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2170,9 +1895,7 @@
 	dir = 1
 	},
 /turf/open/floor/light,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "tS" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable/cyan,
@@ -2184,17 +1907,13 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/item/research_notes/loot/genius,
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "tY" = (
 /obj/structure/chair/bronze{
 	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "ua" = (
 /obj/machinery/atmospherics/miner/oxygen{
 	icon = 'icons/obj/items_and_weapons.dmi';
@@ -2205,9 +1924,7 @@
 /turf/open/floor/engine/air{
 	icon_state = "wood-broken6"
 	},
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "uc" = (
 /obj/machinery/computer/helm/viewscreen{
 	dir = 8;
@@ -2217,15 +1934,11 @@
 	anchored = 1
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "ud" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "uk" = (
 /obj/structure/window/plasma/reinforced/fulltile{
 	color = "#008000"
@@ -2235,9 +1948,7 @@
 	id = "wizardship4"
 	},
 /turf/open/floor/plating,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "um" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -2254,18 +1965,14 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "uA" = (
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "uB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -2277,17 +1984,13 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/light,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "uD" = (
 /obj/machinery/rnd/production/protolathe{
 	name = "experimental mana condenser"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "uJ" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -2336,9 +2039,7 @@
 	name = "The Grimoire of Rock Revelation"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "uR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2364,25 +2065,19 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "uY" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "uZ" = (
 /turf/closed/wall/mineral/uranium/safe{
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "va" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -2397,9 +2092,7 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "vv" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -2408,9 +2101,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "vx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
@@ -2428,9 +2119,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "vJ" = (
 /turf/closed/wall/mineral/uranium/safe{
 	desc = "A wall plated with emerald.";
@@ -2446,9 +2135,7 @@
 	name = "mana injector"
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "vN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -2466,9 +2153,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "we" = (
 /obj/structure/window/plasma/reinforced/fulltile{
 	color = "#008000"
@@ -2478,9 +2163,7 @@
 	},
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "wg" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -2499,9 +2182,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "wj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/dogbed/cayenne{
@@ -2513,30 +2194,22 @@
 	name = "Bunglesworth"
 	},
 /turf/open/floor/wood,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "wt" = (
 /obj/machinery/processor,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "wu" = (
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "wv" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "wx" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -2551,34 +2224,26 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "wy" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/crew/dorm/dormtwo{
-	name = "Archmage's Quarters"
-	})
+/area/ship/crew/dorm/dormtwo)
 "wI" = (
 /obj/structure/chair/bronze{
 	dir = 2
 	},
 /turf/open/floor/carpet/purple,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "wL" = (
 /obj/structure/sign/poster/official/help_others{
 	pixel_x = -32
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "wN" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -2590,9 +2255,7 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "wO" = (
 /obj/machinery/shower{
 	pixel_y = 12;
@@ -2606,9 +2269,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "wQ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -2621,9 +2282,7 @@
 "xc" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "xf" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/book/granter/spell/charge{
@@ -2633,9 +2292,7 @@
 	pixel_x = 5
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "xt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2644,17 +2301,13 @@
 	dir = 8
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "xv" = (
 /obj/effect/mob_spawn/human/corpse/wizard{
 	name = "Pingus"
 	},
 /turf/open/floor/engine/plasma,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "xy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2669,14 +2322,10 @@
 	dir = 8
 	},
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "xA" = (
 /turf/open/floor/carpet/royalblue,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "xB" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
@@ -2690,9 +2339,7 @@
 	dir = 10
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "xI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2705,53 +2352,41 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/light,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "xJ" = (
 /obj/structure/window/plasma/reinforced/spawner/east{
 	color = "#008000"
 	},
 /turf/open/floor/carpet/black,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "xZ" = (
 /turf/closed/wall/mineral/uranium/safe{
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "ya" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
 	},
-/turf/open/floor/carpet/red_gold,
-/area/ship/hallway/central)
+/area/ship/medical)
 "yf" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "yl" = (
 /obj/machinery/atmospherics/components/unary/shuttle/heater{
 	dir = 4;
 	name = "phlogiston heater"
 	},
 /turf/open/floor/plating,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "yp" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plating,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "yq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2766,9 +2401,7 @@
 	},
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "yw" = (
 /obj/structure/window/plasma/reinforced/fulltile{
 	color = "#008000"
@@ -2778,17 +2411,13 @@
 	id = "wizardship4"
 	},
 /turf/open/floor/plating,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "yA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "yG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2800,9 +2429,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "yH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -2813,17 +2440,13 @@
 "yL" = (
 /obj/machinery/rnd/destructive_analyzer,
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "yP" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "yZ" = (
 /obj/structure/closet/crate/miningcar{
 	name = "mining car"
@@ -2858,9 +2481,7 @@
 	name = "The Grimoire of Rock Revelation"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "zc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -2871,9 +2492,7 @@
 	})
 "zh" = (
 /turf/open/floor/carpet/purple,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "zj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2885,17 +2504,13 @@
 	dir = 1
 	},
 /turf/open/floor/light,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "zp" = (
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/crew/dorm/dormtwo{
-	name = "Archmage's Quarters"
-	})
+/area/ship/crew/dorm/dormtwo)
 "zr" = (
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 4;
@@ -2905,9 +2520,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "zw" = (
 /obj/machinery/atmospherics/miner/nitrogen{
 	icon = 'icons/obj/items_and_weapons.dmi';
@@ -2918,15 +2531,11 @@
 /turf/open/floor/engine/air{
 	icon_state = "wood-broken4"
 	},
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "zy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "zz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2950,9 +2559,7 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "zE" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
@@ -2963,9 +2570,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "zF" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -2974,20 +2579,14 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "zI" = (
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "zR" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "Ab" = (
 /obj/machinery/power/shuttle/engine/electric{
 	dir = 4;
@@ -3003,9 +2602,7 @@
 	id = "wizardship4"
 	},
 /turf/open/floor/plating,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "Ae" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -3019,17 +2616,13 @@
 	name = "mana injector"
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "Ao" = (
 /obj/structure/window/plasma/reinforced/spawner/west{
 	color = "#008000"
 	},
 /turf/open/floor/carpet/black,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "As" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
@@ -3042,9 +2635,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "AB" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -3053,9 +2644,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "AF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -3064,9 +2653,7 @@
 	dir = 9
 	},
 /turf/open/floor/carpet/stellar,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "AJ" = (
 /obj/structure/window/plasma/reinforced/fulltile{
 	color = "#008000"
@@ -3076,9 +2663,7 @@
 	id = "wizardship4"
 	},
 /turf/open/floor/plating,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "AU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3107,9 +2692,7 @@
 /turf/open/floor/engine/air{
 	icon_state = "wood-broken7"
 	},
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Bc" = (
 /obj/machinery/computer/helm/viewscreen{
 	dir = 8;
@@ -3128,9 +2711,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "Bh" = (
 /obj/machinery/button/door{
 	id = "wizardship4_top";
@@ -3138,9 +2719,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "Bq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3149,9 +2728,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/dormtwo{
-	name = "Archmage's Quarters"
-	})
+/area/ship/crew/dorm/dormtwo)
 "Bz" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -3166,9 +2743,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "BK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3199,9 +2774,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/crew/dorm/dormtwo{
-	name = "Archmage's Quarters"
-	})
+/area/ship/crew/dorm/dormtwo)
 "BW" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -3216,17 +2789,13 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "BZ" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 9
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Cj" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -3235,9 +2804,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "Cl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3258,16 +2825,12 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "Cs" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Cu" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/book/granter/spell/summonitem{
@@ -3277,9 +2840,7 @@
 	pixel_x = -5
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "Cx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -3287,9 +2848,7 @@
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/table/wood/fancy/royalblue,
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "Cy" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/gun/energy/xray{
@@ -3336,9 +2895,7 @@
 	pixel_x = -10
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "CA" = (
 /obj/structure/altar_of_gods,
 /obj/item/gun/energy/pulse/carbine{
@@ -3352,26 +2909,20 @@
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/carpet/black,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "CF" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/storage/box/beakers,
 /obj/item/gun/magic/wand/resurrection,
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "CL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/xenoblood/xgibs/core,
 /turf/open/floor/carpet/purple,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "CM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -3395,9 +2946,7 @@
 	pixel_x = -5
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "CT" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
@@ -3410,9 +2959,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "CV" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -3425,9 +2972,7 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "CX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 1
@@ -3436,9 +2981,7 @@
 	dir = 1
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "CY" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/book/granter/spell/forcewall{
@@ -3448,9 +2991,7 @@
 	pixel_x = 5
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "De" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3462,9 +3003,7 @@
 	dir = 5
 	},
 /turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/dormtwo{
-	name = "Archmage's Quarters"
-	})
+/area/ship/crew/dorm/dormtwo)
 "Dg" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
@@ -3494,9 +3033,7 @@
 "Dk" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Ds" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -3514,18 +3051,14 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "Dw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Dx" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -3538,23 +3071,17 @@
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "DG" = (
 /obj/structure/window/plasma/reinforced/spawner/east{
 	color = "#008000"
 	},
 /turf/open/floor/engine,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "DK" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "DU" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/soulstone/anybody{
@@ -3567,9 +3094,7 @@
 	pixel_x = -5
 	},
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "Eg" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -3584,9 +3109,7 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "Ei" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
@@ -3607,26 +3130,20 @@
 	color = "#008000"
 	},
 /turf/open/floor/engine,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "Eo" = (
 /turf/closed/wall/mineral/uranium/safe{
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "EB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/structure/bookcase/random,
 /turf/open/floor/carpet/stellar,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "ED" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
@@ -3653,23 +3170,17 @@
 	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "EI" = (
 /obj/machinery/selling_pad,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "ER" = (
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "EU" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/cable/cyan{
@@ -3682,9 +3193,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "EV" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/head/wizard/yellow,
@@ -3701,15 +3210,11 @@
 /area/ship/crew/dorm)
 "EY" = (
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "Fd" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/dorm/dormtwo{
-	name = "Archmage's Quarters"
-	})
+/area/ship/crew/dorm/dormtwo)
 "Fg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 1
@@ -3718,9 +3223,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/stellar,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "Fl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3735,9 +3238,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "Fr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 2
@@ -3756,9 +3257,7 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "Fu" = (
 /obj/machinery/door/poddoor{
 	id = "wizardship4_rear"
@@ -3768,18 +3267,14 @@
 	desc = "A tiny fan, projecting an invisible barrier that doesnt allow gas to pass."
 	},
 /turf/open/floor/plating,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "FD" = (
 /obj/machinery/light/floor,
 /obj/structure/window/plasma/reinforced/spawner/east{
 	color = "#008000"
 	},
 /turf/open/floor/engine/plasma,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "FF" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -3788,9 +3283,7 @@
 	dir = 10
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "FG" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
@@ -3799,9 +3292,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "FH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
@@ -3817,17 +3308,13 @@
 	dir = 8
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "FJ" = (
 /obj/machinery/mineral/ore_redemption{
 	req_access = null
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "FO" = (
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
@@ -3836,48 +3323,36 @@
 	dir = 4
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "Ge" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "Gv" = (
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "Gx" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "GC" = (
 /obj/machinery/computer/operating{
 	dir = 1
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "GF" = (
 /obj/machinery/suit_storage_unit,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/suit/space/hardsuit/wizard,
 /obj/item/clothing/gloves/combat/wizard,
 /turf/open/floor/bronze,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "GH" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -3889,9 +3364,7 @@
 	name = "magic recorder"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "GK" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/head/wizard/yellow,
@@ -3912,9 +3385,7 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "GU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
@@ -3926,9 +3397,7 @@
 	dir = 4
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "GV" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 9
@@ -3940,18 +3409,14 @@
 	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "Hl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/xenoblood,
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "Hn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3984,9 +3449,7 @@
 	dir = 8
 	},
 /turf/open/floor/light,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "HA" = (
 /obj/machinery/computer/rdconsole{
 	dir = 8
@@ -3995,9 +3458,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "HM" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -4006,28 +3467,20 @@
 	dir = 4
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/crew/dorm/dormtwo{
-	name = "Archmage's Quarters"
-	})
+/area/ship/crew/dorm/dormtwo)
 "HN" = (
 /obj/structure/window/plasma/reinforced/spawner/north{
 	color = "#008000"
 	},
 /turf/open/floor/engine,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "Ia" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "If" = (
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "Ii" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4039,9 +3492,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "Ir" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4064,21 +3515,15 @@
 /obj/item/stack/sheet/mineral/gold/fifty,
 /obj/item/stack/sheet/mineral/silver/fifty,
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "Iz" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "IO" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "IQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -4087,9 +3532,7 @@
 	name = "Mana preservation unit"
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "IR" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -4104,17 +3547,13 @@
 	dir = 1
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Jb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "Jc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/meter/atmos/layer4,
@@ -4124,9 +3563,7 @@
 /turf/open/floor/engine/air{
 	icon_state = "wood-broken6"
 	},
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Jf" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -4141,9 +3578,7 @@
 	dir = 8
 	},
 /turf/open/floor/light,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "Jj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4158,9 +3593,7 @@
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/crew/dorm/dormtwo{
-	name = "Archmage's Quarters"
-	})
+/area/ship/crew/dorm/dormtwo)
 "Jo" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
@@ -4177,9 +3610,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "Jr" = (
 /obj/structure/table/wood/fancy/red_gold,
 /obj/machinery/light{
@@ -4189,10 +3620,50 @@
 /area/ship/hallway/central)
 "JE" = (
 /obj/structure/table/wood/fancy/red_gold,
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy{
+	desc = "Magical raisins, the best in all of spess.";
+	name = "magic raisins";
+	pixel_y = 10;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy{
+	desc = "Magical raisins, the best in all of spess.";
+	name = "magic raisins";
+	pixel_x = 10
+	},
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy{
+	desc = "Magical raisins, the best in all of spess.";
+	name = "magic raisins";
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy{
+	desc = "Magical raisins, the best in all of spess.";
+	name = "magic raisins";
+	pixel_x = 10
+	},
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy{
+	desc = "Magical raisins, the best in all of spess.";
+	name = "magic raisins";
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy{
+	desc = "Magical raisins, the best in all of spess.";
+	name = "magic raisins";
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy{
+	desc = "Magical raisins, the best in all of spess.";
+	name = "magic raisins";
+	pixel_y = 10;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy{
+	desc = "Magical raisins, the best in all of spess.";
+	name = "magic raisins";
+	pixel_x = 5
+	},
 /turf/open/floor/wood/mahogany,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "JO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4216,17 +3687,13 @@
 	dir = 4
 	},
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "JY" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/suit/space/hardsuit/wizard,
 /obj/item/clothing/gloves/combat/wizard,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/dorm/dormtwo{
-	name = "Archmage's Quarters"
-	})
+/area/ship/crew/dorm/dormtwo)
 "Kc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4245,9 +3712,7 @@
 	},
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Ki" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4260,9 +3725,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "Kj" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -4278,9 +3741,7 @@
 	},
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "Kk" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/item/storage/toolbox/mechanical{
@@ -4300,9 +3761,7 @@
 	},
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Kp" = (
 /obj/structure/bed,
 /obj/item/bedsheet/wiz,
@@ -4314,32 +3773,24 @@
 "Kr" = (
 /obj/structure/table/wood/fancy/royalblue,
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "Kw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/machinery/light,
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "Kx" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 9
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "KD" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "KG" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 6
@@ -4354,25 +3805,19 @@
 	dir = 6
 	},
 /turf/open/floor/carpet/green,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "KH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "KJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "KM" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -4382,9 +3827,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "KS" = (
 /obj/machinery/light,
 /turf/open/floor/wood/mahogany,
@@ -4392,9 +3835,7 @@
 "KU" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/mahogany,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "KV" = (
 /turf/closed/wall/mineral/uranium/safe{
 	desc = "A wall plated with emerald.";
@@ -4410,17 +3851,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "Lc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/recharge_station{
+	name = "cyborg mana infusing station";
+	desc = "This device recharges cyborgs and resupplies them with materials using complex magical rituals."
+	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "Le" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4436,9 +3877,7 @@
 	name = "Archives"
 	},
 /turf/open/floor/light,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "Lh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4451,17 +3890,17 @@
 "Li" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "Lx" = (
 /obj/structure/cursed_slot_machine,
 /turf/open/floor/carpet/stellar,
 /area/ship/crew/dorm)
 "LB" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/carpet/red_gold,
-/area/ship/hallway/central)
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/maintenance/starboard)
 "LM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4473,15 +3912,11 @@
 	dir = 4
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "LQ" = (
 /obj/machinery/modular_computer/console/preset/command,
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "Mc" = (
 /obj/structure/window/plasma/reinforced/fulltile{
 	color = "#008000"
@@ -4489,9 +3924,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Mm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4518,15 +3951,11 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "MC" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "ME" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable/cyan{
@@ -4555,9 +3984,7 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "MM" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-4"
@@ -4568,9 +3995,7 @@
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/cyan,
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "MO" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -4583,9 +4008,7 @@
 	dir = 4
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Nn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -4594,9 +4017,7 @@
 	dir = 4
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Nu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 2
@@ -4615,9 +4036,7 @@
 "NC" = (
 /obj/machinery/computer/communications,
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "NM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -4635,9 +4054,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/purple,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "NZ" = (
 /obj/machinery/cryopod{
 	dir = 1
@@ -4669,9 +4086,7 @@
 	id = "wizardship4_v2"
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "Om" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4683,39 +4098,29 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "Ou" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/bookcase/random,
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "Ov" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/mahogany,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "OG" = (
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "ON" = (
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "OQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
@@ -4730,25 +4135,19 @@
 	color = "#008000"
 	},
 /turf/open/floor/carpet/black,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "Pi" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/storage/firstaid/brute,
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "Pj" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Ps" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/gun/energy/laser/captain/scattershot{
@@ -4795,9 +4194,7 @@
 	fire_sound = 'sound/magic/wand_teleport.ogg'
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "Px" = (
 /obj/structure/cable/cyan,
 /obj/structure/cable/cyan{
@@ -4805,9 +4202,7 @@
 	},
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/carpet/green,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "PI" = (
 /obj/machinery/cryopod{
 	dir = 8
@@ -4823,9 +4218,7 @@
 	dir = 6
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "PM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4835,25 +4228,19 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/wood/bamboo,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "PR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Qc" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 10
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Qf" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -4868,17 +4255,13 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "Qn" = (
 /obj/structure/chair/bronze{
 	dir = 1
 	},
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "Qr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4891,14 +4274,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "Qt" = (
 /turf/open/floor/carpet/orange,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "QH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4908,9 +4287,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/stellar,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "QP" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -4929,9 +4306,7 @@
 "QT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "QU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
@@ -4940,9 +4315,7 @@
 	dir = 5
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "QW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/mahogany,
@@ -4953,9 +4326,7 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "RI" = (
 /obj/machinery/button/door{
 	id = "wizardship4_v1";
@@ -4963,17 +4334,13 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "RK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/carpet/orange,
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "RN" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
@@ -4986,9 +4353,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "RQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5018,18 +4383,14 @@
 	color = "#008000"
 	},
 /turf/open/floor/engine,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "Sf" = (
 /obj/machinery/chem_heater{
 	name = "box of warming";
 	desc = "A box that can warm chemicals"
 	},
 /turf/open/floor/mineral/silver,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "Sk" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -5038,15 +4399,11 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Sq" = (
 /obj/machinery/light,
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "Sx" = (
 /obj/structure/closet/secure_closet/freezer/cream_pie,
 /obj/item/reagent_containers/food/snacks/pie/cream,
@@ -5056,16 +4413,12 @@
 /obj/item/reagent_containers/food/snacks/pie/cream,
 /obj/item/reagent_containers/food/snacks/pie/cream,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "Sz" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/industrial/outline/yellow,
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "SD" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -5077,9 +4430,7 @@
 	dir = 5
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "SH" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/cable/cyan{
@@ -5092,9 +4443,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "SQ" = (
 /obj/structure/window/plasma/reinforced/fulltile{
 	color = "#008000"
@@ -5114,9 +4463,7 @@
 	id = "wizardship4"
 	},
 /turf/open/floor/plating,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "SX" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -5129,17 +4476,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "Tg" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 10
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "Ti" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -5148,26 +4491,20 @@
 	dir = 2
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Tj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /obj/structure/bookcase/random,
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "Tk" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "Tl" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -5177,9 +4514,7 @@
 	on = 1
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Ts" = (
 /obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/wood,
@@ -5189,9 +4524,7 @@
 	pixel_y = 22
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "Tx" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/item/pipe_dispenser{
@@ -5204,9 +4537,7 @@
 	desc = "A device used to rapidly pipe things, using magic"
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "TB" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/chair/wood/wings{
@@ -5217,9 +4548,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "TE" = (
 /turf/closed/wall/mineral/uranium/safe{
 	desc = "A wall plated with emerald.";
@@ -5239,25 +4568,19 @@
 	dir = 8
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "TM" = (
 /obj/structure/window/plasma/reinforced/spawner/north{
 	color = "#008000"
 	},
 /turf/open/floor/carpet/black,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "TU" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "TW" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -5272,9 +4595,7 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "TY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
@@ -5286,9 +4607,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "Ua" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
@@ -5300,18 +4619,14 @@
 	dir = 4
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "Ub" = (
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/grimy,
-/area/ship/maintenance/fore{
-	name = "Skub closet"
-	})
+/area/ship/maintenance/fore)
 "Uc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5331,9 +4646,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "Uh" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
@@ -5347,9 +4660,7 @@
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/security/armory{
-	name = "Enchantment Storage"
-	})
+/area/ship/security/armory)
 "Up" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 2
@@ -5371,9 +4682,7 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "Uy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 1
@@ -5400,23 +4709,17 @@
 	name = "Waiting Room"
 	},
 /turf/open/floor/carpet/royalblue,
-/area/ship/hallway/fore{
-	name = "Waiting Room"
-	})
+/area/ship/hallway/fore)
 "UN" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/dorm/dormtwo{
-	name = "Archmage's Quarters"
-	})
+/area/ship/crew/dorm/dormtwo)
 "UV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ship/maintenance/fore{
-	name = "Skub closet"
-	})
+/area/ship/maintenance/fore)
 "UY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5431,9 +4734,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/light,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "Va" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5445,9 +4746,7 @@
 /obj/item/mjollnir,
 /obj/machinery/light/floor,
 /turf/open/floor/carpet/black,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "VA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -5457,15 +4756,11 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "VE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/dorm/dormtwo{
-	name = "Archmage's Quarters"
-	})
+/area/ship/crew/dorm/dormtwo)
 "VW" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/cable/cyan{
@@ -5482,9 +4777,7 @@
 	name = "Artificer's Chambers"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "VZ" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -5499,34 +4792,26 @@
 	color = "#008000"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "We" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer2{
 	dir = 1;
 	on = 1
 	},
 /turf/open/floor/plating,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "Wk" = (
 /turf/closed/wall/mineral/uranium/safe{
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "Wp" = (
 /obj/structure/chair/bronze{
 	dir = 1
 	},
 /turf/open/floor/carpet/purple,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "Ws" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5541,15 +4826,11 @@
 	dir = 8
 	},
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "WF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "WG" = (
 /turf/open/floor/carpet/red_gold,
 /area/ship/hallway/central)
@@ -5567,9 +4848,7 @@
 	dir = 5
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "WQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5581,18 +4860,14 @@
 	dir = 8
 	},
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "WV" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "WY" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -5601,9 +4876,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "Xf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
@@ -5618,9 +4891,7 @@
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "Xt" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/wood,
@@ -5650,9 +4921,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "Yj" = (
 /obj/structure/janitorialcart{
 	dir = 4
@@ -5661,9 +4930,7 @@
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/grimy,
-/area/ship/maintenance/fore{
-	name = "Skub closet"
-	})
+/area/ship/maintenance/fore)
 "Ym" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4;
@@ -5676,18 +4943,14 @@
 	id = "wizardship4"
 	},
 /turf/open/floor/plating,
-/area/ship/cargo{
-	name = "Merchant's Chambers"
-	})
+/area/ship/cargo)
 "Yo" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/science{
-	name = "Artificer's Chambers"
-	})
+/area/ship/science)
 "YD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5699,9 +4962,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "YG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 2
@@ -5716,9 +4977,7 @@
 	dir = 5
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "YO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
@@ -5727,25 +4986,19 @@
 	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "YR" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
 /turf/open/floor/engine/plasma,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Ze" = (
 /obj/structure/closet/secure_closet/engineering_personal{
 	anchored = 1
 	},
 /turf/open/floor/bronze,
-/area/ship/maintenance/aft{
-	name = "Artisan's Chambers"
-	})
+/area/ship/maintenance/aft)
 "Zi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5763,16 +5016,12 @@
 	id = "wizardship4"
 	},
 /turf/open/floor/plating,
-/area/ship/maintenance/port{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/port)
 "Zy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/wood/ebony,
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "ZE" = (
 /obj/structure/table/wood/fancy/red_gold,
 /turf/open/floor/carpet/red_gold,
@@ -5782,14 +5031,10 @@
 	dir = 4
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/storage{
-	name = "Artifact Vault"
-	})
+/area/ship/storage)
 "ZO" = (
 /turf/open/floor/plasteel/grimy,
-/area/ship/maintenance/fore{
-	name = "Skub closet"
-	})
+/area/ship/maintenance/fore)
 "ZR" = (
 /turf/closed/wall/mineral/uranium/safe{
 	desc = "A wall plated with emerald.";
@@ -5804,17 +5049,13 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
+/area/ship/maintenance/starboard)
 "ZU" = (
 /turf/closed/wall/mineral/uranium/safe{
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/crew/canteen/kitchen{
-	name = "Food Conjuration Chamber"
-	})
+/area/ship/crew/canteen/kitchen)
 "ZW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6114,12 +5355,12 @@ AY
 iK
 cA
 AV
-AV
-AV
-AV
-AV
-AV
-AV
+LB
+LB
+LB
+LB
+LB
+LB
 MG
 "}
 (8,1,1) = {"
@@ -6154,14 +5395,14 @@ Kh
 jg
 zw
 iR
-AV
+LB
 gv
 gv
 gv
 gv
 kc
-AV
-AV
+LB
+LB
 MG
 "}
 (9,1,1) = {"
@@ -6192,17 +5433,17 @@ dC
 dC
 dC
 pE
-AV
-AV
-AV
-AV
-AV
+LB
+LB
+LB
+LB
+LB
 RN
 sF
 sF
 sF
 Fs
-AV
+LB
 MG
 MG
 "}
@@ -6234,7 +5475,7 @@ nN
 nN
 nN
 jr
-AV
+LB
 BW
 gv
 gv
@@ -6244,7 +5485,7 @@ Eg
 ql
 ql
 jE
-AV
+LB
 MG
 MG
 "}
@@ -6285,8 +5526,8 @@ aH
 TW
 gv
 kc
-AV
-AV
+LB
+LB
 MG
 MG
 "}
@@ -6318,7 +5559,7 @@ fi
 XM
 fi
 CT
-AV
+LB
 va
 ql
 ql
@@ -6360,16 +5601,16 @@ vJ
 vJ
 vJ
 vJ
-AV
-AV
-AV
-AV
+LB
+LB
+LB
+LB
 iP
 ql
 ql
 ql
 jE
-AV
+LB
 MG
 MG
 MG
@@ -6405,13 +5646,13 @@ pW
 pW
 pW
 cg
-TE
-TE
-TE
-TE
-TE
-TE
-TE
+ya
+ya
+ya
+ya
+ya
+ya
+ya
 MG
 MG
 MG
@@ -6452,7 +5693,7 @@ zj
 Jf
 KJ
 GC
-TE
+ya
 MG
 MG
 MG
@@ -6494,7 +5735,7 @@ EY
 hd
 qT
 tJ
-TE
+ya
 MG
 MG
 MG
@@ -6528,15 +5769,15 @@ xZ
 xZ
 xZ
 xZ
-TE
-TE
-TE
+ya
+ya
+ya
 lM
 EY
 Hr
 Cx
-TE
-TE
+ya
+ya
 MG
 MG
 MG
@@ -6570,7 +5811,7 @@ qf
 qf
 qf
 xZ
-TE
+ya
 nI
 wL
 bq
@@ -6612,7 +5853,7 @@ xZ
 xZ
 xZ
 xZ
-TE
+ya
 Pi
 EY
 bx
@@ -6654,14 +5895,14 @@ qa
 ol
 ZN
 xZ
-TE
+ya
 iG
 EY
 Sf
 EY
 ey
-TE
-TE
+ya
+ya
 MG
 MG
 MG
@@ -6696,7 +5937,7 @@ qa
 fL
 Kw
 xZ
-TE
+ya
 Cr
 EY
 CF
@@ -6738,7 +5979,7 @@ qa
 QT
 WJ
 xZ
-TE
+ya
 ag
 aL
 aL
@@ -6780,13 +6021,13 @@ xZ
 RI
 kU
 xZ
-TE
+ya
 UY
 bW
 bW
 bW
-TE
-TE
+ya
+ya
 MG
 MG
 MG
@@ -6822,12 +6063,12 @@ xZ
 wu
 ia
 xZ
-TE
+ya
 tQ
 bW
 bW
 mL
-TE
+ya
 MG
 MG
 MG
@@ -6864,12 +6105,12 @@ xZ
 ux
 Ii
 xZ
-TE
+ya
 xI
 IQ
 bW
 bW
-TE
+ya
 MG
 MG
 MG
@@ -6891,7 +6132,7 @@ ZU
 tL
 ZU
 mZ
-KD
+lK
 ZU
 pW
 Di
@@ -6906,12 +6147,12 @@ Og
 fL
 Ii
 xZ
-TE
+ya
 sQ
 vL
 vL
-TE
-TE
+ya
+ya
 MG
 MG
 MG
@@ -6934,7 +6175,7 @@ Va
 WG
 FH
 gC
-WG
+gC
 gC
 Ir
 pW
@@ -6948,11 +6189,11 @@ Og
 fL
 ek
 xZ
-TE
+ya
 gN
 GN
 EY
-TE
+ya
 MG
 MG
 MG
@@ -6976,7 +6217,7 @@ nV
 Hn
 AU
 cl
-ya
+cl
 cl
 ch
 pW
@@ -6990,11 +6231,11 @@ Og
 fL
 Ii
 xZ
-TE
+ya
 sQ
 Al
 Al
-TE
+ya
 MG
 MG
 MG
@@ -7018,7 +6259,7 @@ KV
 Jr
 FH
 IR
-WG
+IR
 IR
 Ir
 KS
@@ -7060,7 +6301,7 @@ sL
 IR
 FH
 gC
-WG
+gC
 gC
 Di
 pW
@@ -7099,10 +6340,10 @@ MG
 MG
 MG
 sL
-LB
+WG
 FH
 ZE
-WG
+ZE
 ZE
 Ir
 pW
@@ -7144,7 +6385,7 @@ KV
 KV
 FH
 IR
-WG
+IR
 IR
 Cl
 NM
@@ -7311,7 +6552,7 @@ MG
 MG
 MG
 uk
-JE
+eX
 in
 bt
 TK

--- a/_maps/shuttles/shiptest/voidcrew/merlin.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/merlin.dmm
@@ -31,6 +31,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
 /area/ship/cargo)
+"aw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 25
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library)
 "ay" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 1
@@ -72,6 +87,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/ship/bridge)
 "aH" = (
@@ -410,6 +426,9 @@
 	dir = 8
 	},
 /obj/machinery/light,
+/obj/machinery/firealarm{
+	pixel_y = -25
+	},
 /turf/open/floor/wood/mahogany,
 /area/ship/storage)
 "ep" = (
@@ -599,6 +618,7 @@
 	name = "Mana requillary";
 	req_access_txt = "16"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/starboard)
 "fX" = (
@@ -620,6 +640,13 @@
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/port)
+"gq" = (
+/mob/living/carbon/monkey/punpun,
+/obj/machinery/firealarm{
+	pixel_y = -25
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/starboard)
 "gu" = (
 /obj/effect/turf_decal/atmos/plasma,
 /turf/open/floor/engine/plasma,
@@ -989,6 +1016,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/squid_ink,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/grimy,
 /area/ship/maintenance/fore)
 "jr" = (
@@ -1100,6 +1128,9 @@
 /area/ship/storage)
 "lh" = (
 /obj/structure/chair/sofa/left,
+/obj/machinery/firealarm{
+	pixel_y = 25
+	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/port)
 "lk" = (
@@ -1190,6 +1221,7 @@
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
 	name = "Archives"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "mi" = (
@@ -1213,12 +1245,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood/mahogany,
 /area/ship/storage)
 "mw" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/bronze,
-/area/ship/maintenance/aft)
+/obj/machinery/firealarm{
+	pixel_y = -25
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen/kitchen)
 "mL" = (
 /obj/machinery/stasis{
 	name = "Mana preservation unit"
@@ -1234,6 +1269,9 @@
 /obj/structure/tank_dispenser/oxygen,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 25
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/security/armory)
@@ -1422,7 +1460,12 @@
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
 	name = "Cargo"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/green,
+/area/ship/maintenance/aft)
+"oP" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "oT" = (
 /obj/structure/cable/cyan{
@@ -1475,6 +1518,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
 "pO" = (
@@ -1533,6 +1577,9 @@
 /obj/structure/constructshell,
 /obj/structure/constructshell,
 /obj/structure/constructshell,
+/obj/machinery/firealarm{
+	pixel_y = -25
+	},
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
 "qA" = (
@@ -1790,6 +1837,9 @@
 "ti" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/closet/emcloset/anchored,
+/obj/machinery/firealarm{
+	pixel_y = 25
+	},
 /turf/open/floor/wood/bamboo,
 /area/ship/science)
 "tt" = (
@@ -1808,6 +1858,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen/kitchen)
 "tP" = (
@@ -1867,6 +1918,27 @@
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
+"tZ" = (
+/obj/structure/table/wood/fancy,
+/obj/item/skub{
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/skub{
+	pixel_y = 11
+	},
+/obj/item/skub{
+	pixel_y = 4
+	},
+/obj/machinery/door/window/survival_pod{
+	req_access_txt = "1";
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/maintenance/fore)
 "ua" = (
 /obj/machinery/atmospherics/miner/oxygen{
 	icon = 'icons/obj/items_and_weapons.dmi';
@@ -1877,6 +1949,14 @@
 /turf/open/floor/engine/air{
 	icon_state = "wood-broken6"
 	},
+/area/ship/maintenance/aft)
+"ub" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/machinery/firealarm{
+	pixel_y = 25
+	},
+/turf/open/floor/wood/bamboo,
 /area/ship/maintenance/aft)
 "uc" = (
 /obj/machinery/computer/helm/viewscreen{
@@ -2056,12 +2136,6 @@
 	},
 /turf/open/floor/carpet/red_gold,
 /area/ship/hallway/central)
-"vD" = (
-/obj/structure/closet/crate/bin{
-	pixel_y = 10
-	},
-/turf/open/floor/mineral/silver,
-/area/ship/medical)
 "vE" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -2728,6 +2802,7 @@
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
 	name = "Mana Channeling Chamber"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
 "BV" = (
@@ -3017,6 +3092,15 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/central)
+"DB" = (
+/obj/structure/closet/crate/bin{
+	pixel_y = 10
+	},
+/obj/machinery/firealarm{
+	pixel_y = 25
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical)
 "DD" = (
 /turf/closed/wall/mineral/uranium/safe{
 	desc = "A wall plated with emerald.";
@@ -3058,6 +3142,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
 "Ej" = (
@@ -3133,6 +3218,9 @@
 /obj/item/clothing/suit/wizrobe/marisa,
 /obj/item/clothing/suit/wizrobe/black,
 /obj/item/clothing/suit/wizrobe,
+/obj/machinery/firealarm{
+	pixel_y = -25
+	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "EY" = (
@@ -3159,6 +3247,7 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
 "Fr" = (
@@ -3326,6 +3415,13 @@
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/cargo)
+"Ha" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/firealarm{
+	pixel_y = -25
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
 "Hl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -3528,6 +3624,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
 "Jr" = (
@@ -3809,6 +3906,7 @@
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
 	name = "Archives"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/light,
 /area/ship/crew/library)
 "Lh" = (
@@ -3910,6 +4008,7 @@
 	name = "Mana requillary";
 	req_access_txt = "16"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/port)
 "MM" = (
@@ -3936,6 +4035,12 @@
 	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
+"Ni" = (
+/obj/machinery/firealarm{
+	pixel_y = -25
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/hallway/central)
 "Nn" = (
 /obj/machinery/light{
 	dir = 4
@@ -4027,6 +4132,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
+	},
+/obj/machinery/firealarm{
+	pixel_y = -25
 	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/hallway/fore)
@@ -4297,6 +4405,7 @@
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
 	name = "Wound Nullification Chamber"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood/mahogany,
 /area/ship/medical)
 "RS" = (
@@ -4615,10 +4724,14 @@
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
 	name = "Waiting Room"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/royalblue,
 /area/ship/hallway/fore)
 "UN" = (
 /obj/item/kirbyplants/random,
+/obj/machinery/firealarm{
+	pixel_y = -25
+	},
 /turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "UV" = (
@@ -4662,6 +4775,9 @@
 	dir = 9
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/firealarm{
+	pixel_y = -25
+	},
 /turf/open/floor/wood/bamboo,
 /area/ship/cargo)
 "VE" = (
@@ -4683,6 +4799,7 @@
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
 	name = "Artificer's Chambers"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/aft)
 "VZ" = (
@@ -4853,6 +4970,12 @@
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/science)
+"Yr" = (
+/obj/machinery/firealarm{
+	pixel_y = 25
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/central)
 "YD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5110,7 +5233,7 @@ KW
 VA
 cA
 cA
-Sz
+ub
 CP
 fy
 ER
@@ -5281,7 +5404,7 @@ FF
 Ti
 Bz
 Nn
-mw
+oP
 cA
 cA
 cA
@@ -5325,7 +5448,7 @@ Ei
 vJ
 vJ
 vJ
-fi
+Yr
 fi
 fi
 bC
@@ -5427,7 +5550,7 @@ gJ
 aH
 TW
 Fg
-AF
+gq
 LB
 LB
 MG
@@ -5530,7 +5653,7 @@ nD
 nD
 lJ
 lJ
-lJ
+tZ
 nD
 cg
 Xf
@@ -5547,7 +5670,7 @@ pW
 pW
 pW
 pW
-cg
+Ha
 ya
 ya
 ya
@@ -5633,7 +5756,7 @@ iF
 Ae
 pW
 ya
-vD
+DB
 hd
 GN
 mL
@@ -5992,7 +6115,7 @@ KD
 mi
 zy
 QU
-ny
+mw
 ZU
 QW
 Mq
@@ -6248,7 +6371,7 @@ ZE
 ZE
 ZE
 Ir
-pW
+Ni
 Uo
 Uo
 Uo
@@ -6507,7 +6630,7 @@ Qt
 Qt
 xf
 DD
-LM
+aw
 jz
 bg
 jz

--- a/_maps/shuttles/shiptest/voidcrew/merlin.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/merlin.dmm
@@ -21,7 +21,7 @@
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/starboard)
 "ar" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
@@ -259,7 +259,7 @@
 	},
 /area/ship/maintenance/aft)
 "cF" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 5
 	},
 /obj/structure/cable/cyan{
@@ -345,7 +345,7 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/science)
 "dm" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
 	dir = 4
 	},
 /turf/open/floor/wood/bamboo,
@@ -752,7 +752,7 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
 "hf" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/structure/cable/cyan{
 	icon_state = "1-4"
 	},
@@ -783,7 +783,7 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "hG" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
 	},
@@ -1161,7 +1161,7 @@
 /turf/open/floor/carpet/stellar,
 /area/ship/crew/dorm)
 "lx" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -1424,7 +1424,7 @@
 /turf/open/floor/carpet/red_gold,
 /area/ship/hallway/central)
 "od" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
 	dir = 4
 	},
 /turf/open/floor/bronze,
@@ -1454,7 +1454,6 @@
 /turf/open/floor/bronze,
 /area/ship/security/armory)
 "oL" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
@@ -1467,6 +1466,7 @@
 	name = "Cargo"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/aft)
 "oP" = (
@@ -2921,7 +2921,7 @@
 /turf/open/floor/mineral/diamond,
 /area/ship/maintenance/starboard)
 "BZ" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 9
 	},
 /turf/open/floor/bronze,
@@ -2957,7 +2957,7 @@
 /turf/open/floor/mineral/silver,
 /area/ship/medical)
 "Cs" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
@@ -3144,7 +3144,7 @@
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/central)
 "Dk" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "Ds" = (
@@ -3281,7 +3281,7 @@
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "EU" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
@@ -3428,7 +3428,7 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "FZ" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
 	dir = 4
 	},
 /turf/open/floor/wood/bamboo,
@@ -3443,7 +3443,7 @@
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
 "Gx" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
@@ -3523,7 +3523,7 @@
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "GV" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -3962,7 +3962,7 @@
 /turf/open/floor/wood/mahogany,
 /area/ship/storage)
 "Kx" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 9
 	},
 /turf/open/floor/wood/bamboo,
@@ -3972,7 +3972,7 @@
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen/kitchen)
 "KG" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 6
 	},
 /obj/structure/cable/cyan{
@@ -4066,7 +4066,7 @@
 /turf/open/floor/carpet/stellar,
 /area/ship/crew/dorm)
 "Li" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/wood/bamboo,
 /area/ship/cargo)
 "Lx" = (
@@ -4126,7 +4126,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/ship/hallway/central)
 "My" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
@@ -4180,7 +4180,7 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "Nf" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
 /turf/open/floor/bronze,
@@ -4409,7 +4409,7 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "PL" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
 	},
@@ -4435,7 +4435,7 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/maintenance/aft)
 "Qc" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 10
 	},
 /turf/open/floor/bronze,
@@ -4621,7 +4621,7 @@
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/aft)
 "SH" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
@@ -4664,7 +4664,7 @@
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/port)
 "Tg" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 10
 	},
 /turf/open/floor/wood/bamboo,
@@ -4759,7 +4759,7 @@
 /turf/open/floor/carpet/black,
 /area/ship/storage)
 "TU" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 5
 	},
 /turf/open/floor/bronze,
@@ -4935,7 +4935,6 @@
 /turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "VW" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
@@ -4950,6 +4949,7 @@
 	name = "Artificer's Chambers"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/aft)
 "VZ" = (
@@ -5040,7 +5040,7 @@
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
 "WV" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},

--- a/_maps/shuttles/shiptest/voidcrew/merlin.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/merlin.dmm
@@ -574,6 +574,7 @@
 /area/ship/science)
 "fF" = (
 /obj/effect/decal/cleanable/wrapping,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/fore)
 "fK" = (
@@ -1165,7 +1166,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ship/maintenance/fore)
 "lK" = (
-/obj/machinery/vending/snack/green,
+/obj/machinery/jukebox,
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/starboard)
 "lM" = (
@@ -1215,10 +1216,9 @@
 /turf/open/floor/wood/mahogany,
 /area/ship/storage)
 "mw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood/mahogany,
-/area/ship/hallway/central)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft)
 "mL" = (
 /obj/machinery/stasis{
 	name = "Mana preservation unit"
@@ -1359,9 +1359,17 @@
 "nS" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/scrying,
-/obj/item/upgradescroll,
-/obj/item/upgradescroll,
-/obj/item/upgradescroll,
+/obj/item/upgradescroll{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/upgradescroll{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/upgradescroll{
+	pixel_y = -5
+	},
 /turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "nV" = (
@@ -2048,6 +2056,12 @@
 	},
 /turf/open/floor/carpet/red_gold,
 /area/ship/hallway/central)
+"vD" = (
+/obj/structure/closet/crate/bin{
+	pixel_y = 10
+	},
+/turf/open/floor/mineral/silver,
+/area/ship/medical)
 "vE" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -2220,6 +2234,28 @@
 	},
 /obj/item/book/granter/spell/charge{
 	pixel_x = 5
+	},
+/obj/item/gun/energy/laser/hitscanpistol{
+	icon_state = "deathwand";
+	icon = 'icons/obj/guns/magic.dmi';
+	desc = "A wand used by Wizards who specialize in offensive magic";
+	pixel_x = 5;
+	name = "wand of beams";
+	item_state = "wand";
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi';
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi';
+	fire_sound = 'sound/magic/wandodeath.ogg'
+	},
+/obj/item/gun/energy/laser/hitscanpistol{
+	icon_state = "deathwand";
+	icon = 'icons/obj/guns/magic.dmi';
+	desc = "A wand used by Wizards who specialize in offensive magic";
+	pixel_x = -5;
+	name = "wand of beams";
+	item_state = "wand";
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi';
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi';
+	fire_sound = 'sound/magic/wandodeath.ogg'
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/security/armory)
@@ -3400,6 +3436,11 @@
 /area/ship/crew/canteen/kitchen)
 "IO" = (
 /obj/machinery/airalarm/directional/north,
+/obj/structure/closet/crate/bin{
+	pixel_y = 10;
+	desc = "A place to put used spellbooks. Read responsibly!";
+	name = "spellbook disposal"
+	},
 /turf/open/floor/wood/bamboo,
 /area/ship/security/armory)
 "IQ" = (
@@ -3570,6 +3611,7 @@
 /obj/structure/closet/cabinet,
 /obj/item/clothing/suit/space/hardsuit/wizard,
 /obj/item/clothing/gloves/combat/wizard,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "Kc" = (
@@ -3898,6 +3940,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "Nu" = (
@@ -3982,8 +4025,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
 	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/hallway/fore)
@@ -4742,8 +4785,8 @@
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/starboard)
 "Xf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/central)
@@ -5238,7 +5281,7 @@ FF
 Ti
 Bz
 Nn
-ER
+mw
 cA
 cA
 cA
@@ -5489,7 +5532,7 @@ lJ
 lJ
 lJ
 nD
-mw
+cg
 Xf
 Up
 pW
@@ -5590,7 +5633,7 @@ iF
 Ae
 pW
 ya
-EY
+vD
 hd
 GN
 mL

--- a/_maps/shuttles/shiptest/voidcrew/merlin.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/merlin.dmm
@@ -2896,6 +2896,10 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi';
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	},
+/obj/structure/mirror/magic{
+	pixel_y = -32;
+	pixel_x = null
+	},
 /turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "BW" = (
@@ -4999,6 +5003,10 @@
 /area/ship/bridge)
 "WF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/structure/mirror/magic{
+	pixel_y = -32;
+	pixel_x = null
+	},
 /turf/open/floor/wood/bamboo,
 /area/ship/science)
 "WG" = (

--- a/_maps/shuttles/shiptest/voidcrew/merlin.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/merlin.dmm
@@ -157,16 +157,6 @@
 	},
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/fore)
-"bv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/bookcase/random,
-/turf/open/floor/wood/bamboo,
-/area/ship/crew/library)
 "bx" = (
 /obj/machinery/chem_master{
 	name = "ChemMagic 3000";
@@ -185,12 +175,9 @@
 /area/ship/maintenance/aft)
 "bC" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/turf/closed/wall/mineral/uranium/safe{
-	desc = "A wall plated with emerald.";
-	name = "emerald wall"
-	},
+/turf/open/floor/wood/bamboo,
 /area/ship/maintenance/central)
 "bI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -286,9 +273,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/central)
@@ -309,10 +298,13 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "dg" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
 "dh" = (
@@ -351,7 +343,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
@@ -371,12 +363,6 @@
 /obj/machinery/power/smes{
 	name = "mana storage unit";
 	charge = 2e+006
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -421,11 +407,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/carpet/stellar,
 /area/ship/crew/library)
@@ -467,6 +456,9 @@
 	},
 /obj/item/slimepotion/lavaproof{
 	pixel_x = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/mineral/silver,
 /area/ship/medical)
@@ -543,11 +535,14 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/cargo)
 "fv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
 	},
-/turf/open/floor/wood/bamboo,
-/area/ship/crew/library)
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central)
 "fy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -602,8 +597,11 @@
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/starboard)
 "fX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 2
 	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
@@ -709,13 +707,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
+	dir = 8
 	},
-/obj/machinery/light,
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
 "hf" = (
@@ -728,14 +726,14 @@
 	name = "Blast Doors";
 	pixel_x = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/aft)
@@ -844,6 +842,9 @@
 /obj/structure/fireaxecabinet{
 	pixel_y = 28
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/aft)
 "im" = (
@@ -867,6 +868,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
@@ -989,9 +993,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/light,
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
@@ -1035,9 +1038,6 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/security/armory)
 "ka" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -1112,6 +1112,9 @@
 "ls" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/carpet/stellar,
 /area/ship/crew/dorm)
@@ -1250,17 +1253,18 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/science)
 "nj" = (
+/obj/machinery/computer/helm/viewscreen{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/structure/closet/secure_closet/engineering_welding{
+	anchored = 1
+	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
-/area/ship/maintenance/central)
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft)
 "nx" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/light,
@@ -1332,7 +1336,7 @@
 /turf/open/floor/plating,
 /area/ship/medical)
 "nN" = (
-/obj/structure/cable/cyan{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood/bamboo,
@@ -1460,6 +1464,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
 "pO" = (
@@ -1550,7 +1557,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/carpet/stellar,
 /area/ship/crew/dorm)
@@ -1622,14 +1629,14 @@
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/aft)
 "rv" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
@@ -1691,11 +1698,12 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "so" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
@@ -1740,11 +1748,14 @@
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/fore)
 "sX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library)
+/area/ship/maintenance/central)
 "sY" = (
 /obj/item/circuitboard/machine/rdserver,
 /obj/structure/frame/machine,
@@ -1826,7 +1837,9 @@
 /area/ship/medical)
 "tS" = (
 /obj/machinery/power/terminal,
-/obj/structure/cable/cyan,
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating/catwalk_floor,
 /area/ship/maintenance/central)
 "tW" = (
@@ -1861,21 +1874,11 @@
 	},
 /area/ship/maintenance/aft)
 "uc" = (
-/obj/machinery/computer/helm/viewscreen{
-	dir = 8;
-	pixel_x = 32
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/closet/secure_closet/engineering_welding{
-	anchored = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/bronze,
-/area/ship/maintenance/aft)
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/central)
 "ud" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/wood/ebony,
@@ -1937,7 +1940,7 @@
 	dir = 1
 	},
 /obj/structure/cable/cyan{
-	icon_state = "0-2"
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating/catwalk_floor,
 /area/ship/maintenance/central)
@@ -1980,17 +1983,9 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/maintenance/aft)
 "uR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/wood/mahogany,
-/area/ship/hallway/central)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library)
 "uW" = (
 /obj/machinery/shower{
 	pixel_y = 12;
@@ -2033,11 +2028,14 @@
 /turf/open/floor/mineral/diamond,
 /area/ship/maintenance/starboard)
 "vv" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/aft)
@@ -2209,9 +2207,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "xc" = (
@@ -2308,8 +2303,15 @@
 	},
 /area/ship/medical)
 "yf" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "yl" = (
@@ -2336,6 +2338,12 @@
 	icon_state = "1-8"
 	},
 /obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
 "yw" = (
@@ -2481,6 +2489,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
+	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/hallway/central)
 "zD" = (
@@ -2562,6 +2573,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/carpet/stellar,
 /area/ship/crew/dorm)
 "Av" = (
@@ -2632,6 +2646,10 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
 "Bh" = (
@@ -2652,14 +2670,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/ship/crew/dorm/dormtwo)
 "Bz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 2
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/aft)
@@ -2749,15 +2764,17 @@
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "Cu" = (
-/obj/structure/table/wood/fancy/green,
-/obj/item/book/granter/spell/cards{
-	pixel_x = -5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
 	},
-/obj/item/book/granter/spell/cards{
-	pixel_x = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
 	},
-/turf/open/floor/wood/bamboo,
-/area/ship/security/armory)
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central)
 "Cx" = (
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/table/wood/fancy/royalblue,
@@ -2835,12 +2852,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-4"
-	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
 "CP" = (
@@ -2851,6 +2862,7 @@
 /obj/item/book/granter/spell/fireball{
 	pixel_x = -5
 	},
+/obj/item/book/granter/spell/cards,
 /turf/open/floor/wood/bamboo,
 /area/ship/security/armory)
 "CT" = (
@@ -2909,14 +2921,14 @@
 /turf/open/floor/carpet/royalblack,
 /area/ship/crew/dorm/dormtwo)
 "Dg" = (
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
@@ -3030,30 +3042,27 @@
 /turf/open/floor/carpet/stellar,
 /area/ship/crew/library)
 "ED" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
 "EG" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/wood/bamboo,
-/area/ship/crew/library)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft)
 "EI" = (
 /obj/machinery/selling_pad,
 /obj/machinery/light{
@@ -3268,9 +3277,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "GV" = (
@@ -3413,11 +3419,8 @@
 /turf/open/floor/carpet/red_gold,
 /area/ship/hallway/central)
 "Ja" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
@@ -3458,6 +3461,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
 	},
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/central)
@@ -3768,9 +3774,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /turf/open/floor/carpet/stellar,
 /area/ship/crew/dorm)
 "Li" = (
@@ -3843,9 +3846,8 @@
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
 "ME" = (
-/obj/machinery/airalarm/directional/west,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/maintenance/central)
@@ -3894,30 +3896,28 @@
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "Nn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft)
+"Nu" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	anchored = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
-"Nu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 2
-	},
-/turf/open/floor/wood/mahogany,
-/area/ship/hallway/central)
 "Ny" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/central)
 "NC" = (
@@ -3962,9 +3962,11 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/hallway/central)
@@ -3987,12 +3989,17 @@
 /turf/open/floor/carpet/royalblue,
 /area/ship/hallway/fore)
 "Ou" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
-/obj/structure/bookcase/random,
-/turf/open/floor/wood/bamboo,
-/area/ship/crew/library)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft)
 "Ov" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
@@ -4008,12 +4015,6 @@
 	},
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
-"OQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/wood/mahogany,
-/area/ship/hallway/central)
 "OX" = (
 /obj/structure/window/plasma/reinforced/spawner/north{
 	color = "#008000"
@@ -4030,11 +4031,15 @@
 /turf/open/floor/mineral/silver,
 /area/ship/medical)
 "Pj" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/power/smes{
+	name = "mana storage unit";
+	charge = 2e+006
 	},
-/turf/open/floor/bronze,
-/area/ship/maintenance/aft)
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/central)
 "Ps" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/gun/energy/laser/captain/scattershot{
@@ -4172,9 +4177,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
@@ -4273,6 +4276,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/aft)
 "Sq" = (
@@ -4302,7 +4308,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/aft)
@@ -4381,7 +4387,10 @@
 	dir = 1;
 	on = 1
 	},
-/obj/structure/cable/cyan{
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/green,
@@ -4504,6 +4513,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
 "Uo" = (
@@ -4513,12 +4525,6 @@
 	},
 /area/ship/security/armory)
 "Up" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/central)
@@ -4540,6 +4546,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
@@ -4727,11 +4736,8 @@
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/starboard)
 "Xf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
 	},
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/central)
@@ -4814,24 +4820,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 2
 	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
 "YH" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "YO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/airalarm/directional/west,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/crew/library)
+/area/ship/maintenance/central)
 "YR" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
@@ -4839,20 +4844,24 @@
 /turf/open/floor/engine/plasma,
 /area/ship/maintenance/aft)
 "Ze" = (
-/obj/structure/closet/secure_closet/engineering_personal{
-	anchored = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
 	},
-/turf/open/floor/bronze,
-/area/ship/maintenance/aft)
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central)
 "Zi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/carpet/stellar,
 /area/ship/crew/library)
@@ -4975,7 +4984,7 @@ ar
 ar
 oL
 hf
-YH
+Dk
 Dk
 TU
 cA
@@ -5017,7 +5026,7 @@ tt
 cA
 cA
 il
-fX
+ER
 ER
 Nf
 cA
@@ -5058,9 +5067,9 @@ VA
 cA
 cA
 Sz
-Sk
-Pj
+EG
 fy
+ER
 Nf
 cA
 cA
@@ -5101,7 +5110,7 @@ cA
 xc
 OG
 Sk
-fX
+ER
 ER
 Qc
 My
@@ -5142,19 +5151,19 @@ cA
 Sz
 FJ
 OG
-Sk
+Ou
 fX
-ER
-ER
-ER
-ER
-ER
-ER
-ER
-ER
-ER
-ER
-rj
+bB
+CX
+CX
+CX
+CX
+CX
+CX
+Dw
+Dw
+bB
+YH
 vS
 Kh
 eV
@@ -5186,16 +5195,16 @@ PR
 OG
 vv
 Ja
-bB
-CX
-CX
-CX
-CX
-CX
-CX
-Dw
-Dw
-bB
+yA
+hQ
+Kk
+Tx
+nj
+Nu
+bf
+jb
+hP
+yA
 yf
 Tl
 Mc
@@ -5228,16 +5237,16 @@ FF
 Ti
 Bz
 Nn
-yA
-hQ
-Kk
-Tx
-uc
-Ze
-bf
-jb
-hP
-yA
+ER
+cA
+cA
+cA
+cA
+cA
+cA
+cA
+cA
+ER
 GU
 SD
 Kh
@@ -5272,12 +5281,12 @@ Ei
 vJ
 vJ
 vJ
-vJ
-vJ
+fi
+fi
+fi
 bC
-bC
-vJ
-vJ
+nN
+YO
 vJ
 vJ
 vJ
@@ -5311,16 +5320,16 @@ wN
 CV
 Eo
 CM
-nN
-nN
-nN
-nN
+fi
+fi
+uc
+fi
 tS
-dU
+Pj
 dU
 uJ
 ME
-nN
+sX
 nN
 nN
 jr
@@ -5357,12 +5366,12 @@ YG
 Uh
 YG
 YG
-YG
+fv
 ka
-nj
 kJ
-kJ
-kJ
+Ze
+Cu
+Cu
 ir
 Uy
 Dg
@@ -5482,10 +5491,10 @@ nD
 mw
 Xf
 Up
-Nu
-Nu
+pW
+pW
 cS
-OQ
+pW
 pW
 pW
 pW
@@ -5527,7 +5536,7 @@ Ny
 zz
 Jj
 QP
-uR
+rg
 Mm
 rg
 Mm
@@ -6163,9 +6172,9 @@ qf
 xZ
 DD
 rv
-Ou
-Ou
-EG
+DK
+DK
+YD
 DK
 yw
 MG
@@ -6204,7 +6213,7 @@ Uo
 DD
 DD
 DD
-YO
+rv
 DK
 DK
 YD
@@ -6245,10 +6254,10 @@ GF
 pU
 DD
 sY
-zI
+uR
 so
-bv
-bv
+DK
+DK
 he
 DD
 DD
@@ -6289,9 +6298,9 @@ DD
 DK
 gb
 dg
-sX
 zI
-fv
+zI
+YD
 yw
 MG
 MG
@@ -6575,7 +6584,7 @@ Tk
 Tk
 TB
 Uo
-Cu
+CP
 CP
 CY
 ZR

--- a/_maps/shuttles/shiptest/voidcrew/merlin.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/merlin.dmm
@@ -191,9 +191,7 @@
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "bI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -366,9 +364,7 @@
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "dU" = (
 /obj/machinery/power/smes{
 	name = "mana storage unit";
@@ -384,9 +380,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/mineral/diamond,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "dV" = (
 /obj/machinery/rnd/production/circuit_imprinter{
 	name = "circuitboard conjurer"
@@ -549,9 +543,7 @@
 /area/ship/maintenance/aft)
 "fi" = (
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "fj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -888,9 +880,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "iF" = (
 /obj/machinery/light{
 	dir = 4
@@ -987,9 +977,7 @@
 /obj/item/clothing/head/wizard/magus,
 /obj/item/clothing/head/wizard/magus,
 /turf/open/floor/wood/yew,
-/area/ship/bridge{
-	name = "Conducting Chamber"
-	})
+/area/ship/bridge)
 "jk" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
@@ -1014,9 +1002,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "jy" = (
 /turf/open/floor/engine,
 /area/ship/cargo)
@@ -1070,9 +1056,7 @@
 	dir = 6
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "kc" = (
 /obj/machinery/power/rtg/advanced{
 	name = "mana field condenser"
@@ -1104,9 +1088,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "kS" = (
 /turf/open/floor/carpet/stellar,
 /area/ship/crew/dorm)
@@ -1307,9 +1289,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "nx" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/light,
@@ -1385,9 +1365,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "nO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1515,9 +1493,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "pO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1900,9 +1876,7 @@
 /obj/machinery/power/terminal,
 /obj/structure/cable/cyan,
 /turf/open/floor/plating/catwalk_floor,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "tW" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/item/research_notes/loot/genius,
@@ -1999,9 +1973,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating/catwalk_floor,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "uP" = (
 /obj/machinery/light{
 	dir = 8
@@ -2125,9 +2097,7 @@
 	desc = "A wall plated with emerald.";
 	name = "emerald wall"
 	},
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "vL" = (
 /obj/machinery/sleeper{
 	icon_state = "sleeper_clockwork-open";
@@ -2145,9 +2115,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "vS" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -2487,9 +2455,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "zh" = (
 /turf/open/floor/carpet/purple,
 /area/ship/bridge)
@@ -2676,14 +2642,6 @@
 	},
 /turf/open/floor/carpet/red_gold,
 /area/ship/hallway/central)
-"AV" = (
-/turf/closed/wall/mineral/uranium/safe{
-	desc = "A wall plated with emerald.";
-	name = "emerald wall"
-	},
-/area/ship/maintenance/starboard{
-	name = "Mana Requillary"
-	})
 "AY" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4{
 	dir = 1;
@@ -2759,9 +2717,7 @@
 	name = "Mana Channeling Chamber"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "BV" = (
 /obj/item/book/granter/spell/charge,
 /obj/structure/table/wood/fancy/green,
@@ -2934,9 +2890,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "CP" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/book/granter/spell/fireball{
@@ -2951,9 +2905,7 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "CU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -3015,9 +2967,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "Di" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3122,9 +3072,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "Ej" = (
 /obj/structure/window/plasma/reinforced/spawner{
 	color = "#008000"
@@ -3153,9 +3101,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "EG" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3962,9 +3908,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "MG" = (
 /turf/template_noop,
 /area/template_noop)
@@ -4369,9 +4313,7 @@
 	name = "Wound Nullification Chamber"
 	},
 /turf/open/floor/wood/mahogany,
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
+/area/ship/medical)
 "RS" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -4549,14 +4491,6 @@
 	},
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/fore)
-"TE" = (
-/turf/closed/wall/mineral/uranium/safe{
-	desc = "A wall plated with emerald.";
-	name = "emerald wall"
-	},
-/area/ship/medical{
-	name = "Wound Nullification Chamber"
-	})
 "TK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4638,9 +4572,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "Uf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -4652,9 +4584,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "Uo" = (
 /turf/closed/wall/mineral/uranium/safe{
 	desc = "A wall plated with emerald.";
@@ -4691,9 +4621,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "UB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4913,9 +4841,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "XS" = (
 /obj/machinery/computer/selling_pad_control{
 	dir = 8
@@ -4968,9 +4894,7 @@
 	dir = 2
 	},
 /turf/open/floor/carpet/green,
-/area/ship/maintenance/central{
-	name = "Mana Channeling Chamber"
-	})
+/area/ship/maintenance/central)
 "YH" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -5004,9 +4928,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/stellar,
-/area/ship/crew/library{
-	name = "Archives"
-	})
+/area/ship/crew/library)
 "Zm" = (
 /obj/structure/window/plasma/reinforced/fulltile{
 	color = "#008000"
@@ -5354,7 +5276,7 @@ Jc
 AY
 iK
 cA
-AV
+LB
 LB
 LB
 LB
@@ -5730,7 +5652,7 @@ pW
 iF
 Ae
 pW
-TE
+ya
 EY
 hd
 qT

--- a/_maps/shuttles/shiptest/voidcrew/merlin.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/merlin.dmm
@@ -1102,8 +1102,8 @@
 /turf/open/floor/mineral/diamond,
 /area/ship/maintenance/starboard)
 "kv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/carpet/stellar,
 /area/ship/crew/dorm)
@@ -1666,6 +1666,9 @@
 /obj/item/storage/box/matches,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
@@ -3245,11 +3248,11 @@
 	},
 /area/ship/maintenance/port)
 "EB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/turf/open/floor/carpet/stellar,
-/area/ship/crew/library)
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
 "ED" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 2
@@ -3887,10 +3890,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
 "Kj" = (
@@ -3987,7 +3990,7 @@
 /turf/open/floor/carpet/green,
 /area/ship/cargo)
 "KH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/wood/bamboo,
@@ -4086,8 +4089,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
@@ -4522,12 +4525,6 @@
 	},
 /turf/open/floor/wood/mahogany,
 /area/ship/storage)
-"RK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/carpet/orange,
-/area/ship/security/armory)
 "RN" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/cyan{
@@ -6738,12 +6735,12 @@ TK
 Uo
 Ps
 oC
-RK
+Qt
 Qt
 IX
 DD
 Ki
-EB
+jz
 jz
 jz
 tY
@@ -6993,7 +6990,7 @@ Jm
 Kp
 FO
 Ts
-FO
+EB
 XH
 FO
 FO

--- a/_maps/shuttles/shiptest/voidcrew/merlin.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/merlin.dmm
@@ -157,6 +157,15 @@
 	},
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/fore)
+"bv" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft)
 "bx" = (
 /obj/machinery/chem_master{
 	name = "ChemMagic 3000";
@@ -535,14 +544,9 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/cargo)
 "fv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 2
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet/green,
-/area/ship/maintenance/central)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library)
 "fy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -1253,18 +1257,14 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/science)
 "nj" = (
-/obj/machinery/computer/helm/viewscreen{
-	dir = 8;
-	pixel_x = 32
-	},
-/obj/structure/closet/secure_closet/engineering_welding{
-	anchored = 1
+/obj/machinery/light{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/bronze,
-/area/ship/maintenance/aft)
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/central)
 "nx" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/light,
@@ -1630,16 +1630,16 @@
 /area/ship/maintenance/aft)
 "rv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 8
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
-/turf/open/floor/wood/bamboo,
-/area/ship/crew/library)
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central)
 "rA" = (
 /obj/machinery/computer/helm,
 /obj/machinery/light{
@@ -1750,9 +1750,6 @@
 "sX" = (
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/maintenance/central)
@@ -1874,11 +1871,18 @@
 	},
 /area/ship/maintenance/aft)
 "uc" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/computer/helm/viewscreen{
+	dir = 8;
+	pixel_x = 32
 	},
-/turf/open/floor/wood/bamboo,
-/area/ship/maintenance/central)
+/obj/structure/closet/secure_closet/engineering_welding{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft)
 "ud" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/wood/ebony,
@@ -1982,10 +1986,6 @@
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/maintenance/aft)
-"uR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood/bamboo,
-/area/ship/crew/library)
 "uW" = (
 /obj/machinery/shower{
 	pixel_y = 12;
@@ -2764,17 +2764,16 @@
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "Cu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 2
+/obj/structure/table/wood/fancy/green,
+/obj/item/book/granter/spell/fireball{
+	pixel_x = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 1
+/obj/item/book/granter/spell/fireball{
+	pixel_x = -5
 	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet/green,
-/area/ship/maintenance/central)
+/obj/item/book/granter/spell/cards,
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory)
 "Cx" = (
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/table/wood/fancy/royalblue,
@@ -2831,7 +2830,8 @@
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
 	lefthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi';
 	desc = "A powerful offensive staff that can fire blasts of eldrich energy that pass through walls.";
-	name = "Gamma Staff"
+	name = "Gamma Staff";
+	pin = /obj/item/firing_pin
 	},
 /turf/open/floor/carpet/black,
 /area/ship/storage)
@@ -2855,16 +2855,17 @@
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
 "CP" = (
-/obj/structure/table/wood/fancy/green,
-/obj/item/book/granter/spell/fireball{
-	pixel_x = 5
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
-/obj/item/book/granter/spell/fireball{
-	pixel_x = -5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/item/book/granter/spell/cards,
-/turf/open/floor/wood/bamboo,
-/area/ship/security/armory)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/aft)
 "CT" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
@@ -3052,17 +3053,15 @@
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
 "EG" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
+/obj/machinery/power/smes{
+	name = "mana storage unit";
+	charge = 2e+006
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
-/area/ship/maintenance/aft)
+/turf/open/floor/mineral/diamond,
+/area/ship/maintenance/central)
 "EI" = (
 /obj/machinery/selling_pad,
 /obj/machinery/light{
@@ -3902,14 +3901,14 @@
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "Nu" = (
-/obj/structure/closet/secure_closet/engineering_personal{
-	anchored = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
 	},
-/turf/open/floor/bronze,
-/area/ship/maintenance/aft)
+/turf/open/floor/carpet/green,
+/area/ship/maintenance/central)
 "Ny" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4015,6 +4014,11 @@
 	},
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
+"OQ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/bronze,
+/area/ship/maintenance/aft)
 "OX" = (
 /obj/structure/window/plasma/reinforced/spawner/north{
 	color = "#008000"
@@ -4031,14 +4035,16 @@
 /turf/open/floor/mineral/silver,
 /area/ship/medical)
 "Pj" = (
-/obj/machinery/power/smes{
-	name = "mana storage unit";
-	charge = 2e+006
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 2
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
 	},
-/turf/open/floor/mineral/diamond,
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
 "Ps" = (
 /obj/structure/table/wood/fancy/green,
@@ -4826,35 +4832,30 @@
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/central)
 "YH" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/bronze,
-/area/ship/maintenance/aft)
-"YO" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/maintenance/central)
+"YO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/library)
 "YR" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
 /turf/open/floor/engine/plasma,
 /area/ship/maintenance/aft)
-"Ze" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/turf/open/floor/carpet/green,
-/area/ship/maintenance/central)
 "Zi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5067,7 +5068,7 @@ VA
 cA
 cA
 Sz
-EG
+CP
 fy
 ER
 Nf
@@ -5163,7 +5164,7 @@ CX
 Dw
 Dw
 bB
-YH
+OQ
 vS
 Kh
 eV
@@ -5199,8 +5200,8 @@ yA
 hQ
 Kk
 Tx
-nj
-Nu
+uc
+bv
 bf
 jb
 hP
@@ -5286,7 +5287,7 @@ fi
 fi
 bC
 nN
-YO
+YH
 vJ
 vJ
 vJ
@@ -5322,14 +5323,14 @@ Eo
 CM
 fi
 fi
-uc
+sX
 fi
 tS
-Pj
+EG
 dU
 uJ
 ME
-sX
+nj
 nN
 nN
 jr
@@ -5366,12 +5367,12 @@ YG
 Uh
 YG
 YG
-fv
+Nu
 ka
 kJ
-Ze
-Cu
-Cu
+Pj
+rv
+rv
 ir
 Uy
 Dg
@@ -6171,7 +6172,7 @@ qf
 qf
 xZ
 DD
-rv
+YO
 DK
 DK
 YD
@@ -6213,7 +6214,7 @@ Uo
 DD
 DD
 DD
-rv
+YO
 DK
 DK
 YD
@@ -6254,7 +6255,7 @@ GF
 pU
 DD
 sY
-uR
+fv
 so
 DK
 DK
@@ -6419,7 +6420,7 @@ Ps
 oC
 RK
 Qt
-oC
+xf
 DD
 Ki
 EB
@@ -6584,8 +6585,8 @@ Tk
 Tk
 TB
 Uo
-CP
-CP
+Cu
+Cu
 CY
 ZR
 ZR

--- a/_maps/shuttles/shiptest/voidcrew/merlin.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/merlin.dmm
@@ -154,6 +154,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
 /turf/open/floor/bronze,
 /area/ship/maintenance/aft)
 "bg" = (
@@ -936,6 +939,9 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
 /turf/open/floor/mineral/diamond,
 /area/ship/maintenance/starboard)
 "iR" = (
@@ -1489,6 +1495,12 @@
 /obj/machinery/grill,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen/kitchen)
+"pl" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/maintenance/central)
 "ps" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1573,6 +1585,13 @@
 	},
 /turf/open/floor/mineral/diamond,
 /area/ship/maintenance/starboard)
+"qr" = (
+/obj/structure/sign/poster/official/random,
+/turf/closed/wall/mineral/uranium/safe{
+	desc = "A wall plated with emerald.";
+	name = "emerald wall"
+	},
+/area/ship/bridge)
 "qw" = (
 /obj/structure/constructshell,
 /obj/structure/constructshell,
@@ -1645,6 +1664,9 @@
 /obj/structure/table/wood,
 /obj/item/candle/infinite,
 /obj/item/storage/box/matches,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/library)
 "rd" = (
@@ -1848,6 +1870,9 @@
 /area/ship/cargo)
 "tJ" = (
 /obj/machinery/vending/snack/green,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/port)
 "tL" = (
@@ -2299,6 +2324,9 @@
 /area/ship/crew/dorm)
 "xc" = (
 /obj/machinery/mineral/equipment_vendor,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
 /turf/open/floor/wood/bamboo,
 /area/ship/maintenance/aft)
 "xf" = (
@@ -2330,6 +2358,16 @@
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi';
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi';
 	fire_sound = 'sound/magic/wandodeath.ogg'
+	},
+/obj/item/melee/transforming/energy/sword/saber/pirate/green{
+	pixel_x = -5;
+	name = "mana cutlass";
+	desc = "Alakazam matey."
+	},
+/obj/item/melee/transforming/energy/sword/saber/pirate/green{
+	pixel_x = 5;
+	name = "mana cutlass";
+	desc = "Alakazam matey."
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/security/armory)
@@ -2381,6 +2419,48 @@
 	},
 /turf/open/floor/carpet/green,
 /area/ship/maintenance/port)
+"xF" = (
+/obj/structure/table/wood/fancy/green,
+/obj/item/book/granter/spell/charge{
+	pixel_x = -5
+	},
+/obj/item/book/granter/spell/charge{
+	pixel_x = 5
+	},
+/obj/item/gun/energy/laser/hitscanpistol{
+	icon_state = "deathwand";
+	icon = 'icons/obj/guns/magic.dmi';
+	desc = "A wand used by Wizards who specialize in offensive magic";
+	pixel_x = 5;
+	name = "wand of beams";
+	item_state = "wand";
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi';
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi';
+	fire_sound = 'sound/magic/wandodeath.ogg'
+	},
+/obj/item/gun/energy/laser/hitscanpistol{
+	icon_state = "deathwand";
+	icon = 'icons/obj/guns/magic.dmi';
+	desc = "A wand used by Wizards who specialize in offensive magic";
+	pixel_x = -5;
+	name = "wand of beams";
+	item_state = "wand";
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi';
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi';
+	fire_sound = 'sound/magic/wandodeath.ogg'
+	},
+/obj/item/melee/transforming/energy/sword/saber/pirate/green{
+	pixel_x = 5;
+	name = "mana cutlass";
+	desc = "Alakazam matey."
+	},
+/obj/item/melee/transforming/energy/sword/saber/pirate/green{
+	pixel_x = -5;
+	name = "mana cutlass";
+	desc = "Alakazam matey."
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory)
 "xI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2831,6 +2911,9 @@
 /obj/structure/window/plasma/reinforced/spawner/east{
 	color = "#008000"
 	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
 /turf/open/floor/mineral/diamond,
 /area/ship/maintenance/starboard)
 "BZ" = (
@@ -3221,6 +3304,23 @@
 /obj/machinery/firealarm{
 	pixel_y = -25
 	},
+/obj/item/storage/backpack/holding{
+	icon_state = "ert_janitor";
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/storage/backpack/holding{
+	icon_state = "ert_janitor";
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/storage/backpack/holding{
+	icon_state = "ert_janitor";
+	pixel_y = 5
+	},
+/obj/item/storage/backpack/holding{
+	icon_state = "ert_janitor"
+	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "EY" = (
@@ -3383,6 +3483,21 @@
 /obj/item/clothing/suit/wizrobe/black,
 /obj/item/clothing/suit/wizrobe,
 /obj/machinery/airalarm/directional/south,
+/obj/item/storage/backpack/holding{
+	icon_state = "ert_janitor";
+	pixel_x = -5
+	},
+/obj/item/storage/backpack/holding{
+	icon_state = "ert_janitor"
+	},
+/obj/item/storage/backpack/holding{
+	icon_state = "ert_janitor";
+	pixel_x = 5
+	},
+/obj/item/storage/backpack/holding{
+	icon_state = "ert_janitor";
+	pixel_y = 5
+	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "GN" = (
@@ -3554,6 +3669,27 @@
 	},
 /turf/open/floor/carpet/red_gold,
 /area/ship/hallway/central)
+"IX" = (
+/obj/structure/table/wood/fancy/green,
+/obj/item/book/granter/spell/charge{
+	pixel_x = -5
+	},
+/obj/item/book/granter/spell/charge{
+	pixel_x = 5
+	},
+/obj/item/clothing/glasses/hud/security/night{
+	icon_state = "trickblindfold";
+	name = "enchanted blindfold";
+	desc = "An enchantment provides an advanced heads-up display that provides ID data and vision in complete darkness.";
+	pixel_y = -5
+	},
+/obj/item/clothing/glasses/hud/security/night{
+	icon_state = "trickblindfold";
+	name = "enchanted blindfold";
+	desc = "An enchantment provides an advanced heads-up display that provides ID data and vision in complete darkness."
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/security/armory)
 "Ja" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3709,6 +3845,16 @@
 /obj/item/clothing/suit/space/hardsuit/wizard,
 /obj/item/clothing/gloves/combat/wizard,
 /obj/item/tank/internals/oxygen,
+/obj/item/storage/backpack/holding{
+	icon_state = "ert_janitor";
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/hud/security/night{
+	icon_state = "trickblindfold";
+	name = "enchanted blindfold";
+	desc = "An enchantment provides an advanced heads-up display that provides ID data and vision in complete darkness."
+	},
 /turf/open/floor/wood/yew,
 /area/ship/crew/dorm/dormtwo)
 "Kc" = (
@@ -5571,14 +5717,14 @@ Ut
 nL
 Eo
 vN
-fi
+pl
 XM
 fi
 fi
 fi
 Uc
 zc
-fi
+pl
 fi
 fi
 XM
@@ -6586,7 +6732,7 @@ Ps
 oC
 RK
 Qt
-xf
+IX
 DD
 Ki
 EB
@@ -6670,7 +6816,7 @@ Uo
 IO
 Qt
 Qt
-xf
+xF
 DD
 TY
 Tj
@@ -7000,7 +7146,7 @@ MG
 MG
 MG
 oz
-oz
+qr
 Jo
 oz
 oz
@@ -7051,7 +7197,7 @@ oz
 oz
 aE
 oz
-oz
+qr
 oz
 MG
 MG


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


![2022 10 05-20 49 09](https://user-images.githubusercontent.com/19318747/194189324-ea8ed04a-85a6-4526-980b-731783e8abec.png)



Adds the Merlin-class Power Projector, the most expensive ship. Extremely powerful starting loadout, but it starts KOS (like the other wizard ships), and it is limited to 1 per round. 

specs:
Price of 2,500 voidcoins
Best with a crew of 10 - 16
Extensive armory with a variety of spellbooks and re-sprited guns
Fully stocked medbay
Fully stocked engineering
R&D
Cargo area with launchpad
Massive powerplant
Secure vault area, and powerful artifacts within
Pet chaos magicarp
3x soul shards and empty shells for them
Large kitchen for banquets
Greed's slot machine
A few silly things
2x shoilets
An insane amount of re-named and re-described items
A jukebox and 2 monkeys!!!!!

currently relies on jobs introduced in #484 

## Why It's Good For The Game

I feel like the current wizard ship, the Lamia, is underutilized due to being shit and overpriced. I also feel like it needs companion wizard ships. This PR is the last of a few that are aimed to make the Wizard Federation a little more represented and add some high-priced ships that are actually worth buying.
## Changelog
:cl:
add: KOS Merlin-class Power Projector
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
