### PR TITLE
stops ships from throwing things when thrust is high

### DIFF
--- a/voidcrew/code/modules/overmap/ships/simulated.dm
+++ b/voidcrew/code/modules/overmap/ships/simulated.dm
@@ -154,7 +154,7 @@
 // Voidcrew Edit: removes throw equation "THROW" = FLOOR(est_thrust / 200, 1)
 /obj/structure/overmap/ship/simulated/proc/dock(obj/structure/overmap/to_dock, obj/docking_port/stationary/dock_to_use)
 	refresh_engines()
-	shuttle.movement_force = list("KNOCKDOWN" = FLOOR(est_thrust / 50, 1), "THROW" = 0))
+	shuttle.movement_force = list("KNOCKDOWN" = FLOOR(est_thrust / 50, 1), "THROW" = 0)
 	shuttle.request(dock_to_use)
 
 	priority_announce("Beginning docking procedures. Completion in [(shuttle.callTime + 1 SECONDS)/10] seconds.", "Docking Announcement", sender_override = name, zlevel = shuttle.virtual_z())

--- a/voidcrew/code/modules/overmap/ships/simulated.dm
+++ b/voidcrew/code/modules/overmap/ships/simulated.dm
@@ -151,9 +151,10 @@
   * * to_dock - The [/obj/structure/overmap] to dock to.
   * * dock_to_use - The [/obj/docking_port/mobile] to dock to.
   */
+// Voidcrew Edit: removes throw equation "THROW" = FLOOR(est_thrust / 200, 1)
 /obj/structure/overmap/ship/simulated/proc/dock(obj/structure/overmap/to_dock, obj/docking_port/stationary/dock_to_use)
 	refresh_engines()
-	shuttle.movement_force = list("KNOCKDOWN" = FLOOR(est_thrust / 50, 1), "THROW" = FLOOR(est_thrust / 200, 1))
+	shuttle.movement_force = list("KNOCKDOWN" = FLOOR(est_thrust / 50, 1), "THROW" = 0))
 	shuttle.request(dock_to_use)
 
 	priority_announce("Beginning docking procedures. Completion in [(shuttle.callTime + 1 SECONDS)/10] seconds.", "Docking Announcement", sender_override = name, zlevel = shuttle.virtual_z())


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

essentially copies #200

Removes heavy ships throwing people and objects when they dock, ships now just knockdown players.

Done by just deleting the equation for ship throwing and instead making it = 0, lazy but works fine. Original code is included in comment above.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/19318747/196064402-a97e3984-7a99-4e4d-a6d7-b1d8d55adc43.png)

People didn't like it back in Febuary, and people still don't like it

## Changelog
:cl:
fix: ships throwing things when the engine thrust is too high
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
