### PR TITLE
Temporarily makes password protection free to reduce issues with griefing somewhat

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -379,7 +379,7 @@
 		var/password = ""
 		var/total_cost = template.cost
 		if (!template.disable_passwords)
-			var/password_cost = template.get_password_cost()
+			var/password_cost = 0// template.get_password_cost() temporary edit for free password due to griefers. If you see this on the master branch someone did a bad.
 			// Prompt for password purchasing
 			var/password_choice = tgui_alert(src, "Enable password protection for [password_cost] voidcoins", "Password Protection", list("Yes", "No"))
 			if(password_choice == null)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Right now we've got griefing happening during the hours when admins aren't on. We can't really do much about this, aside from getting more admins, and we especially can't do anything about it on the code side. But making password protection temporarily free should reduce the severity of the issue
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Someone merged something they shouldn't have
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
