### PR TITLE
Homestead-class Destiny Manifestation Craft

### DIFF
--- a/_maps/configs/NEU_Homestead.json
+++ b/_maps/configs/NEU_Homestead.json
@@ -1,0 +1,31 @@
+{
+	"map_name": "Homestead-class Destiny Manifestation Craft",
+	"map_short_name": "Homestead-class",
+	"prefix": "NEU",
+	"map_path": "_maps/shuttles/shiptest/voidcrew/Homestead.dmm",
+	"map_id": "Homestead",
+	"job_slots": {
+		"Mayor": {
+			"outfit": "/datum/outfit/job/captain",
+			"officer": true,
+			"slots": 1
+		},
+		"Frontier Medic": {
+			"outfit": "/datum/outfit/job/doctor",
+			"slots": 2
+		},
+		"Architect": {
+			"outfit": "/datum/outfit/job/engineer",
+			"slots": 4
+		},
+		"Settlement Security": {
+			"outfit": "/datum/outfit/job/security",
+			"slots": 4
+		},
+		"Settler": {
+			"outfit": "/datum/outfit/job/assistant",
+			"slots": 8
+		}
+	},
+	"cost": 900
+}

--- a/_maps/shuttles/shiptest/voidcrew/Homestead.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/Homestead.dmm
@@ -1,0 +1,4988 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ad" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"ai" = (
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"al" = (
+/obj/structure/closet/crate/engineering,
+/obj/item/storage/backpack/duffelbag/mining_conscript,
+/obj/item/storage/backpack/duffelbag/mining_conscript,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"aY" = (
+/turf/open/floor/engine/air,
+/area/ship/crew/canteen)
+"bm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/crew/canteen/kitchen)
+"bo" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ship/external)
+"bv" = (
+/obj/machinery/airalarm/directional/south,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"bB" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/maintenance/central)
+"bF" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/maintenance/central)
+"bL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"bS" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/power/apc/auto_name/south,
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo)
+"ce" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/medical_kiosk,
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/ship/medical)
+"cr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo)
+"cw" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"cz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"cC" = (
+/obj/machinery/vending/cola/pwr_game,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"cE" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"cF" = (
+/obj/machinery/light,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"cH" = (
+/obj/structure/dresser,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"cR" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating,
+/area/ship/external)
+"cU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/crew/canteen/kitchen)
+"cZ" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ship/external)
+"dg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"dt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"dx" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/fans/tiny,
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo)
+"dI" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"dL" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"dN" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"dW" = (
+/obj/structure/table/wood,
+/obj/machinery/recharger,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"eg" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/wrench/medical,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"eu" = (
+/obj/machinery/computer/telecomms/monitor{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"ex" = (
+/obj/machinery/computer/helm{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"eS" = (
+/obj/machinery/mineral/equipment_vendor,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"eT" = (
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"eU" = (
+/obj/machinery/light,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/crew/canteen/kitchen)
+"eY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/mecha_part_fabricator,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"fb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/crew/canteen/kitchen)
+"fg" = (
+/obj/machinery/ore_silo,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/engine,
+/area/ship/storage)
+"fh" = (
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen/kitchen)
+"fr" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating,
+/area/ship/external)
+"fs" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"fI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"gb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"gs" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo)
+"gE" = (
+/obj/structure/closet/crate,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/ambrosia/deus,
+/obj/item/seeds/ambrosia/deus,
+/obj/item/seeds/tobacco/space,
+/obj/item/seeds/tobacco/space,
+/obj/item/seeds/tomato/killer,
+/obj/item/seeds/tomato/killer,
+/obj/item/seeds/wheat/meat,
+/obj/item/seeds/wheat/meat,
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo)
+"gK" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/ship/external)
+"gL" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4,
+/turf/open/floor/plating,
+/area/ship/external)
+"gQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/crew/canteen/kitchen)
+"gS" = (
+/obj/effect/turf_decal/atmos/air,
+/turf/open/floor/engine/air,
+/area/ship/crew/canteen)
+"hr" = (
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/external)
+"ht" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/fireaxecabinet{
+	pixel_y = 27
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"hC" = (
+/obj/structure/lattice,
+/turf/closed/wall/mineral/wood/nonmetal,
+/area/ship/medical)
+"iw" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = homesteadkitchen
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen/kitchen)
+"iy" = (
+/obj/machinery/computer/telecomms/server{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"iz" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"iI" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"iK" = (
+/obj/structure/catwalk,
+/turf/open/floor/plating,
+/area/ship/external)
+"iQ" = (
+/obj/structure/sign/poster/contraband/steppyflag{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"iX" = (
+/obj/structure/lattice,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/ship/external)
+"jk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/mineral/wood/nonmetal,
+/area/ship/maintenance/central)
+"js" = (
+/obj/machinery/power/solar_control{
+	dir = 4
+	},
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
+/area/ship/external)
+"jE" = (
+/obj/machinery/suit_storage_unit/ert/security,
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"jV" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"kd" = (
+/obj/item/reagent_containers/food/snacks/hotdog,
+/turf/open/floor/plating/dirt{
+	desc = "Upon closer examination, it's still dirt."1
+	},
+/area/ship/external)
+"kj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"kk" = (
+/turf/open/floor/engine,
+/area/ship/storage)
+"kp" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"kT" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/ship/external)
+"le" = (
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo)
+"lh" = (
+/obj/structure/chair/wood,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"lq" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"lr" = (
+/obj/machinery/atmospherics/components/binary/pump/layer2{
+	on = 1
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"lC" = (
+/obj/machinery/suit_storage_unit/ert/security,
+/turf/open/floor/engine,
+/area/ship/storage)
+"lI" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen/kitchen)
+"lR" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating,
+/area/ship/external)
+"lU" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"lY" = (
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/power/apc/auto_name/south,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"mg" = (
+/turf/closed/wall/mineral/wood/nonmetal,
+/area/ship/medical)
+"mm" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen/kitchen)
+"mw" = (
+/obj/structure/catwalk,
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/ship/external)
+"mz" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/ship/external)
+"mA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"mQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"mT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"nE" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ship/external)
+"nJ" = (
+/obj/machinery/computer/operating,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
+	},
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/ship/medical)
+"nY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"oc" = (
+/obj/machinery/telecomms/server/presets/common/birdstation,
+/obj/item/multitool,
+/turf/open/floor/circuit/airless,
+/area/ship/engineering/communications)
+"oh" = (
+/obj/machinery/computer/apc_control{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"or" = (
+/turf/closed/wall/mineral/wood/nonmetal,
+/area/ship/engineering/communications)
+"oy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo)
+"oB" = (
+/obj/machinery/light,
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"oD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"oV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"oZ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ship/storage)
+"pp" = (
+/obj/machinery/vending/hydronutrients,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
+"pr" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/ship/medical)
+"pF" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"pJ" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"qd" = (
+/obj/machinery/computer/helm/viewscreen{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"qf" = (
+/obj/machinery/icecream_vat,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/crew/canteen/kitchen)
+"qk" = (
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/external)
+"qz" = (
+/obj/effect/turf_decal/rechargefloor,
+/obj/mecha/working/ripley,
+/obj/structure/sign/poster/contraband/steppyflag{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"qH" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/fans/tiny,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"qI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"qN" = (
+/obj/structure/table/wood,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/areaeditor/blueprints{
+	name = "settlement expansion permit"
+	},
+/obj/item/areaeditor/shuttle{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"qQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"qT" = (
+/obj/structure/table/wood,
+/obj/item/candle/infinite,
+/turf/open/floor/mineral/titanium,
+/area/ship/external)
+"rc" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "homesteadwindow"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"rd" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"rr" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/food/pie_smudge,
+/turf/open/floor/mineral/titanium,
+/area/ship/external)
+"rJ" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating/dirt{
+	desc = "Upon closer examination, it's still dirt."1
+	},
+/area/ship/external)
+"rM" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/crew/canteen/kitchen)
+"sd" = (
+/obj/machinery/button/door{
+	id = "homesteadwindow";
+	name = "Windows";
+	pixel_y = 24
+	},
+/obj/machinery/computer/autopilot{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"se" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen/kitchen)
+"so" = (
+/obj/machinery/stasis,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/ship/medical)
+"st" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"sw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/obj/machinery/computer/cryopod{
+	pixel_x = -32
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"sD" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "homesteadwindow"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ship/crew/canteen/kitchen)
+"sG" = (
+/obj/structure/table/wood,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/reagent_containers/food/drinks/bottle/absinthe/premium{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/drinks/flask/gold,
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"sI" = (
+/obj/machinery/stasis,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/ship/medical)
+"sK" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"sL" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/crew/canteen/kitchen)
+"sM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"sO" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "homesteadwindow"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"sP" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"sR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"sU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"sW" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "homesteadwindow"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ship/storage)
+"ta" = (
+/obj/structure/chair/wood,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"tn" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ship/maintenance/central)
+"tF" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/o2,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"tT" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"uC" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/ship/external)
+"uN" = (
+/obj/effect/turf_decal/rechargefloor,
+/obj/mecha/working/ripley,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"uR" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen/kitchen)
+"uT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"uU" = (
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"uV" = (
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/external)
+"vb" = (
+/obj/machinery/vending/liberationstation,
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"vr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"vt" = (
+/turf/closed/wall/r_wall,
+/area/ship/storage)
+"vx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"vz" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/ship/external)
+"vF" = (
+/obj/machinery/processor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen/kitchen)
+"vJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/computer/cargo/express{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"vV" = (
+/obj/machinery/atmospherics/pipe/manifold/orange/visible,
+/obj/item/circuitboard/computer/turbine_computer,
+/obj/item/circuitboard/computer/turbine_control,
+/obj/item/circuitboard/machine/power_turbine,
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"wc" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/cell_charger,
+/obj/structure/table/wood,
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"wk" = (
+/turf/open/floor/plasteel/mono/white,
+/area/ship/crew/canteen/kitchen)
+"wu" = (
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/external)
+"wE" = (
+/obj/machinery/deepfryer,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/crew/canteen/kitchen)
+"wF" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/ship/external)
+"wN" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating/dirt{
+	desc = "Upon closer examination, it's still dirt."1
+	},
+/area/ship/external)
+"wS" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"xk" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ship/external)
+"xq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"xv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"xG" = (
+/obj/machinery/autodoc,
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/ship/medical)
+"xV" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/dirt{
+	desc = "Upon closer examination, it's still dirt."1
+	},
+/area/ship/external)
+"xW" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"ya" = (
+/obj/machinery/medipen_refiller,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"yp" = (
+/obj/machinery/smartfridge/bloodbank/preloaded,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"yw" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"yB" = (
+/obj/structure/table/wood/fancy/black,
+/obj/structure/table/wood,
+/obj/item/candle/infinite,
+/turf/open/floor/mineral/titanium,
+/area/ship/external)
+"zk" = (
+/obj/machinery/atmospherics/components/unary/tank/toxins{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"zs" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"zx" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northright{
+	dir = 4;
+	name = "Engine Access"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"zB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"zF" = (
+/obj/structure/table/reinforced,
+/obj/item/sharpener,
+/obj/item/kitchen/knife/butcher,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/crew/canteen/kitchen)
+"zQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"Al" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"As" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/meter/atmos/layer2,
+/turf/open/floor/engine/air,
+/area/ship/crew/canteen)
+"Au" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/circuit/airless,
+/area/ship/engineering/communications)
+"AJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/computer/selling_pad_control{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"Be" = (
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/external)
+"Bh" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/ship/external)
+"Bz" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"BB" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/wood/mahogany,
+/area/ship/storage)
+"BH" = (
+/obj/machinery/door/airlock/vault{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"BI" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes,
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"BY" = (
+/obj/structure/table/reinforced,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen/kitchen)
+"Ci" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/lizardwine{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/bottle/lizardwine{
+	pixel_y = 5;
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/mineral/titanium,
+/area/ship/external)
+"Cm" = (
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"Cr" = (
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette/rollie/cannabis{
+	pixel_y = 5
+	},
+/obj/item/clothing/mask/cigarette/rollie/cannabis{
+	pixel_y = 10
+	},
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/item/lighter,
+/turf/open/floor/mineral/titanium,
+/area/ship/external)
+"Cv" = (
+/obj/machinery/atmospherics/components/unary/tank/toxins{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"Cy" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/ship/external)
+"CQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"Db" = (
+/obj/machinery/telecomms/bus/preset_one/birdstation,
+/turf/open/floor/circuit/airless,
+/area/ship/engineering/communications)
+"Dc" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"Di" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/circuit/airless,
+/area/ship/engineering/communications)
+"Dn" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/turf/open/floor/mineral/titanium,
+/area/ship/external)
+"Dp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"Dv" = (
+/turf/closed/wall/mineral/wood/nonmetal,
+/area/ship/crew/dorm)
+"DL" = (
+/obj/machinery/computer/communications{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"DN" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/port_gen/pacman/uranium,
+/obj/item/stack/sheet/mineral/uranium/five,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"DT" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/crew/canteen/kitchen)
+"DV" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "homesteadwindow"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ship/crew/dorm)
+"Ef" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"Eh" = (
+/turf/closed/wall/mineral/wood/nonmetal,
+/area/ship/maintenance/central)
+"Ej" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/selling_pad,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"El" = (
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"Ep" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"Ew" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"Ey" = (
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen/kitchen)
+"EM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/ship/medical)
+"EO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"EX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"Fc" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"FF" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/engine,
+/area/ship/storage)
+"FI" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer/bounty{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"FQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"Gb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"Gd" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
+/turf/open/floor/engine/air,
+/area/ship/crew/canteen)
+"Gp" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"Gq" = (
+/obj/structure/closet/crate/large{
+	name = "Surgical Equipment"
+	},
+/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
+/obj/item/mecha_parts/mecha_equipment/drill,
+/obj/item/mecha_parts/mecha_equipment/mining_scanner,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"GB" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/ship/external)
+"GO" = (
+/obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"GT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ship/external)
+"GV" = (
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/obj/structure/bed/roller,
+/obj/item/roller,
+/obj/item/roller,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"He" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"Hk" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/structure/closet/crate,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"Hl" = (
+/obj/machinery/vending/games,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"Hn" = (
+/obj/structure/closet/crate,
+/obj/item/toy/plush/snakeplushie,
+/obj/item/autosurgeon/syndicate/anti_stun,
+/obj/item/clothing/gloves/rapid,
+/turf/open/floor/engine,
+/area/ship/storage)
+"Hw" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/port_gen/pacman,
+/obj/item/stack/sheet/mineral/plasma/twenty,
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"HD" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "homesteadwindow"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ship/crew/canteen)
+"HE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"HG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"HJ" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "homesteadwindow"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"HY" = (
+/obj/machinery/deepfryer,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen/kitchen)
+"If" = (
+/turf/closed/wall/mineral/wood/nonmetal,
+/area/ship/bridge)
+"IG" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ship/external)
+"Ja" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"Jh" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "homesteadwindow"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ship/medical)
+"Jt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"Jx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"JS" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/external)
+"Kb" = (
+/obj/machinery/porta_turret/centcom_shuttle/ballistic,
+/obj/machinery/light/floor,
+/turf/open/floor/circuit/red/airless,
+/area/ship/external)
+"KA" = (
+/obj/structure/closet/crate/large{
+	name = "Surgical Equipment"
+	},
+/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
+/obj/item/mecha_parts/mecha_equipment/drill,
+/obj/item/mecha_parts/mecha_equipment/mining_scanner,
+/obj/machinery/computer/helm/viewscreen{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"KB" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ship/external)
+"KD" = (
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/crew/canteen/kitchen)
+"KE" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo)
+"KL" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/ship/external)
+"KX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"Lg" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen/kitchen)
+"LD" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/fans/tiny,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/canteen)
+"LK" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"LQ" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"LR" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"Mb" = (
+/obj/machinery/autolathe,
+/obj/item/storage/box/rndboards,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"Mc" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating/dirt{
+	desc = "Upon closer examination, it's still dirt."1
+	},
+/area/ship/external)
+"Mv" = (
+/turf/closed/wall/mineral/wood/nonmetal,
+/area/ship/cargo)
+"Mz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"ME" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/suit/toggle/chef,
+/obj/item/clothing/suit/toggle/chef,
+/obj/item/clothing/mask/fakemoustache/italian,
+/obj/item/clothing/mask/fakemoustache/italian,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen/kitchen)
+"MR" = (
+/obj/machinery/suit_storage_unit/mining/eva,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"MS" = (
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"MU" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"Nj" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"Nr" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"Ny" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen/kitchen)
+"NE" = (
+/turf/closed/wall/mineral/wood/nonmetal,
+/area/ship/crew/canteen/kitchen)
+"Oc" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/tracker,
+/obj/effect/turf_decal/solarpanel,
+/turf/open/floor/plating/airless,
+/area/ship/external)
+"Op" = (
+/turf/closed/wall/mineral/wood/nonmetal,
+/area/ship/storage)
+"Oq" = (
+/turf/open/floor/plating,
+/area/ship/external)
+"Oy" = (
+/obj/machinery/stasis,
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/ship/medical)
+"Oz" = (
+/obj/structure/table/wood,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/electrical,
+/obj/item/multitool,
+/obj/item/multitool,
+/obj/item/multitool,
+/obj/item/storage/belt,
+/obj/item/storage/belt,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"OF" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/machinery/computer/helm/viewscreen{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo)
+"OM" = (
+/obj/item/restraints/legcuffs/bola/tactical,
+/obj/item/restraints/legcuffs/bola/tactical,
+/obj/item/restraints/legcuffs/bola/tactical,
+/obj/item/restraints/legcuffs/bola/tactical,
+/obj/item/storage/box/handcuffs,
+/obj/structure/table/wood,
+/obj/machinery/recharger,
+/obj/item/areaeditor/blueprints{
+	name = "settlement expansion permit"
+	},
+/obj/item/areaeditor/shuttle{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"OR" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"Pj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/computer/warrant{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"Pm" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/brute,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"PA" = (
+/obj/structure/table/wood,
+/obj/machinery/cell_charger,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"PL" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/turf/open/floor/plating/airless,
+/area/ship/external)
+"Qa" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"Qc" = (
+/obj/machinery/atmospherics/components/binary/pump,
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"Qm" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/plating/dirt{
+	desc = "Upon closer examination, it's still dirt."1
+	},
+/area/ship/external)
+"Qt" = (
+/turf/open/floor/mineral/titanium,
+/area/ship/external)
+"Qw" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"QB" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/ship/medical)
+"QE" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"QI" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/fans/tiny,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/communications)
+"QL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"QN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/closed/wall/mineral/wood/nonmetal,
+/area/ship/crew/canteen)
+"Rc" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"Rk" = (
+/obj/structure/chair/wood,
+/turf/open/floor/mineral/titanium,
+/area/ship/external)
+"Rz" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"RD" = (
+/obj/machinery/telecomms/broadcaster/preset_left/birdstation,
+/turf/open/floor/circuit/airless,
+/area/ship/engineering/communications)
+"RI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"RS" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating,
+/area/ship/external)
+"RY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"Sh" = (
+/obj/machinery/stasis,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/ship/medical)
+"Sq" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo)
+"Sr" = (
+/turf/template_noop,
+/area/template_noop)
+"St" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"SA" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ship/external)
+"SD" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"SE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo)
+"SM" = (
+/obj/machinery/plantgenes/seedvault,
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo)
+"Tg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"Tj" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"TG" = (
+/turf/open/floor/plating/dirt{
+	desc = "Upon closer examination, it's still dirt."1
+	},
+/area/ship/external)
+"TI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"TL" = (
+/obj/structure/table/wood,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"TY" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/external)
+"Ud" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/template_noop,
+/area/template_noop)
+"Uj" = (
+/obj/structure/bonfire,
+/turf/open/floor/plating/dirt{
+	desc = "Upon closer examination, it's still dirt."1
+	},
+/area/ship/external)
+"UA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/crew/canteen/kitchen)
+"UO" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"UQ" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo)
+"US" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock/wood{
+	req_access_txt = "20";
+	name = "Captain's Quarters"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"UW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"Vi" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"Vs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"VA" = (
+/obj/docking_port/mobile{
+	can_move_docking_ports = 1;
+	dir = 2;
+	dwidth = 12;
+	height = 17;
+	launch_status = 0;
+	name = "Homestead";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 28
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/external)
+"VM" = (
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen/kitchen)
+"VR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"VT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"VX" = (
+/obj/structure/table/wood,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt,
+/obj/item/storage/belt,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"Wd" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ship/storage)
+"We" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plating/dirt{
+	desc = "Upon closer examination, it's still dirt."1
+	},
+/area/ship/external)
+"Wi" = (
+/turf/open/floor/circuit/airless,
+/area/ship/engineering/communications)
+"Wp" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"Wv" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/storage)
+"Wz" = (
+/obj/machinery/telecomms/processor/preset_one/birdstation,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/circuit/airless,
+/area/ship/engineering/communications)
+"WB" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"WN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"Xg" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/ship/external)
+"Xl" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen/kitchen)
+"Xv" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo)
+"Xy" = (
+/obj/machinery/grill,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen/kitchen)
+"XB" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/light,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"XF" = (
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"XL" = (
+/turf/closed/wall/mineral/wood/nonmetal,
+/area/ship/crew/canteen)
+"XP" = (
+/obj/structure/table/wood,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/construction/rcd,
+/obj/item/construction/rcd,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_upgrade,
+/obj/item/rcd_upgrade/frames,
+/obj/item/rcd_upgrade/simple_circuits,
+/obj/item/rcd_upgrade/simple_circuits,
+/obj/item/rcd_upgrade,
+/obj/item/rcd_upgrade/frames,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"XT" = (
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"XU" = (
+/obj/machinery/telecomms/receiver/preset_left/birdstation,
+/turf/open/floor/circuit/airless,
+/area/ship/engineering/communications)
+"XW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"XX" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating,
+/area/ship/external)
+"XZ" = (
+/obj/item/circuitboard/machine/rdserver,
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/red,
+/obj/item/stock_parts/scanning_module/triphasic,
+/turf/open/floor/engine,
+/area/ship/storage)
+"Ya" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/ship/external)
+"Ye" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
+"Yi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/structure/closet/secure_closet/captains,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
+"Yl" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/external)
+"Ys" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"YD" = (
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+"YG" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
+"YH" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"YM" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"YN" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"YP" = (
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/ship/medical)
+"YZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/ship/external)
+"Zc" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/light,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
+"Zf" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
+"ZA" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/ship/external)
+"ZE" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
+
+(1,1,1) = {"
+Be
+wu
+uV
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+bo
+Be
+wu
+uV
+"}
+(2,1,1) = {"
+wu
+Kb
+wu
+bo
+bo
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+bo
+wu
+Kb
+wu
+"}
+(3,1,1) = {"
+hr
+wu
+qk
+bo
+bo
+TG
+Qm
+Qm
+Qm
+Qm
+Qm
+Qm
+Qm
+Qm
+Qm
+TG
+bo
+bo
+bB
+bB
+bB
+bo
+bo
+tn
+tn
+tn
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+hr
+wu
+qk
+"}
+(4,1,1) = {"
+bo
+bo
+mw
+bo
+bo
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+bo
+Eh
+zx
+zx
+zx
+Eh
+Eh
+rd
+rd
+rd
+Eh
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+mw
+bo
+bo
+"}
+(5,1,1) = {"
+Sr
+bo
+iK
+Sr
+bo
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+bo
+Eh
+iI
+st
+st
+fs
+Qc
+GO
+GO
+vV
+sO
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+iK
+bo
+Sr
+"}
+(6,1,1) = {"
+Sr
+bo
+iK
+Sr
+bo
+TG
+Qm
+Qm
+Qm
+Qm
+Qm
+Qm
+Qm
+Qm
+Qm
+TG
+bo
+Eh
+wc
+WB
+LR
+MS
+Hw
+zk
+Cv
+zk
+Eh
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+iK
+Sr
+Sr
+"}
+(7,1,1) = {"
+Sr
+bo
+iK
+Sr
+bo
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+TG
+bo
+Eh
+ht
+Nj
+xW
+YM
+DN
+Eh
+Op
+Op
+Op
+Op
+sW
+Op
+Op
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+iK
+Sr
+Sr
+"}
+(8,1,1) = {"
+Sr
+bo
+iK
+Sr
+bo
+bo
+bo
+bo
+bo
+pp
+uU
+iK
+bo
+bo
+bo
+bo
+bo
+Eh
+MU
+BI
+vr
+cw
+jV
+bF
+Rz
+Rz
+Rz
+Ej
+AJ
+vJ
+Op
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+iK
+Sr
+Sr
+"}
+(9,1,1) = {"
+Sr
+bo
+iK
+bo
+bo
+bo
+Mv
+Mv
+Mv
+Mv
+Mv
+dx
+Mv
+bo
+bo
+bo
+bo
+Eh
+Qw
+YH
+sM
+Zf
+KX
+jk
+sR
+cE
+cE
+cE
+YG
+Gp
+Op
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+iK
+Sr
+Sr
+"}
+(10,1,1) = {"
+Sr
+bo
+iK
+Sr
+Sr
+Sr
+Mv
+gs
+UQ
+KE
+le
+oy
+Mv
+bo
+bo
+bo
+xk
+Op
+Op
+Op
+Op
+Op
+Op
+Op
+pJ
+XT
+pJ
+XT
+qQ
+LK
+sW
+bo
+bo
+bo
+bo
+bo
+bo
+iK
+Sr
+Sr
+"}
+(11,1,1) = {"
+Sr
+bo
+iK
+Sr
+Sr
+Sr
+HJ
+gs
+le
+le
+SE
+bS
+Mv
+Sr
+Sr
+Sr
+Sr
+Op
+vt
+vt
+vt
+vt
+vt
+Op
+qz
+XT
+uN
+RY
+UW
+LK
+sW
+bo
+bo
+bo
+bo
+bo
+bo
+iK
+Sr
+Sr
+"}
+(12,1,1) = {"
+Sr
+bo
+iK
+Sr
+Sr
+Sr
+Mv
+OF
+gE
+SM
+Sq
+cr
+Mv
+Sr
+Sr
+Sr
+Sr
+Op
+vt
+FF
+Wd
+Hn
+vt
+Op
+KA
+XT
+Gq
+XT
+eY
+LK
+sW
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+iK
+Sr
+Sr
+"}
+(13,1,1) = {"
+bo
+bo
+mw
+bo
+bo
+bo
+Mv
+Mv
+Mv
+Mv
+Mv
+Xv
+Mv
+Sr
+Sr
+Sr
+Sr
+Op
+vt
+XZ
+kk
+kk
+BH
+El
+XT
+XT
+XT
+HE
+VT
+LK
+sW
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+iK
+Sr
+Sr
+"}
+(14,1,1) = {"
+Be
+wu
+uV
+bo
+Sr
+Sr
+bo
+Sr
+Sr
+Sr
+bo
+JS
+bo
+Sr
+Sr
+Sr
+Sr
+Op
+vt
+fg
+oZ
+lC
+vt
+Op
+Qa
+eT
+XT
+XT
+qQ
+Gp
+Op
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+iK
+Sr
+Sr
+"}
+(15,1,1) = {"
+wu
+Kb
+wu
+bo
+Sr
+Sr
+bo
+Sr
+Sr
+Sr
+bo
+JS
+bo
+Sr
+Sr
+Sr
+Sr
+Op
+vt
+vt
+vt
+vt
+vt
+Op
+eS
+al
+XT
+Mb
+qQ
+LK
+Op
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+iK
+Sr
+Sr
+"}
+(16,1,1) = {"
+hr
+wu
+qk
+bo
+Sr
+Sr
+bo
+Sr
+Sr
+Sr
+bo
+JS
+bo
+Sr
+Sr
+Sr
+Sr
+Op
+Op
+Op
+Op
+Op
+Op
+Op
+Op
+sW
+sW
+Op
+Wv
+BB
+Op
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+iK
+Sr
+Sr
+"}
+(17,1,1) = {"
+bo
+bo
+mw
+bo
+Sr
+Sr
+bo
+Sr
+Sr
+Sr
+bo
+JS
+bo
+Sr
+Sr
+Sr
+Sr
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+Sr
+Sr
+Ud
+TY
+IG
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+iK
+Sr
+Sr
+"}
+(18,1,1) = {"
+Sr
+Sr
+iK
+Sr
+Sr
+Sr
+bo
+Sr
+Sr
+Sr
+bo
+JS
+bo
+Sr
+Sr
+Sr
+Sr
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+Sr
+Sr
+Sr
+TY
+IG
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+iK
+Sr
+Sr
+"}
+(19,1,1) = {"
+Sr
+Sr
+iK
+iK
+iK
+iK
+iK
+iK
+iK
+iK
+iK
+wF
+nE
+nE
+nE
+nE
+Yl
+cZ
+cZ
+cZ
+cZ
+cZ
+cZ
+cZ
+cZ
+cZ
+cZ
+Yl
+gK
+Bh
+SA
+SA
+SA
+SA
+SA
+SA
+SA
+GB
+Sr
+Sr
+"}
+(20,1,1) = {"
+Sr
+Sr
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+bo
+JS
+xk
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+bo
+JS
+bo
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+IG
+Sr
+Sr
+"}
+(21,1,1) = {"
+Sr
+Sr
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+bo
+JS
+xk
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+bo
+JS
+bo
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+IG
+Sr
+Sr
+"}
+(22,1,1) = {"
+Sr
+Sr
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+iX
+JS
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+iX
+JS
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+IG
+Sr
+Sr
+"}
+(23,1,1) = {"
+Sr
+Sr
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Dv
+Dv
+Dv
+Dv
+zs
+If
+rc
+rc
+rc
+rc
+If
+mg
+Jh
+Jh
+mg
+dL
+mg
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+IG
+Sr
+Sr
+"}
+(24,1,1) = {"
+Sr
+Sr
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+DV
+sw
+Gb
+St
+mT
+If
+sd
+sG
+ex
+DL
+If
+Oy
+EM
+Ep
+Ep
+zQ
+mg
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+IG
+Sr
+Sr
+"}
+(25,1,1) = {"
+Sr
+Sr
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Dv
+cH
+Tg
+Dv
+oV
+If
+OR
+XF
+iz
+iz
+If
+nJ
+YP
+pr
+Rc
+oD
+mg
+hC
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+IG
+Sr
+Sr
+"}
+(26,1,1) = {"
+Sr
+Sr
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Dv
+Dv
+Dv
+Dv
+XB
+If
+FI
+sU
+oh
+oB
+If
+sI
+YP
+YP
+Pm
+WN
+tT
+mg
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+IG
+Sr
+Sr
+"}
+(27,1,1) = {"
+Sr
+Sr
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+DV
+Ef
+Gb
+St
+dN
+If
+Pj
+FQ
+eu
+iy
+If
+so
+YP
+xG
+Bz
+dg
+pF
+Jh
+bo
+PL
+mz
+bo
+PL
+mz
+bo
+IG
+Sr
+Sr
+"}
+(28,1,1) = {"
+Sr
+Sr
+iK
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+Dv
+cH
+Tg
+Dv
+zB
+If
+iz
+EO
+iz
+bv
+If
+Oy
+YP
+YP
+tF
+uT
+YN
+mg
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(29,1,1) = {"
+Sr
+Sr
+iK
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+Dv
+Dv
+Dv
+Dv
+zB
+If
+Dc
+EO
+jE
+OM
+If
+nJ
+YP
+QB
+eg
+TI
+Wp
+mg
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(30,1,1) = {"
+Sr
+Sr
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+DV
+Ef
+Gb
+St
+ad
+If
+SD
+Ye
+XF
+vb
+If
+Sh
+YP
+ai
+ya
+HG
+LQ
+Jh
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(31,1,1) = {"
+Sr
+Sr
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Dv
+cH
+Tg
+Dv
+zB
+If
+If
+Nr
+If
+If
+If
+ce
+YP
+ai
+ai
+WN
+yw
+mg
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(32,1,1) = {"
+Sr
+Sr
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Dv
+Dv
+Dv
+Dv
+zB
+Dv
+YD
+UO
+CQ
+CQ
+wS
+fI
+Jt
+fI
+fI
+Zc
+mg
+mg
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(33,1,1) = {"
+Sr
+Sr
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+DV
+Ef
+Gb
+St
+ad
+Dv
+YD
+Ja
+YD
+cF
+mg
+mg
+Fc
+GV
+RI
+QL
+mg
+Sr
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(34,1,1) = {"
+Sr
+Sr
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Dv
+cH
+Tg
+Dv
+EX
+Dv
+dt
+nY
+vx
+YD
+QE
+mg
+mg
+yp
+lU
+Cm
+mg
+Sr
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(35,1,1) = {"
+Sr
+Sr
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Dv
+Dv
+Dv
+Dv
+zB
+Dv
+iQ
+kj
+YD
+YD
+YD
+cC
+NE
+NE
+NE
+NE
+NE
+Sr
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(36,1,1) = {"
+Sr
+Sr
+iK
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+DV
+Ef
+Gb
+St
+ad
+Dv
+lh
+mQ
+sP
+YD
+Hl
+NE
+NE
+VM
+qf
+vF
+NE
+bo
+bo
+PL
+fr
+bo
+PL
+fr
+bo
+KL
+Sr
+Sr
+"}
+(37,1,1) = {"
+Sr
+Sr
+iK
+bo
+bo
+or
+or
+or
+or
+or
+or
+bo
+Dv
+cH
+Tg
+Dv
+qI
+Dv
+lh
+mQ
+sP
+YD
+NE
+NE
+Xy
+wk
+Ey
+eU
+NE
+NE
+bo
+PL
+fr
+bo
+PL
+fr
+bo
+IG
+Sr
+Sr
+"}
+(38,1,1) = {"
+Sr
+Sr
+iK
+bo
+bo
+or
+Db
+Wi
+RD
+Wi
+or
+bo
+Dv
+Dv
+Dv
+Dv
+zB
+Dv
+ta
+mQ
+sP
+cF
+NE
+HY
+wk
+Ey
+wk
+Ey
+KD
+sD
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(39,1,1) = {"
+Sr
+Sr
+iK
+bo
+bo
+or
+Wz
+Wi
+XU
+Wi
+or
+bo
+DV
+Ef
+Gb
+US
+ad
+Dv
+lh
+mQ
+sP
+YD
+iw
+wk
+Ey
+zF
+ME
+fb
+fh
+sD
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(40,1,1) = {"
+bo
+bo
+mw
+bo
+bo
+or
+oc
+Wi
+Au
+Di
+or
+bo
+Dv
+cH
+Yi
+Dv
+zB
+Dv
+lh
+mQ
+sP
+YD
+iw
+Ey
+wk
+BY
+bm
+Ny
+rM
+sD
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(41,1,1) = {"
+Be
+wu
+uV
+bo
+bo
+or
+or
+or
+or
+QI
+or
+bo
+Dv
+Dv
+Dv
+Dv
+mA
+Dv
+qd
+Ew
+YD
+YD
+iw
+wk
+Lg
+DT
+Ey
+UA
+lI
+sD
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(42,1,1) = {"
+VA
+Kb
+wu
+bo
+bo
+bo
+bo
+bo
+bo
+uC
+KB
+KB
+LD
+ZE
+YD
+YD
+Vs
+Tj
+YD
+Ja
+YD
+YD
+iw
+Ey
+wk
+Ey
+wk
+se
+sL
+sD
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(43,1,1) = {"
+hr
+wu
+qk
+bo
+Sr
+bo
+Sr
+Sr
+Sr
+bo
+gL
+GT
+QN
+cz
+Ys
+gb
+Vi
+Jx
+Jx
+Mz
+YD
+cF
+NE
+wE
+uR
+gQ
+mm
+cU
+NE
+NE
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(44,1,1) = {"
+bo
+bo
+mw
+bo
+Sr
+bo
+Sr
+Sr
+Sr
+bo
+Oq
+Oq
+HD
+YD
+YD
+XW
+YD
+YD
+Dp
+xq
+xv
+bL
+NE
+NE
+NE
+NE
+NE
+Xl
+NE
+Sr
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(45,1,1) = {"
+Sr
+bo
+iK
+Sr
+Sr
+bo
+Sr
+Sr
+Sr
+bo
+Oq
+Oq
+HD
+YD
+YD
+YD
+YD
+YD
+YD
+Ja
+YD
+YD
+qN
+TL
+VX
+Oz
+XP
+He
+XL
+Sr
+Sr
+PL
+fr
+Sr
+PL
+fr
+Sr
+IG
+Sr
+Sr
+"}
+(46,1,1) = {"
+Sr
+bo
+iK
+Sr
+Sr
+bo
+Sr
+Sr
+Sr
+bo
+Oq
+Oq
+XL
+XL
+XL
+XL
+YD
+YD
+YD
+sK
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+lY
+XL
+bo
+bo
+iK
+Ya
+XX
+XX
+YZ
+Oc
+IG
+Sr
+Sr
+"}
+(47,1,1) = {"
+Sr
+bo
+iK
+Sr
+Sr
+bo
+Sr
+Sr
+Sr
+bo
+Oq
+Oq
+XL
+Gd
+As
+lq
+lr
+xv
+xv
+VR
+YD
+YD
+YD
+YD
+YD
+YD
+YD
+kp
+XL
+Sr
+Sr
+Qt
+Dn
+vz
+Qt
+lR
+js
+IG
+Sr
+Sr
+"}
+(48,1,1) = {"
+Sr
+bo
+iK
+Sr
+Sr
+bo
+Sr
+Sr
+Sr
+bo
+Oq
+Oq
+XL
+gS
+aY
+dI
+YD
+Hk
+dW
+PA
+MR
+MR
+MR
+MR
+MR
+MR
+Al
+YD
+XL
+Sr
+Sr
+Rk
+yB
+Ci
+Cy
+RS
+Oq
+IG
+Sr
+Sr
+"}
+(49,1,1) = {"
+Sr
+bo
+iK
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+XL
+XL
+XL
+XL
+XL
+XL
+HD
+HD
+HD
+XL
+HD
+HD
+HD
+XL
+XL
+qH
+XL
+Sr
+Sr
+Rk
+Cr
+qT
+Cy
+RS
+Oq
+IG
+Sr
+Sr
+"}
+(50,1,1) = {"
+Sr
+bo
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+iK
+bo
+bo
+bo
+Qt
+ZA
+rr
+Qt
+cR
+Xg
+kT
+Sr
+Sr
+"}
+(51,1,1) = {"
+Sr
+bo
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+bo
+TG
+TG
+TG
+TG
+TG
+bo
+iK
+Sr
+Sr
+Sr
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+iK
+Sr
+Sr
+"}
+(52,1,1) = {"
+Sr
+bo
+iK
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+bo
+TG
+Mc
+kd
+rJ
+TG
+bo
+iK
+Sr
+Sr
+Sr
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+iK
+bo
+Sr
+"}
+(53,1,1) = {"
+bo
+bo
+mw
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+bo
+xV
+TG
+Uj
+TG
+TG
+bo
+mw
+iK
+iK
+iK
+iK
+iK
+iK
+iK
+iK
+iK
+mw
+bo
+bo
+"}
+(54,1,1) = {"
+Be
+wu
+uV
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+bo
+TG
+wN
+We
+kd
+Mc
+bo
+bo
+bo
+bo
+bo
+bo
+Sr
+Sr
+Sr
+bo
+bo
+Be
+wu
+uV
+"}
+(55,1,1) = {"
+wu
+Kb
+wu
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+bo
+TG
+TG
+TG
+TG
+TG
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+bo
+wu
+Kb
+wu
+"}
+(56,1,1) = {"
+hr
+wu
+qk
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+bo
+bo
+bo
+bo
+bo
+bo
+bo
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+bo
+hr
+wu
+qk
+"}

--- a/_maps/shuttles/shiptest/voidcrew/Homestead.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/Homestead.dmm
@@ -32,7 +32,7 @@
 /area/ship/crew/canteen/kitchen)
 "bo" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ship/external)
 "bv" = (
 /obj/machinery/airalarm/directional/south,
@@ -418,7 +418,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ship/external)
 "jk" = (
 /obj/structure/cable{
@@ -443,9 +443,7 @@
 /area/ship/maintenance/central)
 "kd" = (
 /obj/item/reagent_containers/food/snacks/hotdog,
-/turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."
-	},
+/turf/open/floor/plating/dirt,
 /area/ship/external)
 "kj" = (
 /obj/structure/cable{
@@ -816,9 +814,7 @@
 /area/ship/external)
 "rJ" = (
 /obj/effect/decal/cleanable/ash,
-/turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."
-	},
+/turf/open/floor/plating/dirt,
 /area/ship/external)
 "rM" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -1123,9 +1119,7 @@
 /area/ship/medical)
 "wN" = (
 /obj/effect/decal/cleanable/ash/large,
-/turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."
-	},
+/turf/open/floor/plating/dirt,
 /area/ship/external)
 "wS" = (
 /obj/machinery/door/airlock/wood,
@@ -1139,7 +1133,7 @@
 "xk" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ship/external)
 "xq" = (
 /obj/structure/cable{
@@ -1155,15 +1149,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood/yew,
 /area/ship/crew/canteen)
+"xB" = (
+/mob/living/simple_animal/pet/gondola,
+/turf/open/floor/wood/bamboo,
+/area/ship/cargo)
 "xG" = (
 /obj/machinery/autodoc,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/ship/medical)
 "xV" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."
-	},
+/turf/open/floor/plating/dirt,
 /area/ship/external)
 "xW" = (
 /obj/structure/cable/yellow{
@@ -1802,7 +1798,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood/yew,
 /area/ship/crew/canteen)
 "LK" = (
 /obj/structure/cable/yellow{
@@ -1827,9 +1823,7 @@
 /area/ship/storage)
 "Mc" = (
 /obj/item/stack/rods,
-/turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."
-	},
+/turf/open/floor/plating/dirt,
 /area/ship/external)
 "Mv" = (
 /turf/closed/wall/mineral/wood/nonmetal,
@@ -2004,9 +1998,7 @@
 /area/ship/maintenance/central)
 "Qm" = (
 /obj/machinery/hydroponics/soil,
-/turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."
-	},
+/turf/open/floor/plating/dirt,
 /area/ship/external)
 "Qt" = (
 /turf/open/floor/mineral/titanium,
@@ -2033,7 +2025,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/circuit/airless,
 /area/ship/engineering/communications)
 "QL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -2145,9 +2137,7 @@
 /turf/open/floor/wood/yew,
 /area/ship/crew/canteen)
 "TG" = (
-/turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."
-	},
+/turf/open/floor/plating/dirt,
 /area/ship/external)
 "TI" = (
 /obj/structure/cable{
@@ -2196,9 +2186,7 @@
 /area/template_noop)
 "Uj" = (
 /obj/structure/bonfire,
-/turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."
-	},
+/turf/open/floor/plating/dirt,
 /area/ship/external)
 "UA" = (
 /obj/structure/cable{
@@ -2326,9 +2314,7 @@
 /area/ship/storage)
 "We" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."
-	},
+/turf/open/floor/plating/dirt,
 /area/ship/external)
 "Wi" = (
 /turf/open/floor/circuit/airless,
@@ -3068,7 +3054,7 @@ Sr
 Sr
 HJ
 gs
-le
+xB
 le
 SE
 bS
@@ -3883,8 +3869,8 @@ vb
 If
 wH
 YP
-ai
 ya
+ai
 GR
 sA
 Jh

--- a/_maps/shuttles/shiptest/voidcrew/Homestead.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/Homestead.dmm
@@ -817,7 +817,7 @@
 "rJ" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."1
+	desc = "Upon closer examination, it's still dirt."
 	},
 /area/ship/external)
 "rM" = (
@@ -1124,7 +1124,7 @@
 "wN" = (
 /obj/effect/decal/cleanable/ash/large,
 /turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."1
+	desc = "Upon closer examination, it's still dirt."
 	},
 /area/ship/external)
 "wS" = (
@@ -1162,7 +1162,7 @@
 "xV" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."1
+	desc = "Upon closer examination, it's still dirt."
 	},
 /area/ship/external)
 "xW" = (
@@ -1828,7 +1828,7 @@
 "Mc" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."1
+	desc = "Upon closer examination, it's still dirt."
 	},
 /area/ship/external)
 "Mv" = (
@@ -2005,7 +2005,7 @@
 "Qm" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."1
+	desc = "Upon closer examination, it's still dirt."
 	},
 /area/ship/external)
 "Qt" = (
@@ -2146,7 +2146,7 @@
 /area/ship/crew/canteen)
 "TG" = (
 /turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."1
+	desc = "Upon closer examination, it's still dirt."
 	},
 /area/ship/external)
 "TI" = (
@@ -2197,7 +2197,7 @@
 "Uj" = (
 /obj/structure/bonfire,
 /turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."1
+	desc = "Upon closer examination, it's still dirt."
 	},
 /area/ship/external)
 "UA" = (
@@ -2327,7 +2327,7 @@
 "We" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."1
+	desc = "Upon closer examination, it's still dirt."
 	},
 /area/ship/external)
 "Wi" = (

--- a/_maps/shuttles/shiptest/voidcrew/Homestead.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/Homestead.dmm
@@ -13,6 +13,16 @@
 /obj/item/storage/backpack/duffelbag/mining_conscript,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage)
+"ay" = (
+/obj/machinery/suit_storage_unit/ert/security,
+/turf/open/floor/engine,
+/area/ship/storage)
+"aH" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
 "aY" = (
 /turf/open/floor/engine/air,
 /area/ship/crew/canteen)
@@ -166,9 +176,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
+/obj/machinery/light,
 /turf/open/floor/wood/yew,
 /area/ship/medical)
 "dt" = (
@@ -375,10 +383,13 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/central)
-"hC" = (
-/obj/structure/lattice,
-/turf/closed/wall/mineral/wood/nonmetal,
-/area/ship/medical)
+"if" = (
+/obj/structure/chair/wood,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
 "iw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -398,28 +409,10 @@
 	},
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
-"iI" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/ship/maintenance/central)
 "iK" = (
 /obj/structure/catwalk,
 /turf/open/floor/plating,
 /area/ship/external)
-"iQ" = (
-/obj/structure/sign/poster/contraband/steppyflag{
-	pixel_y = 32
-	},
-/turf/open/floor/wood/yew,
-/area/ship/crew/canteen)
 "iX" = (
 /obj/structure/lattice,
 /obj/machinery/light{
@@ -440,10 +433,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ship/external)
-"jE" = (
-/obj/machinery/suit_storage_unit/ert/security,
-/turf/open/floor/wood/yew,
-/area/ship/bridge)
 "jV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -506,9 +495,11 @@
 /turf/open/floor/wood/yew,
 /area/ship/crew/canteen)
 "lC" = (
-/obj/machinery/suit_storage_unit/ert/security,
-/turf/open/floor/engine,
-/area/ship/storage)
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
 "lI" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/plasteel/mono/dark,
@@ -544,6 +535,18 @@
 "mg" = (
 /turf/closed/wall/mineral/wood/nonmetal,
 /area/ship/medical)
+"mi" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
 "mm" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/donkpockets,
@@ -600,6 +603,21 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/dorm)
+"ni" = (
+/obj/structure/table/wood,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/reagent_containers/food/drinks/bottle/absinthe/premium{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/drinks/flask/gold,
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
 "nE" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -637,6 +655,10 @@
 	},
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
+"oj" = (
+/obj/structure/lattice,
+/turf/closed/wall/mineral/wood/nonmetal,
+/area/ship/medical)
 "or" = (
 /turf/closed/wall/mineral/wood/nonmetal,
 /area/ship/engineering/communications)
@@ -654,19 +676,6 @@
 	},
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
-"oD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/wood/yew,
-/area/ship/medical)
 "oV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -698,10 +707,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/ship/medical)
-"pF" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/wood/yew,
-/area/ship/medical)
 "pJ" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plasteel/tech/techmaint,
@@ -722,14 +727,6 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/external)
-"qz" = (
-/obj/effect/turf_decal/rechargefloor,
-/obj/mecha/working/ripley,
-/obj/structure/sign/poster/contraband/steppyflag{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/storage)
 "qH" = (
 /obj/machinery/door/airlock/wood,
 /obj/structure/fans/tiny,
@@ -850,13 +847,6 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen/kitchen)
-"so" = (
-/obj/machinery/stasis,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/mineral/titanium/tiled/blue,
-/area/ship/medical)
 "st" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -876,6 +866,12 @@
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/dorm)
+"sA" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
 "sD" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "homesteadwindow"
@@ -883,21 +879,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ship/crew/canteen/kitchen)
-"sG" = (
-/obj/structure/table/wood,
-/obj/item/stack/spacecash/c1000,
-/obj/item/stack/spacecash/c1000,
-/obj/item/stack/spacecash/c1000,
-/obj/item/stack/spacecash/c1000,
-/obj/item/reagent_containers/food/drinks/bottle/absinthe/premium{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
-	pixel_x = -5
-	},
-/obj/item/reagent_containers/food/drinks/flask/gold,
-/turf/open/floor/wood/yew,
-/area/ship/bridge)
 "sI" = (
 /obj/machinery/stasis,
 /obj/machinery/light{
@@ -972,13 +953,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ship/storage)
-"ta" = (
-/obj/structure/chair/wood,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/wood/yew,
-/area/ship/crew/canteen)
 "tn" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
@@ -991,9 +965,18 @@
 /obj/item/storage/firstaid/o2,
 /turf/open/floor/wood/yew,
 /area/ship/medical)
-"tT" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell{
-	dir = 4
+"ue" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
 	},
 /turf/open/floor/wood/yew,
 /area/ship/medical)
@@ -1014,21 +997,6 @@
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen/kitchen)
-"uT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/wood/yew,
-/area/ship/medical)
 "uU" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/plating,
@@ -1076,6 +1044,15 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage)
+"vT" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
 "vV" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible,
 /obj/item/circuitboard/computer/turbine_computer,
@@ -1098,6 +1075,21 @@
 "wk" = (
 /turf/open/floor/plasteel/mono/white,
 /area/ship/crew/canteen/kitchen)
+"wo" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
 "wu" = (
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/external)
@@ -1122,6 +1114,13 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/ship/external)
+"wH" = (
+/obj/machinery/stasis,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/ship/medical)
 "wN" = (
 /obj/effect/decal/cleanable/ash/large,
 /turf/open/floor/plating/dirt{
@@ -1178,12 +1177,6 @@
 /area/ship/medical)
 "yp" = (
 /obj/machinery/smartfridge/bloodbank/preloaded,
-/turf/open/floor/wood/yew,
-/area/ship/medical)
-"yw" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell{
-	dir = 8
-	},
 /turf/open/floor/wood/yew,
 /area/ship/medical)
 "yB" = (
@@ -1253,13 +1246,6 @@
 	},
 /turf/open/floor/wood/yew,
 /area/ship/medical)
-"Al" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/wood/yew,
-/area/ship/crew/canteen)
 "As" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/meter/atmos/layer2,
@@ -1503,18 +1489,6 @@
 	},
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
-"EX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/turf/open/floor/wood/bamboo,
-/area/ship/crew/dorm)
 "Fc" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -1583,6 +1557,21 @@
 /obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
 /turf/open/floor/plating,
 /area/ship/maintenance/central)
+"GR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
 "GT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
@@ -1612,17 +1601,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/radio/headset/binary,
-/obj/item/radio/headset/binary,
-/obj/item/radio/headset/binary,
-/obj/item/radio/headset/binary,
-/obj/item/radio/headset/binary,
-/obj/item/radio/headset/binary,
-/obj/item/radio/headset/binary,
-/obj/item/radio/headset/binary,
-/obj/item/radio/headset/binary,
-/obj/item/radio/headset/binary,
-/obj/structure/closet/crate,
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/wood/yew,
 /area/ship/crew/canteen)
 "Hl" = (
@@ -1655,21 +1634,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage)
-"HG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/wood/yew,
-/area/ship/medical)
 "HJ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "homesteadwindow"
@@ -1677,8 +1641,28 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ship/cargo)
+"HR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/structure/closet/secure_closet/captains,
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
 "HY" = (
 /obj/machinery/deepfryer,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen/kitchen)
+"Ib" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/suit/toggle/chef,
+/obj/item/clothing/suit/toggle/chef,
+/obj/item/clothing/mask/fakemoustache/italian,
+/obj/item/clothing/mask/fakemoustache/italian,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen/kitchen)
 "If" = (
@@ -1747,6 +1731,15 @@
 /obj/machinery/light/floor,
 /turf/open/floor/circuit/red/airless,
 /area/ship/external)
+"Kz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock/wood{
+	req_access_txt = "20";
+	name = "Captain's Quarters"
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
 "KA" = (
 /obj/structure/closet/crate/large{
 	name = "Surgical Equipment"
@@ -1812,18 +1805,16 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage)
-"LQ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/wood/yew,
-/area/ship/medical)
 "LR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/central)
+"LV" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
 "Mb" = (
 /obj/machinery/autolathe,
 /obj/item/storage/box/rndboards,
@@ -1849,18 +1840,6 @@
 	},
 /turf/open/floor/wood/yew,
 /area/ship/crew/canteen)
-"ME" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/apron/chef,
-/obj/item/clothing/suit/apron/chef,
-/obj/item/clothing/head/chefhat,
-/obj/item/clothing/head/chefhat,
-/obj/item/clothing/suit/toggle/chef,
-/obj/item/clothing/suit/toggle/chef,
-/obj/item/clothing/mask/fakemoustache/italian,
-/obj/item/clothing/mask/fakemoustache/italian,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/crew/canteen/kitchen)
 "MR" = (
 /obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/wood/yew,
@@ -1911,6 +1890,14 @@
 "NE" = (
 /turf/closed/wall/mineral/wood/nonmetal,
 /area/ship/crew/canteen/kitchen)
+"NK" = (
+/obj/effect/turf_decal/rechargefloor,
+/obj/mecha/working/ripley,
+/obj/structure/sign/poster/contraband/steppyflag{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/storage)
 "Oc" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/tracker,
@@ -1925,6 +1912,9 @@
 /area/ship/external)
 "Oy" = (
 /obj/machinery/stasis,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/ship/medical)
 "Oz" = (
@@ -1962,15 +1952,6 @@
 	},
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
-"OR" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/wood/yew,
-/area/ship/bridge)
 "Pj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/computer/warrant{
@@ -1997,6 +1978,12 @@
 /obj/effect/turf_decal/solarpanel,
 /turf/open/floor/plating/airless,
 /area/ship/external)
+"PY" = (
+/obj/structure/sign/poster/contraband/steppyflag{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
 "Qa" = (
 /obj/machinery/light{
 	dir = 1
@@ -2066,6 +2053,13 @@
 /obj/structure/chair/wood,
 /turf/open/floor/mineral/titanium,
 /area/ship/external)
+"Rs" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/wood/yew,
+/area/ship/medical)
 "Rz" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -2094,12 +2088,9 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage)
 "Sh" = (
-/obj/machinery/stasis,
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/turf/open/floor/mineral/titanium/tiled/blue,
-/area/ship/medical)
+/obj/machinery/suit_storage_unit/ert/security,
+/turf/open/floor/wood/yew,
+/area/ship/bridge)
 "Sq" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/wood/bamboo,
@@ -2239,15 +2230,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/wood/bamboo,
 /area/ship/cargo)
-"US" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/airlock/wood{
-	req_access_txt = "20";
-	name = "Captain's Quarters"
-	},
-/turf/open/floor/wood/bamboo,
-/area/ship/crew/dorm)
 "UW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2293,6 +2275,13 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/external)
+"VF" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
+	},
+/turf/open/floor/wood/yew,
+/area/ship/medical)
 "VM" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/mono/dark,
@@ -2339,13 +2328,6 @@
 "Wi" = (
 /turf/open/floor/circuit/airless,
 /area/ship/engineering/communications)
-"Wp" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/wood/yew,
-/area/ship/medical)
 "Wv" = (
 /obj/machinery/door/airlock/wood,
 /obj/structure/cable{
@@ -2376,6 +2358,23 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/central)
+"WL" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/item/radio/headset/binary,
+/obj/structure/closet/crate,
+/turf/open/floor/wood/yew,
+/area/ship/crew/canteen)
 "WN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2423,6 +2422,10 @@
 	},
 /turf/open/floor/wood/bamboo,
 /area/ship/cargo)
+"Xx" = (
+/obj/machinery/stasis,
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/ship/medical)
 "Xy" = (
 /obj/machinery/grill,
 /turf/open/floor/plasteel/mono/dark,
@@ -2514,14 +2517,6 @@
 	},
 /turf/open/floor/wood/yew,
 /area/ship/bridge)
-"Yi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/structure/closet/secure_closet/captains,
-/turf/open/floor/wood/bamboo,
-/area/ship/crew/dorm)
 "Yl" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -2579,13 +2574,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/central)
-"YN" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
-	},
-/turf/open/floor/wood/yew,
-/area/ship/medical)
 "YP" = (
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/ship/medical)
@@ -2603,6 +2591,18 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/ship/external)
+"Zb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/bamboo,
+/area/ship/crew/dorm)
 "Zc" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -2821,7 +2821,7 @@ TG
 TG
 bo
 Eh
-iI
+mi
 st
 st
 fs
@@ -3079,7 +3079,7 @@ vt
 vt
 vt
 Op
-qz
+NK
 XT
 uN
 RY
@@ -3202,7 +3202,7 @@ Op
 vt
 fg
 oZ
-lC
+ay
 vt
 Op
 Qa
@@ -3620,11 +3620,11 @@ St
 mT
 If
 sd
-sG
+ni
 ex
 DL
 If
-Oy
+Xx
 EM
 Ep
 Ep
@@ -3661,7 +3661,7 @@ Tg
 Dv
 oV
 If
-OR
+vT
 XF
 iz
 iz
@@ -3670,9 +3670,9 @@ nJ
 YP
 pr
 Rc
-oD
+dg
 mg
-hC
+oj
 Sr
 Sr
 Sr
@@ -3713,7 +3713,7 @@ YP
 YP
 Pm
 WN
-tT
+aH
 mg
 Sr
 Sr
@@ -3750,12 +3750,12 @@ FQ
 eu
 iy
 If
-so
+Oy
 YP
 xG
 Bz
-dg
-pF
+ue
+LV
 Jh
 bo
 PL
@@ -3792,12 +3792,12 @@ EO
 iz
 bv
 If
-Oy
+Xx
 YP
 YP
 tF
-uT
-YN
+wo
+VF
 mg
 Sr
 PL
@@ -3831,7 +3831,7 @@ zB
 If
 Dc
 EO
-jE
+Sh
 OM
 If
 nJ
@@ -3839,7 +3839,7 @@ YP
 QB
 eg
 TI
-Wp
+Rs
 mg
 Sr
 PL
@@ -3876,12 +3876,12 @@ Ye
 XF
 vb
 If
-Sh
+wH
 YP
 ai
 ya
-HG
-LQ
+GR
+sA
 Jh
 Sr
 PL
@@ -3923,7 +3923,7 @@ YP
 ai
 ai
 WN
-yw
+lC
 mg
 Sr
 PL
@@ -4037,7 +4037,7 @@ Dv
 cH
 Tg
 Dv
-EX
+Zb
 Dv
 dt
 nY
@@ -4081,7 +4081,7 @@ Dv
 Dv
 zB
 Dv
-iQ
+PY
 kj
 YD
 YD
@@ -4207,7 +4207,7 @@ Dv
 Dv
 zB
 Dv
-ta
+if
 mQ
 sP
 cF
@@ -4246,7 +4246,7 @@ bo
 DV
 Ef
 Gb
-US
+Kz
 ad
 Dv
 lh
@@ -4257,7 +4257,7 @@ iw
 wk
 Ey
 zF
-ME
+Ib
 fb
 fh
 sD
@@ -4287,7 +4287,7 @@ or
 bo
 Dv
 cH
-Yi
+HR
 Dv
 zB
 Dv
@@ -4626,7 +4626,7 @@ gS
 aY
 dI
 YD
-Hk
+WL
 dW
 PA
 MR
@@ -4635,7 +4635,7 @@ MR
 MR
 MR
 MR
-Al
+Hk
 YD
 XL
 Sr

--- a/_maps/shuttles/shiptest/voidcrew/Homestead.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/Homestead.dmm
@@ -444,7 +444,7 @@
 "kd" = (
 /obj/item/reagent_containers/food/snacks/hotdog,
 /turf/open/floor/plating/dirt{
-	desc = "Upon closer examination, it's still dirt."1
+	desc = "Upon closer examination, it's still dirt."
 	},
 /area/ship/external)
 "kj" = (

--- a/_maps/shuttles/shiptest/voidcrew/Homestead.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/Homestead.dmm
@@ -393,7 +393,7 @@
 "iw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = homesteadkitchen
+	id = "homesteadkitchen"
 	},
 /turf/open/floor/wood/yew,
 /area/ship/crew/canteen/kitchen)
@@ -826,8 +826,8 @@
 /area/ship/crew/canteen/kitchen)
 "sd" = (
 /obj/machinery/button/door{
-	id = "homesteadwindow";
-	name = "Windows";
+	id = "homesteadkitchen";
+	name = "shutters";
 	pixel_y = 24
 	},
 /obj/machinery/computer/autopilot{
@@ -1651,6 +1651,11 @@
 /area/ship/crew/dorm)
 "HY" = (
 /obj/machinery/deepfryer,
+/obj/machinery/button/door{
+	id = "homesteadwindow";
+	name = "Windows";
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen/kitchen)
 "Ib" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![2022 10 09-13 13 54](https://user-images.githubusercontent.com/19318747/194770318-0e8e9298-abfe-4694-9a61-e370c7fa217d.png)


This pr adds the Homestead-class, a ship intended to be used to start a colony. It has everything you could ever want to personally experience Manifest Destiny (in a 20-year-old video game)

specs:
Full R&D, mining, kitchen and hydroponics
medbay with cryo and autodoc
Unique layout
Turrets
Tcomms
2x mining ripleys
Arrangement of extra starting seeds



## Why It's Good For The Game

I had a strawpoll with a few good options and this one got the most votes. I think it's cool when people start colonies on planets, but it's not a very common thing to see. Hopefully this will enable the players who do want to start a colony, to do so.

## Changelog
:cl:
add: Homestead-class
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
